### PR TITLE
Update Argo Workflow CRDs to v3.5.4

### DIFF
--- a/argoproj.io/clusterworkflowtemplate_v1alpha1.json
+++ b/argoproj.io/clusterworkflowtemplate_v1alpha1.json
@@ -621,6 +621,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -669,6 +705,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -710,6 +790,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -749,6 +832,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -885,6 +971,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -990,6 +1250,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -1038,6 +1301,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -1218,6 +1499,48 @@
           "type": "object",
           "additionalProperties": false
         },
+        "artifactGC": {
+          "properties": {
+            "forceFinalizerRemoval": {
+              "type": "boolean"
+            },
+            "podMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podSpecPatch": {
+              "type": "string"
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "strategy": {
+              "enum": [
+                "",
+                "OnWorkflowCompletion",
+                "OnWorkflowDeletion",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "configMap": {
@@ -1314,6 +1637,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -1362,6 +1721,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -1403,6 +1806,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -1442,6 +1848,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -1578,6 +1987,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -1683,6 +2266,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -1731,6 +2317,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -1933,9 +2537,6 @@
                 "additionalProperties": false
               }
             },
-            "required": [
-              "template"
-            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1993,6 +2594,9 @@
                   },
                   "gauge": {
                     "properties": {
+                      "operation": {
+                        "type": "string"
+                      },
                       "realtime": {
                         "type": "boolean"
                       },
@@ -2151,6 +2755,9 @@
         },
         "podGC": {
           "properties": {
+            "deleteDelayDuration": {
+              "type": "string"
+            },
             "labelSelector": {
               "properties": {
                 "matchExpressions": {
@@ -2401,6 +3008,9 @@
               "properties": {
                 "name": {
                   "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -2425,6 +3035,9 @@
                   ],
                   "type": "object",
                   "additionalProperties": false
+                },
+                "namespace": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -3073,6 +3686,47 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blob": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blob",
+                    "container",
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "gcs": {
                   "properties": {
                     "bucket": {
@@ -3108,6 +3762,9 @@
                 },
                 "git": {
                   "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
                     "depth": {
                       "format": "int64",
                       "type": "integer"
@@ -3147,6 +3804,9 @@
                     },
                     "revision": {
                       "type": "string"
+                    },
+                    "singleBranch": {
+                      "type": "boolean"
                     },
                     "sshPrivateKeySecret": {
                       "properties": {
@@ -3280,6 +3940,180 @@
                 },
                 "http": {
                   "properties": {
+                    "auth": {
+                      "properties": {
+                        "basicAuth": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clientCert": {
+                          "properties": {
+                            "clientCertSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauth2": {
+                          "properties": {
+                            "clientIDSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientSecretSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpointParams": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tokenURLSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "headers": {
                       "items": {
                         "properties": {
@@ -3375,6 +4209,9 @@
                     },
                     "securityToken": {
                       "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -3417,6 +4254,24 @@
                     },
                     "bucket": {
                       "type": "string"
+                    },
+                    "caSecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "createBucketIfNotPresent": {
                       "properties": {
@@ -5575,6 +6430,42 @@
                                 "archiveLogs": {
                                   "type": "boolean"
                                 },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "artifactory": {
                                   "properties": {
                                     "passwordSecret": {
@@ -5623,6 +6514,50 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
                                 "from": {
                                   "type": "string"
                                 },
@@ -5664,6 +6599,9 @@
                                 },
                                 "git": {
                                   "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
                                     "depth": {
                                       "format": "int64",
                                       "type": "integer"
@@ -5703,6 +6641,9 @@
                                     },
                                     "revision": {
                                       "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
                                     },
                                     "sshPrivateKeySecret": {
                                       "properties": {
@@ -5839,6 +6780,180 @@
                                 },
                                 "http": {
                                   "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "headers": {
                                       "items": {
                                         "properties": {
@@ -5944,6 +7059,9 @@
                                     },
                                     "securityToken": {
                                       "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
                                     }
                                   },
                                   "required": [
@@ -5992,6 +7110,24 @@
                                     },
                                     "bucket": {
                                       "type": "string"
+                                    },
+                                    "caSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "createBucketIfNotPresent": {
                                       "properties": {
@@ -6226,6 +7362,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -6274,6 +7446,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -6315,6 +7531,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -6354,6 +7573,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -6490,6 +7712,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -6595,6 +7991,9 @@
                                           },
                                           "securityToken": {
                                             "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
                                           }
                                         },
                                         "required": [
@@ -6643,6 +8042,24 @@
                                           },
                                           "bucket": {
                                             "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "createBucketIfNotPresent": {
                                             "properties": {
@@ -6845,9 +8262,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "template"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -6979,6 +8393,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7027,6 +8477,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7068,6 +8562,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7107,6 +8604,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7243,6 +8743,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7348,6 +9022,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -7396,6 +9073,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -7550,6 +9245,16 @@
               "properties": {
                 "body": {
                   "type": "string"
+                },
+                "bodyFrom": {
+                  "properties": {
+                    "bytes": {
+                      "format": "byte",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "headers": {
                   "items": {
@@ -8628,6 +10333,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -8676,6 +10417,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -8717,6 +10502,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -8756,6 +10544,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -8892,6 +10683,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -8997,6 +10962,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -9045,6 +11013,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -9306,6 +11292,9 @@
                       },
                       "gauge": {
                         "properties": {
+                          "operation": {
+                            "type": "string"
+                          },
                           "realtime": {
                             "type": "boolean"
                           },
@@ -9423,6 +11412,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -9471,6 +11496,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -9512,6 +11581,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -9551,6 +11623,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -9687,6 +11762,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -9792,6 +12041,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -9840,6 +12092,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -10059,6 +12329,833 @@
                 },
                 "manifest": {
                   "type": "string"
+                },
+                "manifestFrom": {
+                  "properties": {
+                    "artifact": {
+                      "properties": {
+                        "archive": {
+                          "properties": {
+                            "none": {
+                              "type": "object"
+                            },
+                            "tar": {
+                              "properties": {
+                                "compressionLevel": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "zip": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "archiveLogs": {
+                          "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "artifactory": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "fromExpression": {
+                          "type": "string"
+                        },
+                        "gcs": {
+                          "properties": {
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "serviceAccountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
+                            "depth": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "disableSubmodules": {
+                              "type": "boolean"
+                            },
+                            "fetch": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "insecureIgnoreHostKey": {
+                              "type": "boolean"
+                            },
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
+                            },
+                            "sshPrivateKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repo"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "globalName": {
+                          "type": "string"
+                        },
+                        "hdfs": {
+                          "properties": {
+                            "addresses": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "force": {
+                              "type": "boolean"
+                            },
+                            "hdfsUser": {
+                              "type": "string"
+                            },
+                            "krbCCacheSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbConfigConfigMap": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbKeytabSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbRealm": {
+                              "type": "string"
+                            },
+                            "krbServicePrincipalName": {
+                              "type": "string"
+                            },
+                            "krbUsername": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "http": {
+                          "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headers": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        },
+                        "oss": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "type": "boolean"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "lifecycleRule": {
+                              "properties": {
+                                "markDeletionAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "markInfrequentAccessAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "securityToken": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "raw": {
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurseMode": {
+                          "type": "boolean"
+                        },
+                        "s3": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "createBucketIfNotPresent": {
+                              "properties": {
+                                "objectLocking": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "encryptionOptions": {
+                              "properties": {
+                                "enableEncryption": {
+                                  "type": "boolean"
+                                },
+                                "kmsEncryptionContext": {
+                                  "type": "string"
+                                },
+                                "kmsKeyId": {
+                                  "type": "string"
+                                },
+                                "serverSideCustomerKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "insecure": {
+                              "type": "boolean"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "roleARN": {
+                              "type": "string"
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "subPath": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "artifact"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mergeStrategy": {
                   "type": "string"
@@ -12221,6 +15318,9 @@
                   "properties": {
                     "name": {
                       "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -12245,6 +15345,9 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -14035,6 +17138,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -14070,6 +17214,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -14109,6 +17256,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -14242,6 +17392,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -14337,6 +17661,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -14379,6 +17706,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -16537,6 +19882,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -16585,6 +19966,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -16626,6 +20051,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -16665,6 +20093,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -16801,6 +20232,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -16906,6 +20511,9 @@
                                       },
                                       "securityToken": {
                                         "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
                                       }
                                     },
                                     "required": [
@@ -16954,6 +20562,24 @@
                                       },
                                       "bucket": {
                                         "type": "string"
+                                      },
+                                      "caSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "createBucketIfNotPresent": {
                                         "properties": {
@@ -17188,6 +20814,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -17236,6 +20898,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -17277,6 +20983,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -17316,6 +21025,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -17452,6 +21164,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -17557,6 +21443,9 @@
                                             },
                                             "securityToken": {
                                               "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
                                             }
                                           },
                                           "required": [
@@ -17605,6 +21494,24 @@
                                             },
                                             "bucket": {
                                               "type": "string"
+                                            },
+                                            "caSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "createBucketIfNotPresent": {
                                               "properties": {
@@ -17807,9 +21714,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17941,6 +21845,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -17989,6 +21929,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -18030,6 +22014,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -18069,6 +22056,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -18205,6 +22195,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -18310,6 +22474,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -18358,6 +22525,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -18512,6 +22697,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -19590,6 +23785,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -19638,6 +23869,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -19679,6 +23954,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -19718,6 +23996,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -19854,6 +24135,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -19959,6 +24414,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -20007,6 +24465,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -20268,6 +24744,9 @@
                         },
                         "gauge": {
                           "properties": {
+                            "operation": {
+                              "type": "string"
+                            },
                             "realtime": {
                               "type": "boolean"
                             },
@@ -20385,6 +24864,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -20433,6 +24948,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -20474,6 +25033,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -20513,6 +25075,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -20649,6 +25214,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -20754,6 +25493,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -20802,6 +25544,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -21021,6 +25781,833 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -23183,6 +28770,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -23207,6 +28797,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",

--- a/argoproj.io/cronworkflow_v1alpha1.json
+++ b/argoproj.io/cronworkflow_v1alpha1.json
@@ -650,6 +650,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -698,6 +734,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -739,6 +819,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -778,6 +861,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -914,6 +1000,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -1019,6 +1279,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -1067,6 +1330,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -1247,6 +1528,48 @@
               "type": "object",
               "additionalProperties": false
             },
+            "artifactGC": {
+              "properties": {
+                "forceFinalizerRemoval": {
+                  "type": "boolean"
+                },
+                "podMetadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podSpecPatch": {
+                  "type": "string"
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "strategy": {
+                  "enum": [
+                    "",
+                    "OnWorkflowCompletion",
+                    "OnWorkflowDeletion",
+                    "Never"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "artifactRepositoryRef": {
               "properties": {
                 "configMap": {
@@ -1343,6 +1666,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -1391,6 +1750,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -1432,6 +1835,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -1471,6 +1877,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -1607,6 +2016,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -1712,6 +2295,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -1760,6 +2346,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -1962,9 +2566,6 @@
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "template"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2022,6 +2623,9 @@
                       },
                       "gauge": {
                         "properties": {
+                          "operation": {
+                            "type": "string"
+                          },
                           "realtime": {
                             "type": "boolean"
                           },
@@ -2180,6 +2784,9 @@
             },
             "podGC": {
               "properties": {
+                "deleteDelayDuration": {
+                  "type": "string"
+                },
                 "labelSelector": {
                   "properties": {
                     "matchExpressions": {
@@ -2430,6 +3037,9 @@
                   "properties": {
                     "name": {
                       "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -2454,6 +3064,9 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -3102,6 +3715,47 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "azure": {
+                      "properties": {
+                        "accountKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "blob": {
+                          "type": "string"
+                        },
+                        "container": {
+                          "type": "string"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "blob",
+                        "container",
+                        "endpoint"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "gcs": {
                       "properties": {
                         "bucket": {
@@ -3137,6 +3791,9 @@
                     },
                     "git": {
                       "properties": {
+                        "branch": {
+                          "type": "string"
+                        },
                         "depth": {
                           "format": "int64",
                           "type": "integer"
@@ -3176,6 +3833,9 @@
                         },
                         "revision": {
                           "type": "string"
+                        },
+                        "singleBranch": {
+                          "type": "boolean"
                         },
                         "sshPrivateKeySecret": {
                           "properties": {
@@ -3309,6 +3969,180 @@
                     },
                     "http": {
                       "properties": {
+                        "auth": {
+                          "properties": {
+                            "basicAuth": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientCert": {
+                              "properties": {
+                                "clientCertSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "oauth2": {
+                              "properties": {
+                                "clientIDSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientSecretSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpointParams": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "scopes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tokenURLSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "headers": {
                           "items": {
                             "properties": {
@@ -3404,6 +4238,9 @@
                         },
                         "securityToken": {
                           "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -3446,6 +4283,24 @@
                         },
                         "bucket": {
                           "type": "string"
+                        },
+                        "caSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "createBucketIfNotPresent": {
                           "properties": {
@@ -5604,6 +6459,42 @@
                                     "archiveLogs": {
                                       "type": "boolean"
                                     },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "artifactory": {
                                       "properties": {
                                         "passwordSecret": {
@@ -5652,6 +6543,50 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
                                     "from": {
                                       "type": "string"
                                     },
@@ -5693,6 +6628,9 @@
                                     },
                                     "git": {
                                       "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
                                         "depth": {
                                           "format": "int64",
                                           "type": "integer"
@@ -5732,6 +6670,9 @@
                                         },
                                         "revision": {
                                           "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
                                         },
                                         "sshPrivateKeySecret": {
                                           "properties": {
@@ -5868,6 +6809,180 @@
                                     },
                                     "http": {
                                       "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "headers": {
                                           "items": {
                                             "properties": {
@@ -5973,6 +7088,9 @@
                                         },
                                         "securityToken": {
                                           "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
                                         }
                                       },
                                       "required": [
@@ -6021,6 +7139,24 @@
                                         },
                                         "bucket": {
                                           "type": "string"
+                                        },
+                                        "caSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "createBucketIfNotPresent": {
                                           "properties": {
@@ -6255,6 +7391,42 @@
                                           "archiveLogs": {
                                             "type": "boolean"
                                           },
+                                          "artifactGC": {
+                                            "properties": {
+                                              "podMetadata": {
+                                                "properties": {
+                                                  "annotations": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "labels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "serviceAccountName": {
+                                                "type": "string"
+                                              },
+                                              "strategy": {
+                                                "enum": [
+                                                  "",
+                                                  "OnWorkflowCompletion",
+                                                  "OnWorkflowDeletion",
+                                                  "Never"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "artifactory": {
                                             "properties": {
                                               "passwordSecret": {
@@ -6303,6 +7475,50 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
+                                          "azure": {
+                                            "properties": {
+                                              "accountKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "blob": {
+                                                "type": "string"
+                                              },
+                                              "container": {
+                                                "type": "string"
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "blob",
+                                              "container",
+                                              "endpoint"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "deleted": {
+                                            "type": "boolean"
+                                          },
                                           "from": {
                                             "type": "string"
                                           },
@@ -6344,6 +7560,9 @@
                                           },
                                           "git": {
                                             "properties": {
+                                              "branch": {
+                                                "type": "string"
+                                              },
                                               "depth": {
                                                 "format": "int64",
                                                 "type": "integer"
@@ -6383,6 +7602,9 @@
                                               },
                                               "revision": {
                                                 "type": "string"
+                                              },
+                                              "singleBranch": {
+                                                "type": "boolean"
                                               },
                                               "sshPrivateKeySecret": {
                                                 "properties": {
@@ -6519,6 +7741,180 @@
                                           },
                                           "http": {
                                             "properties": {
+                                              "auth": {
+                                                "properties": {
+                                                  "basicAuth": {
+                                                    "properties": {
+                                                      "passwordSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "usernameSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientCert": {
+                                                    "properties": {
+                                                      "clientCertSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientKeySecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "oauth2": {
+                                                    "properties": {
+                                                      "clientIDSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientSecretSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "endpointParams": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "scopes": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "tokenURLSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "headers": {
                                                 "items": {
                                                   "properties": {
@@ -6624,6 +8020,9 @@
                                               },
                                               "securityToken": {
                                                 "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
                                               }
                                             },
                                             "required": [
@@ -6672,6 +8071,24 @@
                                               },
                                               "bucket": {
                                                 "type": "string"
+                                              },
+                                              "caSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "createBucketIfNotPresent": {
                                                 "properties": {
@@ -6874,9 +8291,6 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": [
-                                "template"
-                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -7008,6 +8422,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -7056,6 +8506,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -7097,6 +8591,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -7136,6 +8633,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -7272,6 +8772,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -7377,6 +9051,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -7425,6 +9102,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -7579,6 +9274,16 @@
                   "properties": {
                     "body": {
                       "type": "string"
+                    },
+                    "bodyFrom": {
+                      "properties": {
+                        "bytes": {
+                          "format": "byte",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "headers": {
                       "items": {
@@ -8657,6 +10362,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -8705,6 +10446,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -8746,6 +10531,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -8785,6 +10573,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -8921,6 +10712,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -9026,6 +10991,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -9074,6 +11042,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -9335,6 +11321,9 @@
                           },
                           "gauge": {
                             "properties": {
+                              "operation": {
+                                "type": "string"
+                              },
                               "realtime": {
                                 "type": "boolean"
                               },
@@ -9452,6 +11441,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -9500,6 +11525,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -9541,6 +11610,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -9580,6 +11652,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -9716,6 +11791,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -9821,6 +12070,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -9869,6 +12121,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -10088,6 +12358,833 @@
                     },
                     "manifest": {
                       "type": "string"
+                    },
+                    "manifestFrom": {
+                      "properties": {
+                        "artifact": {
+                          "properties": {
+                            "archive": {
+                              "properties": {
+                                "none": {
+                                  "type": "object"
+                                },
+                                "tar": {
+                                  "properties": {
+                                    "compressionLevel": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "zip": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "archiveLogs": {
+                              "type": "boolean"
+                            },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "artifactory": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
+                            "from": {
+                              "type": "string"
+                            },
+                            "fromExpression": {
+                              "type": "string"
+                            },
+                            "gcs": {
+                              "properties": {
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "serviceAccountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "git": {
+                              "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
+                                "depth": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "disableSubmodules": {
+                                  "type": "boolean"
+                                },
+                                "fetch": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "insecureIgnoreHostKey": {
+                                  "type": "boolean"
+                                },
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "revision": {
+                                  "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
+                                },
+                                "sshPrivateKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "globalName": {
+                              "type": "string"
+                            },
+                            "hdfs": {
+                              "properties": {
+                                "addresses": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "force": {
+                                  "type": "boolean"
+                                },
+                                "hdfsUser": {
+                                  "type": "string"
+                                },
+                                "krbCCacheSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbConfigConfigMap": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbKeytabSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbRealm": {
+                                  "type": "string"
+                                },
+                                "krbServicePrincipalName": {
+                                  "type": "string"
+                                },
+                                "krbUsername": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "http": {
+                              "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "url": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            },
+                            "oss": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "createBucketIfNotPresent": {
+                                  "type": "boolean"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "lifecycleRule": {
+                                  "properties": {
+                                    "markDeletionAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "markInfrequentAccessAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "securityToken": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "raw": {
+                              "properties": {
+                                "data": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "data"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "recurseMode": {
+                              "type": "boolean"
+                            },
+                            "s3": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "createBucketIfNotPresent": {
+                                  "properties": {
+                                    "objectLocking": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "encryptionOptions": {
+                                  "properties": {
+                                    "enableEncryption": {
+                                      "type": "boolean"
+                                    },
+                                    "kmsEncryptionContext": {
+                                      "type": "string"
+                                    },
+                                    "kmsKeyId": {
+                                      "type": "string"
+                                    },
+                                    "serverSideCustomerKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "roleARN": {
+                                  "type": "string"
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "subPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "artifact"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "mergeStrategy": {
                       "type": "string"
@@ -12250,6 +15347,9 @@
                       "properties": {
                         "name": {
                           "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -12274,6 +15374,9 @@
                           ],
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "namespace": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -14064,6 +17167,47 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "gcs": {
                         "properties": {
                           "bucket": {
@@ -14099,6 +17243,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -14138,6 +17285,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -14271,6 +17421,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -14366,6 +17690,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -14408,6 +17735,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -16566,6 +19911,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -16614,6 +19995,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -16655,6 +20080,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -16694,6 +20122,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -16830,6 +20261,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -16935,6 +20540,9 @@
                                           },
                                           "securityToken": {
                                             "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
                                           }
                                         },
                                         "required": [
@@ -16983,6 +20591,24 @@
                                           },
                                           "bucket": {
                                             "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "createBucketIfNotPresent": {
                                             "properties": {
@@ -17217,6 +20843,42 @@
                                             "archiveLogs": {
                                               "type": "boolean"
                                             },
+                                            "artifactGC": {
+                                              "properties": {
+                                                "podMetadata": {
+                                                  "properties": {
+                                                    "annotations": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "labels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "serviceAccountName": {
+                                                  "type": "string"
+                                                },
+                                                "strategy": {
+                                                  "enum": [
+                                                    "",
+                                                    "OnWorkflowCompletion",
+                                                    "OnWorkflowDeletion",
+                                                    "Never"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "artifactory": {
                                               "properties": {
                                                 "passwordSecret": {
@@ -17265,6 +20927,50 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
+                                            "azure": {
+                                              "properties": {
+                                                "accountKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "blob": {
+                                                  "type": "string"
+                                                },
+                                                "container": {
+                                                  "type": "string"
+                                                },
+                                                "endpoint": {
+                                                  "type": "string"
+                                                },
+                                                "useSDKCreds": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "blob",
+                                                "container",
+                                                "endpoint"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "deleted": {
+                                              "type": "boolean"
+                                            },
                                             "from": {
                                               "type": "string"
                                             },
@@ -17306,6 +21012,9 @@
                                             },
                                             "git": {
                                               "properties": {
+                                                "branch": {
+                                                  "type": "string"
+                                                },
                                                 "depth": {
                                                   "format": "int64",
                                                   "type": "integer"
@@ -17345,6 +21054,9 @@
                                                 },
                                                 "revision": {
                                                   "type": "string"
+                                                },
+                                                "singleBranch": {
+                                                  "type": "boolean"
                                                 },
                                                 "sshPrivateKeySecret": {
                                                   "properties": {
@@ -17481,6 +21193,180 @@
                                             },
                                             "http": {
                                               "properties": {
+                                                "auth": {
+                                                  "properties": {
+                                                    "basicAuth": {
+                                                      "properties": {
+                                                        "passwordSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "usernameSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientCert": {
+                                                      "properties": {
+                                                        "clientCertSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientKeySecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "oauth2": {
+                                                      "properties": {
+                                                        "clientIDSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientSecretSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "endpointParams": {
+                                                          "items": {
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "scopes": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "tokenURLSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
                                                 "headers": {
                                                   "items": {
                                                     "properties": {
@@ -17586,6 +21472,9 @@
                                                 },
                                                 "securityToken": {
                                                   "type": "string"
+                                                },
+                                                "useSDKCreds": {
+                                                  "type": "boolean"
                                                 }
                                               },
                                               "required": [
@@ -17634,6 +21523,24 @@
                                                 },
                                                 "bucket": {
                                                   "type": "string"
+                                                },
+                                                "caSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "createBucketIfNotPresent": {
                                                   "properties": {
@@ -17836,9 +21743,6 @@
                                     "additionalProperties": false
                                   }
                                 },
-                                "required": [
-                                  "template"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -17970,6 +21874,42 @@
                               "archiveLogs": {
                                 "type": "boolean"
                               },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "artifactory": {
                                 "properties": {
                                   "passwordSecret": {
@@ -18018,6 +21958,50 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
                               "from": {
                                 "type": "string"
                               },
@@ -18059,6 +22043,9 @@
                               },
                               "git": {
                                 "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
                                   "depth": {
                                     "format": "int64",
                                     "type": "integer"
@@ -18098,6 +22085,9 @@
                                   },
                                   "revision": {
                                     "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
                                   },
                                   "sshPrivateKeySecret": {
                                     "properties": {
@@ -18234,6 +22224,180 @@
                               },
                               "http": {
                                 "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "headers": {
                                     "items": {
                                       "properties": {
@@ -18339,6 +22503,9 @@
                                   },
                                   "securityToken": {
                                     "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [
@@ -18387,6 +22554,24 @@
                                   },
                                   "bucket": {
                                     "type": "string"
+                                  },
+                                  "caSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "createBucketIfNotPresent": {
                                     "properties": {
@@ -18541,6 +22726,16 @@
                     "properties": {
                       "body": {
                         "type": "string"
+                      },
+                      "bodyFrom": {
+                        "properties": {
+                          "bytes": {
+                            "format": "byte",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -19619,6 +23814,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -19667,6 +23898,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -19708,6 +23983,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -19747,6 +24025,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -19883,6 +24164,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -19988,6 +24443,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -20036,6 +24494,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -20297,6 +24773,9 @@
                             },
                             "gauge": {
                               "properties": {
+                                "operation": {
+                                  "type": "string"
+                                },
                                 "realtime": {
                                   "type": "boolean"
                                 },
@@ -20414,6 +24893,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -20462,6 +24977,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -20503,6 +25062,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -20542,6 +25104,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -20678,6 +25243,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -20783,6 +25522,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -20831,6 +25573,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -21050,6 +25810,833 @@
                       },
                       "manifest": {
                         "type": "string"
+                      },
+                      "manifestFrom": {
+                        "properties": {
+                          "artifact": {
+                            "properties": {
+                              "archive": {
+                                "properties": {
+                                  "none": {
+                                    "type": "object"
+                                  },
+                                  "tar": {
+                                    "properties": {
+                                      "compressionLevel": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "zip": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "archiveLogs": {
+                                "type": "boolean"
+                              },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "artifactory": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "fromExpression": {
+                                "type": "string"
+                              },
+                              "gcs": {
+                                "properties": {
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "git": {
+                                "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "depth": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "disableSubmodules": {
+                                    "type": "boolean"
+                                  },
+                                  "fetch": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "insecureIgnoreHostKey": {
+                                    "type": "boolean"
+                                  },
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "repo": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
+                                  },
+                                  "sshPrivateKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "repo"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "hdfs": {
+                                "properties": {
+                                  "addresses": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "hdfsUser": {
+                                    "type": "string"
+                                  },
+                                  "krbCCacheSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbConfigConfigMap": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbKeytabSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbRealm": {
+                                    "type": "string"
+                                  },
+                                  "krbServicePrincipalName": {
+                                    "type": "string"
+                                  },
+                                  "krbUsername": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "mode": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "oss": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "type": "boolean"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "lifecycleRule": {
+                                    "properties": {
+                                      "markDeletionAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "markInfrequentAccessAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "securityToken": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "raw": {
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "data"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurseMode": {
+                                "type": "boolean"
+                              },
+                              "s3": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "caSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "properties": {
+                                      "objectLocking": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "encryptionOptions": {
+                                    "properties": {
+                                      "enableEncryption": {
+                                        "type": "boolean"
+                                      },
+                                      "kmsEncryptionContext": {
+                                        "type": "string"
+                                      },
+                                      "kmsKeyId": {
+                                        "type": "string"
+                                      },
+                                      "serverSideCustomerKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "insecure": {
+                                    "type": "boolean"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "roleARN": {
+                                    "type": "string"
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "subPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "artifact"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "mergeStrategy": {
                         "type": "string"
@@ -23212,6 +28799,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -23236,6 +28826,9 @@
                             ],
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "namespace": {
+                            "type": "string"
                           }
                         },
                         "type": "object",

--- a/argoproj.io/workflow_v1alpha1.json
+++ b/argoproj.io/workflow_v1alpha1.json
@@ -621,6 +621,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -669,6 +705,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -710,6 +790,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -749,6 +832,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -885,6 +971,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -990,6 +1250,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -1038,6 +1301,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -1218,6 +1499,48 @@
           "type": "object",
           "additionalProperties": false
         },
+        "artifactGC": {
+          "properties": {
+            "forceFinalizerRemoval": {
+              "type": "boolean"
+            },
+            "podMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podSpecPatch": {
+              "type": "string"
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "strategy": {
+              "enum": [
+                "",
+                "OnWorkflowCompletion",
+                "OnWorkflowDeletion",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "configMap": {
@@ -1314,6 +1637,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -1362,6 +1721,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -1403,6 +1806,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -1442,6 +1848,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -1578,6 +1987,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -1683,6 +2266,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -1731,6 +2317,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -1933,9 +2537,6 @@
                 "additionalProperties": false
               }
             },
-            "required": [
-              "template"
-            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1993,6 +2594,9 @@
                   },
                   "gauge": {
                     "properties": {
+                      "operation": {
+                        "type": "string"
+                      },
                       "realtime": {
                         "type": "boolean"
                       },
@@ -2151,6 +2755,9 @@
         },
         "podGC": {
           "properties": {
+            "deleteDelayDuration": {
+              "type": "string"
+            },
             "labelSelector": {
               "properties": {
                 "matchExpressions": {
@@ -2401,6 +3008,9 @@
               "properties": {
                 "name": {
                   "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -2425,6 +3035,9 @@
                   ],
                   "type": "object",
                   "additionalProperties": false
+                },
+                "namespace": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -3073,6 +3686,47 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blob": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blob",
+                    "container",
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "gcs": {
                   "properties": {
                     "bucket": {
@@ -3108,6 +3762,9 @@
                 },
                 "git": {
                   "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
                     "depth": {
                       "format": "int64",
                       "type": "integer"
@@ -3147,6 +3804,9 @@
                     },
                     "revision": {
                       "type": "string"
+                    },
+                    "singleBranch": {
+                      "type": "boolean"
                     },
                     "sshPrivateKeySecret": {
                       "properties": {
@@ -3280,6 +3940,180 @@
                 },
                 "http": {
                   "properties": {
+                    "auth": {
+                      "properties": {
+                        "basicAuth": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clientCert": {
+                          "properties": {
+                            "clientCertSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauth2": {
+                          "properties": {
+                            "clientIDSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientSecretSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpointParams": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tokenURLSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "headers": {
                       "items": {
                         "properties": {
@@ -3375,6 +4209,9 @@
                     },
                     "securityToken": {
                       "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -3417,6 +4254,24 @@
                     },
                     "bucket": {
                       "type": "string"
+                    },
+                    "caSecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "createBucketIfNotPresent": {
                       "properties": {
@@ -5575,6 +6430,42 @@
                                 "archiveLogs": {
                                   "type": "boolean"
                                 },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "artifactory": {
                                   "properties": {
                                     "passwordSecret": {
@@ -5623,6 +6514,50 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
                                 "from": {
                                   "type": "string"
                                 },
@@ -5664,6 +6599,9 @@
                                 },
                                 "git": {
                                   "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
                                     "depth": {
                                       "format": "int64",
                                       "type": "integer"
@@ -5703,6 +6641,9 @@
                                     },
                                     "revision": {
                                       "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
                                     },
                                     "sshPrivateKeySecret": {
                                       "properties": {
@@ -5839,6 +6780,180 @@
                                 },
                                 "http": {
                                   "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "headers": {
                                       "items": {
                                         "properties": {
@@ -5944,6 +7059,9 @@
                                     },
                                     "securityToken": {
                                       "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
                                     }
                                   },
                                   "required": [
@@ -5992,6 +7110,24 @@
                                     },
                                     "bucket": {
                                       "type": "string"
+                                    },
+                                    "caSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "createBucketIfNotPresent": {
                                       "properties": {
@@ -6226,6 +7362,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -6274,6 +7446,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -6315,6 +7531,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -6354,6 +7573,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -6490,6 +7712,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -6595,6 +7991,9 @@
                                           },
                                           "securityToken": {
                                             "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
                                           }
                                         },
                                         "required": [
@@ -6643,6 +8042,24 @@
                                           },
                                           "bucket": {
                                             "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "createBucketIfNotPresent": {
                                             "properties": {
@@ -6845,9 +8262,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "template"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -6979,6 +8393,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7027,6 +8477,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7068,6 +8562,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7107,6 +8604,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7243,6 +8743,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7348,6 +9022,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -7396,6 +9073,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -7550,6 +9245,16 @@
               "properties": {
                 "body": {
                   "type": "string"
+                },
+                "bodyFrom": {
+                  "properties": {
+                    "bytes": {
+                      "format": "byte",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "headers": {
                   "items": {
@@ -8628,6 +10333,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -8676,6 +10417,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -8717,6 +10502,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -8756,6 +10544,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -8892,6 +10683,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -8997,6 +10962,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -9045,6 +11013,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -9306,6 +11292,9 @@
                       },
                       "gauge": {
                         "properties": {
+                          "operation": {
+                            "type": "string"
+                          },
                           "realtime": {
                             "type": "boolean"
                           },
@@ -9423,6 +11412,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -9471,6 +11496,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -9512,6 +11581,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -9551,6 +11623,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -9687,6 +11762,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -9792,6 +12041,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -9840,6 +12092,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -10059,6 +12329,833 @@
                 },
                 "manifest": {
                   "type": "string"
+                },
+                "manifestFrom": {
+                  "properties": {
+                    "artifact": {
+                      "properties": {
+                        "archive": {
+                          "properties": {
+                            "none": {
+                              "type": "object"
+                            },
+                            "tar": {
+                              "properties": {
+                                "compressionLevel": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "zip": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "archiveLogs": {
+                          "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "artifactory": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "fromExpression": {
+                          "type": "string"
+                        },
+                        "gcs": {
+                          "properties": {
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "serviceAccountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
+                            "depth": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "disableSubmodules": {
+                              "type": "boolean"
+                            },
+                            "fetch": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "insecureIgnoreHostKey": {
+                              "type": "boolean"
+                            },
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
+                            },
+                            "sshPrivateKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repo"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "globalName": {
+                          "type": "string"
+                        },
+                        "hdfs": {
+                          "properties": {
+                            "addresses": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "force": {
+                              "type": "boolean"
+                            },
+                            "hdfsUser": {
+                              "type": "string"
+                            },
+                            "krbCCacheSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbConfigConfigMap": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbKeytabSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbRealm": {
+                              "type": "string"
+                            },
+                            "krbServicePrincipalName": {
+                              "type": "string"
+                            },
+                            "krbUsername": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "http": {
+                          "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headers": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        },
+                        "oss": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "type": "boolean"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "lifecycleRule": {
+                              "properties": {
+                                "markDeletionAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "markInfrequentAccessAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "securityToken": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "raw": {
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurseMode": {
+                          "type": "boolean"
+                        },
+                        "s3": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "createBucketIfNotPresent": {
+                              "properties": {
+                                "objectLocking": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "encryptionOptions": {
+                              "properties": {
+                                "enableEncryption": {
+                                  "type": "boolean"
+                                },
+                                "kmsEncryptionContext": {
+                                  "type": "string"
+                                },
+                                "kmsKeyId": {
+                                  "type": "string"
+                                },
+                                "serverSideCustomerKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "insecure": {
+                              "type": "boolean"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "roleARN": {
+                              "type": "string"
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "subPath": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "artifact"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mergeStrategy": {
                   "type": "string"
@@ -12221,6 +15318,9 @@
                   "properties": {
                     "name": {
                       "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -12245,6 +15345,9 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -14035,6 +17138,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -14070,6 +17214,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -14109,6 +17256,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -14242,6 +17392,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -14337,6 +17661,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -14379,6 +17706,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -16537,6 +19882,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -16585,6 +19966,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -16626,6 +20051,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -16665,6 +20093,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -16801,6 +20232,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -16906,6 +20511,9 @@
                                       },
                                       "securityToken": {
                                         "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
                                       }
                                     },
                                     "required": [
@@ -16954,6 +20562,24 @@
                                       },
                                       "bucket": {
                                         "type": "string"
+                                      },
+                                      "caSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "createBucketIfNotPresent": {
                                         "properties": {
@@ -17188,6 +20814,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -17236,6 +20898,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -17277,6 +20983,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -17316,6 +21025,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -17452,6 +21164,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -17557,6 +21443,9 @@
                                             },
                                             "securityToken": {
                                               "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
                                             }
                                           },
                                           "required": [
@@ -17605,6 +21494,24 @@
                                             },
                                             "bucket": {
                                               "type": "string"
+                                            },
+                                            "caSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "createBucketIfNotPresent": {
                                               "properties": {
@@ -17807,9 +21714,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17941,6 +21845,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -17989,6 +21929,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -18030,6 +22014,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -18069,6 +22056,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -18205,6 +22195,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -18310,6 +22474,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -18358,6 +22525,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -18512,6 +22697,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -19590,6 +23785,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -19638,6 +23869,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -19679,6 +23954,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -19718,6 +23996,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -19854,6 +24135,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -19959,6 +24414,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -20007,6 +24465,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -20268,6 +24744,9 @@
                         },
                         "gauge": {
                           "properties": {
+                            "operation": {
+                              "type": "string"
+                            },
                             "realtime": {
                               "type": "boolean"
                             },
@@ -20385,6 +24864,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -20433,6 +24948,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -20474,6 +25033,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -20513,6 +25075,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -20649,6 +25214,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -20754,6 +25493,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -20802,6 +25544,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -21021,6 +25781,833 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -23183,6 +28770,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -23207,6 +28797,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -25802,6 +31395,27 @@
     },
     "status": {
       "properties": {
+        "artifactGCStatus": {
+          "properties": {
+            "notSpecified": {
+              "type": "boolean"
+            },
+            "podsRecouped": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            },
+            "strategiesProcessed": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "artifactRepository": {
@@ -25811,6 +31425,9 @@
                 },
                 "artifactory": {
                   "properties": {
+                    "keyFormat": {
+                      "type": "string"
+                    },
                     "passwordSecret": {
                       "properties": {
                         "key": {
@@ -25851,6 +31468,46 @@
                       "additionalProperties": false
                     }
                   },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blobNameFormat": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "container",
+                    "endpoint"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -26034,6 +31691,9 @@
                     },
                     "securityToken": {
                       "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
                     }
                   },
                   "type": "object",
@@ -26061,6 +31721,24 @@
                     },
                     "bucket": {
                       "type": "string"
+                    },
+                    "caSecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "createBucketIfNotPresent": {
                       "properties": {
@@ -26259,6 +31937,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -26307,6 +32021,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -26348,6 +32106,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -26387,6 +32148,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -26523,6 +32287,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -26628,6 +32566,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -26676,6 +32617,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -26882,6 +32841,18 @@
               "name": {
                 "type": "string"
               },
+              "nodeFlag": {
+                "properties": {
+                  "hooked": {
+                    "type": "boolean"
+                  },
+                  "retried": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "outboundNodes": {
                 "items": {
                   "type": "string"
@@ -26917,6 +32888,42 @@
                         },
                         "archiveLogs": {
                           "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "artifactory": {
                           "properties": {
@@ -26966,6 +32973,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -27007,6 +33058,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -27046,6 +33100,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -27182,6 +33239,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -27287,6 +33518,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -27335,6 +33569,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -27618,6 +33870,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -27666,6 +33954,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -27707,6 +34039,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -27746,6 +34081,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -27882,6 +34220,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -27987,6 +34499,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -28035,6 +34550,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -29987,6 +36520,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -30022,6 +36596,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -30061,6 +36638,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -30194,6 +36774,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -30289,6 +37043,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -30331,6 +37088,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -32489,6 +39264,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -32537,6 +39348,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -32578,6 +39433,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -32617,6 +39475,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -32753,6 +39614,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -32858,6 +39893,9 @@
                                       },
                                       "securityToken": {
                                         "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
                                       }
                                     },
                                     "required": [
@@ -32906,6 +39944,24 @@
                                       },
                                       "bucket": {
                                         "type": "string"
+                                      },
+                                      "caSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "createBucketIfNotPresent": {
                                         "properties": {
@@ -33140,6 +40196,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -33188,6 +40280,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -33229,6 +40365,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -33268,6 +40407,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -33404,6 +40546,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -33509,6 +40825,9 @@
                                             },
                                             "securityToken": {
                                               "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
                                             }
                                           },
                                           "required": [
@@ -33557,6 +40876,24 @@
                                             },
                                             "bucket": {
                                               "type": "string"
+                                            },
+                                            "caSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "createBucketIfNotPresent": {
                                               "properties": {
@@ -33759,9 +41096,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -33893,6 +41227,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -33941,6 +41311,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -33982,6 +41396,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -34021,6 +41438,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -34157,6 +41577,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -34262,6 +41856,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -34310,6 +41907,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -34464,6 +42079,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -35542,6 +43167,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -35590,6 +43251,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -35631,6 +43336,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -35670,6 +43378,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -35806,6 +43517,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -35911,6 +43796,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -35959,6 +43847,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -36220,6 +44126,9 @@
                         },
                         "gauge": {
                           "properties": {
+                            "operation": {
+                              "type": "string"
+                            },
                             "realtime": {
                               "type": "boolean"
                             },
@@ -36337,6 +44246,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -36385,6 +44330,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -36426,6 +44415,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -36465,6 +44457,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -36601,6 +44596,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -36706,6 +44875,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -36754,6 +44926,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -36973,6 +45163,833 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -39135,6 +48152,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -39159,6 +48179,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -40923,6 +49946,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -40971,6 +50030,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -41012,6 +50115,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -41051,6 +50157,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -41187,6 +50296,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -41292,6 +50575,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -41340,6 +50626,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -41520,6 +50824,48 @@
               "type": "object",
               "additionalProperties": false
             },
+            "artifactGC": {
+              "properties": {
+                "forceFinalizerRemoval": {
+                  "type": "boolean"
+                },
+                "podMetadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "podSpecPatch": {
+                  "type": "string"
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "strategy": {
+                  "enum": [
+                    "",
+                    "OnWorkflowCompletion",
+                    "OnWorkflowDeletion",
+                    "Never"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "artifactRepositoryRef": {
               "properties": {
                 "configMap": {
@@ -41616,6 +50962,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -41664,6 +51046,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -41705,6 +51131,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -41744,6 +51173,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -41880,6 +51312,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -41985,6 +51591,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -42033,6 +51642,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -42235,9 +51862,6 @@
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "template"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -42295,6 +51919,9 @@
                       },
                       "gauge": {
                         "properties": {
+                          "operation": {
+                            "type": "string"
+                          },
                           "realtime": {
                             "type": "boolean"
                           },
@@ -42453,6 +52080,9 @@
             },
             "podGC": {
               "properties": {
+                "deleteDelayDuration": {
+                  "type": "string"
+                },
                 "labelSelector": {
                   "properties": {
                     "matchExpressions": {
@@ -42703,6 +52333,9 @@
                   "properties": {
                     "name": {
                       "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -42727,6 +52360,9 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -43375,6 +53011,47 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "azure": {
+                      "properties": {
+                        "accountKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "blob": {
+                          "type": "string"
+                        },
+                        "container": {
+                          "type": "string"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "blob",
+                        "container",
+                        "endpoint"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "gcs": {
                       "properties": {
                         "bucket": {
@@ -43410,6 +53087,9 @@
                     },
                     "git": {
                       "properties": {
+                        "branch": {
+                          "type": "string"
+                        },
                         "depth": {
                           "format": "int64",
                           "type": "integer"
@@ -43449,6 +53129,9 @@
                         },
                         "revision": {
                           "type": "string"
+                        },
+                        "singleBranch": {
+                          "type": "boolean"
                         },
                         "sshPrivateKeySecret": {
                           "properties": {
@@ -43582,6 +53265,180 @@
                     },
                     "http": {
                       "properties": {
+                        "auth": {
+                          "properties": {
+                            "basicAuth": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientCert": {
+                              "properties": {
+                                "clientCertSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "oauth2": {
+                              "properties": {
+                                "clientIDSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientSecretSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpointParams": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "scopes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tokenURLSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "headers": {
                           "items": {
                             "properties": {
@@ -43677,6 +53534,9 @@
                         },
                         "securityToken": {
                           "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -43719,6 +53579,24 @@
                         },
                         "bucket": {
                           "type": "string"
+                        },
+                        "caSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "createBucketIfNotPresent": {
                           "properties": {
@@ -45877,6 +55755,42 @@
                                     "archiveLogs": {
                                       "type": "boolean"
                                     },
+                                    "artifactGC": {
+                                      "properties": {
+                                        "podMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountName": {
+                                          "type": "string"
+                                        },
+                                        "strategy": {
+                                          "enum": [
+                                            "",
+                                            "OnWorkflowCompletion",
+                                            "OnWorkflowDeletion",
+                                            "Never"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "artifactory": {
                                       "properties": {
                                         "passwordSecret": {
@@ -45925,6 +55839,50 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
+                                    "azure": {
+                                      "properties": {
+                                        "accountKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "blob": {
+                                          "type": "string"
+                                        },
+                                        "container": {
+                                          "type": "string"
+                                        },
+                                        "endpoint": {
+                                          "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "blob",
+                                        "container",
+                                        "endpoint"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "deleted": {
+                                      "type": "boolean"
+                                    },
                                     "from": {
                                       "type": "string"
                                     },
@@ -45966,6 +55924,9 @@
                                     },
                                     "git": {
                                       "properties": {
+                                        "branch": {
+                                          "type": "string"
+                                        },
                                         "depth": {
                                           "format": "int64",
                                           "type": "integer"
@@ -46005,6 +55966,9 @@
                                         },
                                         "revision": {
                                           "type": "string"
+                                        },
+                                        "singleBranch": {
+                                          "type": "boolean"
                                         },
                                         "sshPrivateKeySecret": {
                                           "properties": {
@@ -46141,6 +56105,180 @@
                                     },
                                     "http": {
                                       "properties": {
+                                        "auth": {
+                                          "properties": {
+                                            "basicAuth": {
+                                              "properties": {
+                                                "passwordSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "usernameSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientCert": {
+                                              "properties": {
+                                                "clientCertSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "oauth2": {
+                                              "properties": {
+                                                "clientIDSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientSecretSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "endpointParams": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "scopes": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tokenURLSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "headers": {
                                           "items": {
                                             "properties": {
@@ -46246,6 +56384,9 @@
                                         },
                                         "securityToken": {
                                           "type": "string"
+                                        },
+                                        "useSDKCreds": {
+                                          "type": "boolean"
                                         }
                                       },
                                       "required": [
@@ -46294,6 +56435,24 @@
                                         },
                                         "bucket": {
                                           "type": "string"
+                                        },
+                                        "caSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "createBucketIfNotPresent": {
                                           "properties": {
@@ -46528,6 +56687,42 @@
                                           "archiveLogs": {
                                             "type": "boolean"
                                           },
+                                          "artifactGC": {
+                                            "properties": {
+                                              "podMetadata": {
+                                                "properties": {
+                                                  "annotations": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "labels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "serviceAccountName": {
+                                                "type": "string"
+                                              },
+                                              "strategy": {
+                                                "enum": [
+                                                  "",
+                                                  "OnWorkflowCompletion",
+                                                  "OnWorkflowDeletion",
+                                                  "Never"
+                                                ],
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "artifactory": {
                                             "properties": {
                                               "passwordSecret": {
@@ -46576,6 +56771,50 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
+                                          "azure": {
+                                            "properties": {
+                                              "accountKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "blob": {
+                                                "type": "string"
+                                              },
+                                              "container": {
+                                                "type": "string"
+                                              },
+                                              "endpoint": {
+                                                "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "blob",
+                                              "container",
+                                              "endpoint"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "deleted": {
+                                            "type": "boolean"
+                                          },
                                           "from": {
                                             "type": "string"
                                           },
@@ -46617,6 +56856,9 @@
                                           },
                                           "git": {
                                             "properties": {
+                                              "branch": {
+                                                "type": "string"
+                                              },
                                               "depth": {
                                                 "format": "int64",
                                                 "type": "integer"
@@ -46656,6 +56898,9 @@
                                               },
                                               "revision": {
                                                 "type": "string"
+                                              },
+                                              "singleBranch": {
+                                                "type": "boolean"
                                               },
                                               "sshPrivateKeySecret": {
                                                 "properties": {
@@ -46792,6 +57037,180 @@
                                           },
                                           "http": {
                                             "properties": {
+                                              "auth": {
+                                                "properties": {
+                                                  "basicAuth": {
+                                                    "properties": {
+                                                      "passwordSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "usernameSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientCert": {
+                                                    "properties": {
+                                                      "clientCertSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientKeySecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "oauth2": {
+                                                    "properties": {
+                                                      "clientIDSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "clientSecretSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "endpointParams": {
+                                                        "items": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "scopes": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "tokenURLSecret": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "type": "string"
+                                                          },
+                                                          "optional": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "headers": {
                                                 "items": {
                                                   "properties": {
@@ -46897,6 +57316,9 @@
                                               },
                                               "securityToken": {
                                                 "type": "string"
+                                              },
+                                              "useSDKCreds": {
+                                                "type": "boolean"
                                               }
                                             },
                                             "required": [
@@ -46945,6 +57367,24 @@
                                               },
                                               "bucket": {
                                                 "type": "string"
+                                              },
+                                              "caSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "createBucketIfNotPresent": {
                                                 "properties": {
@@ -47147,9 +57587,6 @@
                                   "additionalProperties": false
                                 }
                               },
-                              "required": [
-                                "template"
-                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -47281,6 +57718,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -47329,6 +57802,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -47370,6 +57887,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -47409,6 +57929,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -47545,6 +58068,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -47650,6 +58347,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -47698,6 +58398,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -47852,6 +58570,16 @@
                   "properties": {
                     "body": {
                       "type": "string"
+                    },
+                    "bodyFrom": {
+                      "properties": {
+                        "bytes": {
+                          "format": "byte",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "headers": {
                       "items": {
@@ -48930,6 +59658,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -48978,6 +59742,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -49019,6 +59827,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -49058,6 +59869,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -49194,6 +60008,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -49299,6 +60287,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -49347,6 +60338,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -49608,6 +60617,9 @@
                           },
                           "gauge": {
                             "properties": {
+                              "operation": {
+                                "type": "string"
+                              },
                               "realtime": {
                                 "type": "boolean"
                               },
@@ -49725,6 +60737,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -49773,6 +60821,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -49814,6 +60906,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -49853,6 +60948,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -49989,6 +61087,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -50094,6 +61366,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -50142,6 +61417,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -50361,6 +61654,833 @@
                     },
                     "manifest": {
                       "type": "string"
+                    },
+                    "manifestFrom": {
+                      "properties": {
+                        "artifact": {
+                          "properties": {
+                            "archive": {
+                              "properties": {
+                                "none": {
+                                  "type": "object"
+                                },
+                                "tar": {
+                                  "properties": {
+                                    "compressionLevel": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "zip": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "archiveLogs": {
+                              "type": "boolean"
+                            },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "artifactory": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
+                            "from": {
+                              "type": "string"
+                            },
+                            "fromExpression": {
+                              "type": "string"
+                            },
+                            "gcs": {
+                              "properties": {
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "serviceAccountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "git": {
+                              "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
+                                "depth": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "disableSubmodules": {
+                                  "type": "boolean"
+                                },
+                                "fetch": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "insecureIgnoreHostKey": {
+                                  "type": "boolean"
+                                },
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "revision": {
+                                  "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
+                                },
+                                "sshPrivateKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "globalName": {
+                              "type": "string"
+                            },
+                            "hdfs": {
+                              "properties": {
+                                "addresses": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "force": {
+                                  "type": "boolean"
+                                },
+                                "hdfsUser": {
+                                  "type": "string"
+                                },
+                                "krbCCacheSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbConfigConfigMap": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbKeytabSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "krbRealm": {
+                                  "type": "string"
+                                },
+                                "krbServicePrincipalName": {
+                                  "type": "string"
+                                },
+                                "krbUsername": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "http": {
+                              "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "headers": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "url": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            },
+                            "oss": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "createBucketIfNotPresent": {
+                                  "type": "boolean"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "lifecycleRule": {
+                                  "properties": {
+                                    "markDeletionAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "markInfrequentAccessAfterDays": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "securityToken": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "raw": {
+                              "properties": {
+                                "data": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "data"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "recurseMode": {
+                              "type": "boolean"
+                            },
+                            "s3": {
+                              "properties": {
+                                "accessKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bucket": {
+                                  "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "createBucketIfNotPresent": {
+                                  "properties": {
+                                    "objectLocking": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "encryptionOptions": {
+                                  "properties": {
+                                    "enableEncryption": {
+                                      "type": "boolean"
+                                    },
+                                    "kmsEncryptionContext": {
+                                      "type": "string"
+                                    },
+                                    "kmsKeyId": {
+                                      "type": "string"
+                                    },
+                                    "serverSideCustomerKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "roleARN": {
+                                  "type": "string"
+                                },
+                                "secretKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "subPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "artifact"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "mergeStrategy": {
                       "type": "string"
@@ -52523,6 +64643,9 @@
                       "properties": {
                         "name": {
                           "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -52547,6 +64670,9 @@
                           ],
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "namespace": {
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -54337,6 +66463,47 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "gcs": {
                         "properties": {
                           "bucket": {
@@ -54372,6 +66539,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -54411,6 +66581,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -54544,6 +66717,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -54639,6 +66986,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -54681,6 +67031,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -56839,6 +69207,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -56887,6 +69291,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -56928,6 +69376,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -56967,6 +69418,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -57103,6 +69557,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -57208,6 +69836,9 @@
                                           },
                                           "securityToken": {
                                             "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
                                           }
                                         },
                                         "required": [
@@ -57256,6 +69887,24 @@
                                           },
                                           "bucket": {
                                             "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "createBucketIfNotPresent": {
                                             "properties": {
@@ -57490,6 +70139,42 @@
                                             "archiveLogs": {
                                               "type": "boolean"
                                             },
+                                            "artifactGC": {
+                                              "properties": {
+                                                "podMetadata": {
+                                                  "properties": {
+                                                    "annotations": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "labels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "serviceAccountName": {
+                                                  "type": "string"
+                                                },
+                                                "strategy": {
+                                                  "enum": [
+                                                    "",
+                                                    "OnWorkflowCompletion",
+                                                    "OnWorkflowDeletion",
+                                                    "Never"
+                                                  ],
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "artifactory": {
                                               "properties": {
                                                 "passwordSecret": {
@@ -57538,6 +70223,50 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
+                                            "azure": {
+                                              "properties": {
+                                                "accountKeySecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "blob": {
+                                                  "type": "string"
+                                                },
+                                                "container": {
+                                                  "type": "string"
+                                                },
+                                                "endpoint": {
+                                                  "type": "string"
+                                                },
+                                                "useSDKCreds": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "blob",
+                                                "container",
+                                                "endpoint"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "deleted": {
+                                              "type": "boolean"
+                                            },
                                             "from": {
                                               "type": "string"
                                             },
@@ -57579,6 +70308,9 @@
                                             },
                                             "git": {
                                               "properties": {
+                                                "branch": {
+                                                  "type": "string"
+                                                },
                                                 "depth": {
                                                   "format": "int64",
                                                   "type": "integer"
@@ -57618,6 +70350,9 @@
                                                 },
                                                 "revision": {
                                                   "type": "string"
+                                                },
+                                                "singleBranch": {
+                                                  "type": "boolean"
                                                 },
                                                 "sshPrivateKeySecret": {
                                                   "properties": {
@@ -57754,6 +70489,180 @@
                                             },
                                             "http": {
                                               "properties": {
+                                                "auth": {
+                                                  "properties": {
+                                                    "basicAuth": {
+                                                      "properties": {
+                                                        "passwordSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "usernameSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientCert": {
+                                                      "properties": {
+                                                        "clientCertSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientKeySecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "oauth2": {
+                                                      "properties": {
+                                                        "clientIDSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "clientSecretSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        },
+                                                        "endpointParams": {
+                                                          "items": {
+                                                            "properties": {
+                                                              "key": {
+                                                                "type": "string"
+                                                              },
+                                                              "value": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "key"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "scopes": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        "tokenURLSecret": {
+                                                          "properties": {
+                                                            "key": {
+                                                              "type": "string"
+                                                            },
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "optional": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "key"
+                                                          ],
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
                                                 "headers": {
                                                   "items": {
                                                     "properties": {
@@ -57859,6 +70768,9 @@
                                                 },
                                                 "securityToken": {
                                                   "type": "string"
+                                                },
+                                                "useSDKCreds": {
+                                                  "type": "boolean"
                                                 }
                                               },
                                               "required": [
@@ -57907,6 +70819,24 @@
                                                 },
                                                 "bucket": {
                                                   "type": "string"
+                                                },
+                                                "caSecret": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "optional": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "createBucketIfNotPresent": {
                                                   "properties": {
@@ -58109,9 +71039,6 @@
                                     "additionalProperties": false
                                   }
                                 },
-                                "required": [
-                                  "template"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -58243,6 +71170,42 @@
                               "archiveLogs": {
                                 "type": "boolean"
                               },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "artifactory": {
                                 "properties": {
                                   "passwordSecret": {
@@ -58291,6 +71254,50 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
                               "from": {
                                 "type": "string"
                               },
@@ -58332,6 +71339,9 @@
                               },
                               "git": {
                                 "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
                                   "depth": {
                                     "format": "int64",
                                     "type": "integer"
@@ -58371,6 +71381,9 @@
                                   },
                                   "revision": {
                                     "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
                                   },
                                   "sshPrivateKeySecret": {
                                     "properties": {
@@ -58507,6 +71520,180 @@
                               },
                               "http": {
                                 "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "headers": {
                                     "items": {
                                       "properties": {
@@ -58612,6 +71799,9 @@
                                   },
                                   "securityToken": {
                                     "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
                                   }
                                 },
                                 "required": [
@@ -58660,6 +71850,24 @@
                                   },
                                   "bucket": {
                                     "type": "string"
+                                  },
+                                  "caSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "createBucketIfNotPresent": {
                                     "properties": {
@@ -58814,6 +72022,16 @@
                     "properties": {
                       "body": {
                         "type": "string"
+                      },
+                      "bodyFrom": {
+                        "properties": {
+                          "bytes": {
+                            "format": "byte",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -59892,6 +73110,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -59940,6 +73194,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -59981,6 +73279,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -60020,6 +73321,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -60156,6 +73460,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -60261,6 +73739,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -60309,6 +73790,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -60570,6 +74069,9 @@
                             },
                             "gauge": {
                               "properties": {
+                                "operation": {
+                                  "type": "string"
+                                },
                                 "realtime": {
                                   "type": "boolean"
                                 },
@@ -60687,6 +74189,42 @@
                             "archiveLogs": {
                               "type": "boolean"
                             },
+                            "artifactGC": {
+                              "properties": {
+                                "podMetadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountName": {
+                                  "type": "string"
+                                },
+                                "strategy": {
+                                  "enum": [
+                                    "",
+                                    "OnWorkflowCompletion",
+                                    "OnWorkflowDeletion",
+                                    "Never"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "artifactory": {
                               "properties": {
                                 "passwordSecret": {
@@ -60735,6 +74273,50 @@
                               "type": "object",
                               "additionalProperties": false
                             },
+                            "azure": {
+                              "properties": {
+                                "accountKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "blob": {
+                                  "type": "string"
+                                },
+                                "container": {
+                                  "type": "string"
+                                },
+                                "endpoint": {
+                                  "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "blob",
+                                "container",
+                                "endpoint"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "deleted": {
+                              "type": "boolean"
+                            },
                             "from": {
                               "type": "string"
                             },
@@ -60776,6 +74358,9 @@
                             },
                             "git": {
                               "properties": {
+                                "branch": {
+                                  "type": "string"
+                                },
                                 "depth": {
                                   "format": "int64",
                                   "type": "integer"
@@ -60815,6 +74400,9 @@
                                 },
                                 "revision": {
                                   "type": "string"
+                                },
+                                "singleBranch": {
+                                  "type": "boolean"
                                 },
                                 "sshPrivateKeySecret": {
                                   "properties": {
@@ -60951,6 +74539,180 @@
                             },
                             "http": {
                               "properties": {
+                                "auth": {
+                                  "properties": {
+                                    "basicAuth": {
+                                      "properties": {
+                                        "passwordSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "usernameSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientCert": {
+                                      "properties": {
+                                        "clientCertSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientKeySecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "oauth2": {
+                                      "properties": {
+                                        "clientIDSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientSecretSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "endpointParams": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "scopes": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tokenURLSecret": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "headers": {
                                   "items": {
                                     "properties": {
@@ -61056,6 +74818,9 @@
                                 },
                                 "securityToken": {
                                   "type": "string"
+                                },
+                                "useSDKCreds": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
@@ -61104,6 +74869,24 @@
                                 },
                                 "bucket": {
                                   "type": "string"
+                                },
+                                "caSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "createBucketIfNotPresent": {
                                   "properties": {
@@ -61323,6 +75106,833 @@
                       },
                       "manifest": {
                         "type": "string"
+                      },
+                      "manifestFrom": {
+                        "properties": {
+                          "artifact": {
+                            "properties": {
+                              "archive": {
+                                "properties": {
+                                  "none": {
+                                    "type": "object"
+                                  },
+                                  "tar": {
+                                    "properties": {
+                                      "compressionLevel": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "zip": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "archiveLogs": {
+                                "type": "boolean"
+                              },
+                              "artifactGC": {
+                                "properties": {
+                                  "podMetadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "serviceAccountName": {
+                                    "type": "string"
+                                  },
+                                  "strategy": {
+                                    "enum": [
+                                      "",
+                                      "OnWorkflowCompletion",
+                                      "OnWorkflowDeletion",
+                                      "Never"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "artifactory": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azure": {
+                                "properties": {
+                                  "accountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "blob": {
+                                    "type": "string"
+                                  },
+                                  "container": {
+                                    "type": "string"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "blob",
+                                  "container",
+                                  "endpoint"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "fromExpression": {
+                                "type": "string"
+                              },
+                              "gcs": {
+                                "properties": {
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "serviceAccountKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "git": {
+                                "properties": {
+                                  "branch": {
+                                    "type": "string"
+                                  },
+                                  "depth": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "disableSubmodules": {
+                                    "type": "boolean"
+                                  },
+                                  "fetch": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "insecureIgnoreHostKey": {
+                                    "type": "boolean"
+                                  },
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "repo": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  },
+                                  "singleBranch": {
+                                    "type": "boolean"
+                                  },
+                                  "sshPrivateKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "repo"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalName": {
+                                "type": "string"
+                              },
+                              "hdfs": {
+                                "properties": {
+                                  "addresses": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "force": {
+                                    "type": "boolean"
+                                  },
+                                  "hdfsUser": {
+                                    "type": "string"
+                                  },
+                                  "krbCCacheSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbConfigConfigMap": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbKeytabSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "krbRealm": {
+                                    "type": "string"
+                                  },
+                                  "krbServicePrincipalName": {
+                                    "type": "string"
+                                  },
+                                  "krbUsername": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "http": {
+                                "properties": {
+                                  "auth": {
+                                    "properties": {
+                                      "basicAuth": {
+                                        "properties": {
+                                          "passwordSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "usernameSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientCert": {
+                                        "properties": {
+                                          "clientCertSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "oauth2": {
+                                        "properties": {
+                                          "clientIDSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientSecretSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "endpointParams": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "scopes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "tokenURLSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "headers": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "mode": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "oss": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "type": "boolean"
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "lifecycleRule": {
+                                    "properties": {
+                                      "markDeletionAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "markInfrequentAccessAfterDays": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "securityToken": {
+                                    "type": "string"
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "raw": {
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "data"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "recurseMode": {
+                                "type": "boolean"
+                              },
+                              "s3": {
+                                "properties": {
+                                  "accessKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "bucket": {
+                                    "type": "string"
+                                  },
+                                  "caSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "createBucketIfNotPresent": {
+                                    "properties": {
+                                      "objectLocking": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "encryptionOptions": {
+                                    "properties": {
+                                      "enableEncryption": {
+                                        "type": "boolean"
+                                      },
+                                      "kmsEncryptionContext": {
+                                        "type": "string"
+                                      },
+                                      "kmsKeyId": {
+                                        "type": "string"
+                                      },
+                                      "serverSideCustomerKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpoint": {
+                                    "type": "string"
+                                  },
+                                  "insecure": {
+                                    "type": "boolean"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "roleARN": {
+                                    "type": "string"
+                                  },
+                                  "secretKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "useSDKCreds": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "subPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "artifact"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "mergeStrategy": {
                         "type": "string"
@@ -63485,6 +78095,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -63509,6 +78122,9 @@
                             ],
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "namespace": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -66189,6 +80805,12 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "taskResultsCompletionStatus": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "type": "object"
         }
       },
       "type": "object",

--- a/argoproj.io/workflowartifactgctask_v1alpha1.json
+++ b/argoproj.io/workflowartifactgctask_v1alpha1.json
@@ -1,0 +1,1616 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "artifactsByNode": {
+          "additionalProperties": {
+            "properties": {
+              "archiveLocation": {
+                "properties": {
+                  "archiveLogs": {
+                    "type": "boolean"
+                  },
+                  "artifactory": {
+                    "properties": {
+                      "passwordSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "url": {
+                        "type": "string"
+                      },
+                      "usernameSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcs": {
+                    "properties": {
+                      "bucket": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "serviceAccountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "git": {
+                    "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
+                      "depth": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "disableSubmodules": {
+                        "type": "boolean"
+                      },
+                      "fetch": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "insecureIgnoreHostKey": {
+                        "type": "boolean"
+                      },
+                      "passwordSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "repo": {
+                        "type": "string"
+                      },
+                      "revision": {
+                        "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
+                      },
+                      "sshPrivateKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "usernameSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hdfs": {
+                    "properties": {
+                      "addresses": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "force": {
+                        "type": "boolean"
+                      },
+                      "hdfsUser": {
+                        "type": "string"
+                      },
+                      "krbCCacheSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "krbConfigConfigMap": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "krbKeytabSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "krbRealm": {
+                        "type": "string"
+                      },
+                      "krbServicePrincipalName": {
+                        "type": "string"
+                      },
+                      "krbUsername": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "http": {
+                    "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headers": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "oss": {
+                    "properties": {
+                      "accessKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "bucket": {
+                        "type": "string"
+                      },
+                      "createBucketIfNotPresent": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "lifecycleRule": {
+                        "properties": {
+                          "markDeletionAfterDays": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "markInfrequentAccessAfterDays": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secretKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityToken": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "raw": {
+                    "properties": {
+                      "data": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "data"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "s3": {
+                    "properties": {
+                      "accessKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "bucket": {
+                        "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "createBucketIfNotPresent": {
+                        "properties": {
+                          "objectLocking": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "encryptionOptions": {
+                        "properties": {
+                          "enableEncryption": {
+                            "type": "boolean"
+                          },
+                          "kmsEncryptionContext": {
+                            "type": "string"
+                          },
+                          "kmsKeyId": {
+                            "type": "string"
+                          },
+                          "serverSideCustomerKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "region": {
+                        "type": "string"
+                      },
+                      "roleARN": {
+                        "type": "string"
+                      },
+                      "secretKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "artifacts": {
+                "additionalProperties": {
+                  "properties": {
+                    "archive": {
+                      "properties": {
+                        "none": {
+                          "type": "object"
+                        },
+                        "tar": {
+                          "properties": {
+                            "compressionLevel": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "zip": {
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "archiveLogs": {
+                      "type": "boolean"
+                    },
+                    "artifactGC": {
+                      "properties": {
+                        "podMetadata": {
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "strategy": {
+                          "enum": [
+                            "",
+                            "OnWorkflowCompletion",
+                            "OnWorkflowDeletion",
+                            "Never"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "artifactory": {
+                      "properties": {
+                        "passwordSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "usernameSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "url"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "azure": {
+                      "properties": {
+                        "accountKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "blob": {
+                          "type": "string"
+                        },
+                        "container": {
+                          "type": "string"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "blob",
+                        "container",
+                        "endpoint"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "deleted": {
+                      "type": "boolean"
+                    },
+                    "from": {
+                      "type": "string"
+                    },
+                    "fromExpression": {
+                      "type": "string"
+                    },
+                    "gcs": {
+                      "properties": {
+                        "bucket": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "serviceAccountKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "git": {
+                      "properties": {
+                        "branch": {
+                          "type": "string"
+                        },
+                        "depth": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "disableSubmodules": {
+                          "type": "boolean"
+                        },
+                        "fetch": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "insecureIgnoreHostKey": {
+                          "type": "boolean"
+                        },
+                        "passwordSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "repo": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "string"
+                        },
+                        "singleBranch": {
+                          "type": "boolean"
+                        },
+                        "sshPrivateKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "usernameSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "repo"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "globalName": {
+                      "type": "string"
+                    },
+                    "hdfs": {
+                      "properties": {
+                        "addresses": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "force": {
+                          "type": "boolean"
+                        },
+                        "hdfsUser": {
+                          "type": "string"
+                        },
+                        "krbCCacheSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "krbConfigConfigMap": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "krbKeytabSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "krbRealm": {
+                          "type": "string"
+                        },
+                        "krbServicePrincipalName": {
+                          "type": "string"
+                        },
+                        "krbUsername": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "http": {
+                      "properties": {
+                        "auth": {
+                          "properties": {
+                            "basicAuth": {
+                              "properties": {
+                                "passwordSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "usernameSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientCert": {
+                              "properties": {
+                                "clientCertSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "oauth2": {
+                              "properties": {
+                                "clientIDSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientSecretSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "endpointParams": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "scopes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tokenURLSecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "headers": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "mode": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "optional": {
+                      "type": "boolean"
+                    },
+                    "oss": {
+                      "properties": {
+                        "accessKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "bucket": {
+                          "type": "string"
+                        },
+                        "createBucketIfNotPresent": {
+                          "type": "boolean"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "lifecycleRule": {
+                          "properties": {
+                            "markDeletionAfterDays": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "markInfrequentAccessAfterDays": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "securityToken": {
+                          "type": "string"
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "raw": {
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "recurseMode": {
+                      "type": "boolean"
+                    },
+                    "s3": {
+                      "properties": {
+                        "accessKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "bucket": {
+                          "type": "string"
+                        },
+                        "caSecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "createBucketIfNotPresent": {
+                          "properties": {
+                            "objectLocking": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "encryptionOptions": {
+                          "properties": {
+                            "enableEncryption": {
+                              "type": "boolean"
+                            },
+                            "kmsEncryptionContext": {
+                              "type": "string"
+                            },
+                            "kmsKeyId": {
+                              "type": "string"
+                            },
+                            "serverSideCustomerKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        },
+                        "insecure": {
+                          "type": "boolean"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "region": {
+                          "type": "string"
+                        },
+                        "roleARN": {
+                          "type": "string"
+                        },
+                        "secretKeySecret": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "useSDKCreds": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "subPath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "artifactResultsByNode": {
+          "additionalProperties": {
+            "properties": {
+              "artifactResults": {
+                "additionalProperties": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object"
+}

--- a/argoproj.io/workfloweventbinding_v1alpha1.json
+++ b/argoproj.io/workfloweventbinding_v1alpha1.json
@@ -55,6 +55,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -103,6 +139,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -144,6 +224,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -183,6 +266,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -319,6 +405,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -424,6 +684,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -472,6 +735,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {

--- a/argoproj.io/workflowtaskresult_v1alpha1.json
+++ b/argoproj.io/workflowtaskresult_v1alpha1.json
@@ -44,11 +44,33 @@
               },
               "artifactGC": {
                 "properties": {
+                  "podMetadata": {
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "serviceAccountName": {
+                    "type": "string"
+                  },
                   "strategy": {
                     "enum": [
                       "",
                       "OnWorkflowCompletion",
-                      "OnWorkflowDeletion"
+                      "OnWorkflowDeletion",
+                      "Never"
                     ],
                     "type": "string"
                   }
@@ -100,6 +122,47 @@
                 },
                 "required": [
                   "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azure": {
+                "properties": {
+                  "accountKeySecret": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "blob": {
+                    "type": "string"
+                  },
+                  "container": {
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "type": "string"
+                  },
+                  "useSDKCreds": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "blob",
+                  "container",
+                  "endpoint"
                 ],
                 "type": "object",
                 "additionalProperties": false
@@ -608,6 +671,9 @@
                   },
                   "securityToken": {
                     "type": "string"
+                  },
+                  "useSDKCreds": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -656,6 +722,24 @@
                   },
                   "bucket": {
                     "type": "string"
+                  },
+                  "caSecret": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "createBucketIfNotPresent": {
                     "properties": {

--- a/argoproj.io/workflowtaskset_v1alpha1.json
+++ b/argoproj.io/workflowtaskset_v1alpha1.json
@@ -651,6 +651,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -686,6 +727,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -725,6 +769,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -858,6 +905,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -953,6 +1174,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -995,6 +1219,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -3153,6 +3395,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -3201,6 +3479,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -3242,6 +3564,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -3281,6 +3606,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -3417,6 +3745,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -3522,6 +4024,9 @@
                                       },
                                       "securityToken": {
                                         "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
                                       }
                                     },
                                     "required": [
@@ -3570,6 +4075,24 @@
                                       },
                                       "bucket": {
                                         "type": "string"
+                                      },
+                                      "caSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "createBucketIfNotPresent": {
                                         "properties": {
@@ -3804,6 +4327,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -3852,6 +4411,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -3893,6 +4496,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -3932,6 +4538,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -4068,6 +4677,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -4173,6 +4956,9 @@
                                             },
                                             "securityToken": {
                                               "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
                                             }
                                           },
                                           "required": [
@@ -4221,6 +5007,24 @@
                                             },
                                             "bucket": {
                                               "type": "string"
+                                            },
+                                            "caSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "createBucketIfNotPresent": {
                                               "properties": {
@@ -4423,9 +5227,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -4557,6 +5358,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -4605,6 +5442,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -4646,6 +5527,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -4685,6 +5569,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -4821,6 +5708,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -4926,6 +5987,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -4974,6 +6038,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -5128,6 +6210,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -6206,6 +7298,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -6254,6 +7382,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -6295,6 +7467,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -6334,6 +7509,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -6470,6 +7648,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -6575,6 +7927,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -6623,6 +7978,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -6884,6 +8257,9 @@
                         },
                         "gauge": {
                           "properties": {
+                            "operation": {
+                              "type": "string"
+                            },
                             "realtime": {
                               "type": "boolean"
                             },
@@ -7001,6 +8377,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7049,6 +8461,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7090,6 +8546,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7129,6 +8588,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7265,6 +8727,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7370,6 +9006,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -7418,6 +9057,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -7637,6 +9294,833 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -9799,6 +12283,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -9823,6 +12310,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -11017,6 +13507,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -11065,6 +13591,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -11106,6 +13676,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -11145,6 +13718,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -11281,6 +13857,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -11386,6 +14136,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -11434,6 +14187,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -11621,6 +14392,9 @@
                 "additionalProperties": false
               },
               "phase": {
+                "type": "string"
+              },
+              "progress": {
                 "type": "string"
               }
             },

--- a/argoproj.io/workflowtemplate_v1alpha1.json
+++ b/argoproj.io/workflowtemplate_v1alpha1.json
@@ -621,6 +621,42 @@
                   "archiveLogs": {
                     "type": "boolean"
                   },
+                  "artifactGC": {
+                    "properties": {
+                      "podMetadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "strategy": {
+                        "enum": [
+                          "",
+                          "OnWorkflowCompletion",
+                          "OnWorkflowDeletion",
+                          "Never"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "artifactory": {
                     "properties": {
                       "passwordSecret": {
@@ -669,6 +705,50 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "deleted": {
+                    "type": "boolean"
+                  },
                   "from": {
                     "type": "string"
                   },
@@ -710,6 +790,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -749,6 +832,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -885,6 +971,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -990,6 +1250,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -1038,6 +1301,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -1218,6 +1499,48 @@
           "type": "object",
           "additionalProperties": false
         },
+        "artifactGC": {
+          "properties": {
+            "forceFinalizerRemoval": {
+              "type": "boolean"
+            },
+            "podMetadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podSpecPatch": {
+              "type": "string"
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "strategy": {
+              "enum": [
+                "",
+                "OnWorkflowCompletion",
+                "OnWorkflowDeletion",
+                "Never"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "artifactRepositoryRef": {
           "properties": {
             "configMap": {
@@ -1314,6 +1637,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -1362,6 +1721,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -1403,6 +1806,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -1442,6 +1848,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -1578,6 +1987,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -1683,6 +2266,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -1731,6 +2317,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -1933,9 +2537,6 @@
                 "additionalProperties": false
               }
             },
-            "required": [
-              "template"
-            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1993,6 +2594,9 @@
                   },
                   "gauge": {
                     "properties": {
+                      "operation": {
+                        "type": "string"
+                      },
                       "realtime": {
                         "type": "boolean"
                       },
@@ -2151,6 +2755,9 @@
         },
         "podGC": {
           "properties": {
+            "deleteDelayDuration": {
+              "type": "string"
+            },
             "labelSelector": {
               "properties": {
                 "matchExpressions": {
@@ -2401,6 +3008,9 @@
               "properties": {
                 "name": {
                   "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -2425,6 +3035,9 @@
                   ],
                   "type": "object",
                   "additionalProperties": false
+                },
+                "namespace": {
+                  "type": "string"
                 }
               },
               "type": "object",
@@ -3073,6 +3686,47 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "azure": {
+                  "properties": {
+                    "accountKeySecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "blob": {
+                      "type": "string"
+                    },
+                    "container": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "blob",
+                    "container",
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "gcs": {
                   "properties": {
                     "bucket": {
@@ -3108,6 +3762,9 @@
                 },
                 "git": {
                   "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
                     "depth": {
                       "format": "int64",
                       "type": "integer"
@@ -3147,6 +3804,9 @@
                     },
                     "revision": {
                       "type": "string"
+                    },
+                    "singleBranch": {
+                      "type": "boolean"
                     },
                     "sshPrivateKeySecret": {
                       "properties": {
@@ -3280,6 +3940,180 @@
                 },
                 "http": {
                   "properties": {
+                    "auth": {
+                      "properties": {
+                        "basicAuth": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "clientCert": {
+                          "properties": {
+                            "clientCertSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "oauth2": {
+                          "properties": {
+                            "clientIDSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "clientSecretSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpointParams": {
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "scopes": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "tokenURLSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "headers": {
                       "items": {
                         "properties": {
@@ -3375,6 +4209,9 @@
                     },
                     "securityToken": {
                       "type": "string"
+                    },
+                    "useSDKCreds": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -3417,6 +4254,24 @@
                     },
                     "bucket": {
                       "type": "string"
+                    },
+                    "caSecret": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "createBucketIfNotPresent": {
                       "properties": {
@@ -5575,6 +6430,42 @@
                                 "archiveLogs": {
                                   "type": "boolean"
                                 },
+                                "artifactGC": {
+                                  "properties": {
+                                    "podMetadata": {
+                                      "properties": {
+                                        "annotations": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "labels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountName": {
+                                      "type": "string"
+                                    },
+                                    "strategy": {
+                                      "enum": [
+                                        "",
+                                        "OnWorkflowCompletion",
+                                        "OnWorkflowDeletion",
+                                        "Never"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "artifactory": {
                                   "properties": {
                                     "passwordSecret": {
@@ -5623,6 +6514,50 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
+                                "azure": {
+                                  "properties": {
+                                    "accountKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "blob": {
+                                      "type": "string"
+                                    },
+                                    "container": {
+                                      "type": "string"
+                                    },
+                                    "endpoint": {
+                                      "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "blob",
+                                    "container",
+                                    "endpoint"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "deleted": {
+                                  "type": "boolean"
+                                },
                                 "from": {
                                   "type": "string"
                                 },
@@ -5664,6 +6599,9 @@
                                 },
                                 "git": {
                                   "properties": {
+                                    "branch": {
+                                      "type": "string"
+                                    },
                                     "depth": {
                                       "format": "int64",
                                       "type": "integer"
@@ -5703,6 +6641,9 @@
                                     },
                                     "revision": {
                                       "type": "string"
+                                    },
+                                    "singleBranch": {
+                                      "type": "boolean"
                                     },
                                     "sshPrivateKeySecret": {
                                       "properties": {
@@ -5839,6 +6780,180 @@
                                 },
                                 "http": {
                                   "properties": {
+                                    "auth": {
+                                      "properties": {
+                                        "basicAuth": {
+                                          "properties": {
+                                            "passwordSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "usernameSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "clientCert": {
+                                          "properties": {
+                                            "clientCertSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "oauth2": {
+                                          "properties": {
+                                            "clientIDSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "clientSecretSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "endpointParams": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "scopes": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "tokenURLSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "headers": {
                                       "items": {
                                         "properties": {
@@ -5944,6 +7059,9 @@
                                     },
                                     "securityToken": {
                                       "type": "string"
+                                    },
+                                    "useSDKCreds": {
+                                      "type": "boolean"
                                     }
                                   },
                                   "required": [
@@ -5992,6 +7110,24 @@
                                     },
                                     "bucket": {
                                       "type": "string"
+                                    },
+                                    "caSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "createBucketIfNotPresent": {
                                       "properties": {
@@ -6226,6 +7362,42 @@
                                       "archiveLogs": {
                                         "type": "boolean"
                                       },
+                                      "artifactGC": {
+                                        "properties": {
+                                          "podMetadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "serviceAccountName": {
+                                            "type": "string"
+                                          },
+                                          "strategy": {
+                                            "enum": [
+                                              "",
+                                              "OnWorkflowCompletion",
+                                              "OnWorkflowDeletion",
+                                              "Never"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "artifactory": {
                                         "properties": {
                                           "passwordSecret": {
@@ -6274,6 +7446,50 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "azure": {
+                                        "properties": {
+                                          "accountKeySecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "blob": {
+                                            "type": "string"
+                                          },
+                                          "container": {
+                                            "type": "string"
+                                          },
+                                          "endpoint": {
+                                            "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "blob",
+                                          "container",
+                                          "endpoint"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "deleted": {
+                                        "type": "boolean"
+                                      },
                                       "from": {
                                         "type": "string"
                                       },
@@ -6315,6 +7531,9 @@
                                       },
                                       "git": {
                                         "properties": {
+                                          "branch": {
+                                            "type": "string"
+                                          },
                                           "depth": {
                                             "format": "int64",
                                             "type": "integer"
@@ -6354,6 +7573,9 @@
                                           },
                                           "revision": {
                                             "type": "string"
+                                          },
+                                          "singleBranch": {
+                                            "type": "boolean"
                                           },
                                           "sshPrivateKeySecret": {
                                             "properties": {
@@ -6490,6 +7712,180 @@
                                       },
                                       "http": {
                                         "properties": {
+                                          "auth": {
+                                            "properties": {
+                                              "basicAuth": {
+                                                "properties": {
+                                                  "passwordSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "usernameSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientCert": {
+                                                "properties": {
+                                                  "clientCertSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientKeySecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "oauth2": {
+                                                "properties": {
+                                                  "clientIDSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "clientSecretSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "endpointParams": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "scopes": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tokenURLSecret": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "headers": {
                                             "items": {
                                               "properties": {
@@ -6595,6 +7991,9 @@
                                           },
                                           "securityToken": {
                                             "type": "string"
+                                          },
+                                          "useSDKCreds": {
+                                            "type": "boolean"
                                           }
                                         },
                                         "required": [
@@ -6643,6 +8042,24 @@
                                           },
                                           "bucket": {
                                             "type": "string"
+                                          },
+                                          "caSecret": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                              "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "createBucketIfNotPresent": {
                                             "properties": {
@@ -6845,9 +8262,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "template"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -6979,6 +8393,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -7027,6 +8477,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -7068,6 +8562,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -7107,6 +8604,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -7243,6 +8743,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -7348,6 +9022,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -7396,6 +9073,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -7550,6 +9245,16 @@
               "properties": {
                 "body": {
                   "type": "string"
+                },
+                "bodyFrom": {
+                  "properties": {
+                    "bytes": {
+                      "format": "byte",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "headers": {
                   "items": {
@@ -8628,6 +10333,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -8676,6 +10417,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -8717,6 +10502,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -8756,6 +10544,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -8892,6 +10683,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -8997,6 +10962,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -9045,6 +11013,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -9306,6 +11292,9 @@
                       },
                       "gauge": {
                         "properties": {
+                          "operation": {
+                            "type": "string"
+                          },
                           "realtime": {
                             "type": "boolean"
                           },
@@ -9423,6 +11412,42 @@
                       "archiveLogs": {
                         "type": "boolean"
                       },
+                      "artifactGC": {
+                        "properties": {
+                          "podMetadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "serviceAccountName": {
+                            "type": "string"
+                          },
+                          "strategy": {
+                            "enum": [
+                              "",
+                              "OnWorkflowCompletion",
+                              "OnWorkflowDeletion",
+                              "Never"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "artifactory": {
                         "properties": {
                           "passwordSecret": {
@@ -9471,6 +11496,50 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "azure": {
+                        "properties": {
+                          "accountKeySecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "blob": {
+                            "type": "string"
+                          },
+                          "container": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "blob",
+                          "container",
+                          "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "deleted": {
+                        "type": "boolean"
+                      },
                       "from": {
                         "type": "string"
                       },
@@ -9512,6 +11581,9 @@
                       },
                       "git": {
                         "properties": {
+                          "branch": {
+                            "type": "string"
+                          },
                           "depth": {
                             "format": "int64",
                             "type": "integer"
@@ -9551,6 +11623,9 @@
                           },
                           "revision": {
                             "type": "string"
+                          },
+                          "singleBranch": {
+                            "type": "boolean"
                           },
                           "sshPrivateKeySecret": {
                             "properties": {
@@ -9687,6 +11762,180 @@
                       },
                       "http": {
                         "properties": {
+                          "auth": {
+                            "properties": {
+                              "basicAuth": {
+                                "properties": {
+                                  "passwordSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "usernameSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientCert": {
+                                "properties": {
+                                  "clientCertSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "oauth2": {
+                                "properties": {
+                                  "clientIDSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientSecretSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "endpointParams": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "scopes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "tokenURLSecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "headers": {
                             "items": {
                               "properties": {
@@ -9792,6 +12041,9 @@
                           },
                           "securityToken": {
                             "type": "string"
+                          },
+                          "useSDKCreds": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -9840,6 +12092,24 @@
                           },
                           "bucket": {
                             "type": "string"
+                          },
+                          "caSecret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "createBucketIfNotPresent": {
                             "properties": {
@@ -10059,6 +12329,833 @@
                 },
                 "manifest": {
                   "type": "string"
+                },
+                "manifestFrom": {
+                  "properties": {
+                    "artifact": {
+                      "properties": {
+                        "archive": {
+                          "properties": {
+                            "none": {
+                              "type": "object"
+                            },
+                            "tar": {
+                              "properties": {
+                                "compressionLevel": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "zip": {
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "archiveLogs": {
+                          "type": "boolean"
+                        },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "artifactory": {
+                          "properties": {
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
+                        "from": {
+                          "type": "string"
+                        },
+                        "fromExpression": {
+                          "type": "string"
+                        },
+                        "gcs": {
+                          "properties": {
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "serviceAccountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "git": {
+                          "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
+                            "depth": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "disableSubmodules": {
+                              "type": "boolean"
+                            },
+                            "fetch": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "insecureIgnoreHostKey": {
+                              "type": "boolean"
+                            },
+                            "passwordSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "revision": {
+                              "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
+                            },
+                            "sshPrivateKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "usernameSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "repo"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "globalName": {
+                          "type": "string"
+                        },
+                        "hdfs": {
+                          "properties": {
+                            "addresses": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "force": {
+                              "type": "boolean"
+                            },
+                            "hdfsUser": {
+                              "type": "string"
+                            },
+                            "krbCCacheSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbConfigConfigMap": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbKeytabSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "krbRealm": {
+                              "type": "string"
+                            },
+                            "krbServicePrincipalName": {
+                              "type": "string"
+                            },
+                            "krbUsername": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "http": {
+                          "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "headers": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        },
+                        "oss": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "createBucketIfNotPresent": {
+                              "type": "boolean"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "lifecycleRule": {
+                              "properties": {
+                                "markDeletionAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "markInfrequentAccessAfterDays": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "securityToken": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "raw": {
+                          "properties": {
+                            "data": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "data"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "recurseMode": {
+                          "type": "boolean"
+                        },
+                        "s3": {
+                          "properties": {
+                            "accessKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bucket": {
+                              "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "createBucketIfNotPresent": {
+                              "properties": {
+                                "objectLocking": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "encryptionOptions": {
+                              "properties": {
+                                "enableEncryption": {
+                                  "type": "boolean"
+                                },
+                                "kmsEncryptionContext": {
+                                  "type": "string"
+                                },
+                                "kmsKeyId": {
+                                  "type": "string"
+                                },
+                                "serverSideCustomerKeySecret": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "insecure": {
+                              "type": "boolean"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "region": {
+                              "type": "string"
+                            },
+                            "roleARN": {
+                              "type": "string"
+                            },
+                            "secretKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "subPath": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "artifact"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "mergeStrategy": {
                   "type": "string"
@@ -12221,6 +15318,9 @@
                   "properties": {
                     "name": {
                       "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -12245,6 +15345,9 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "namespace": {
+                      "type": "string"
                     }
                   },
                   "type": "object",
@@ -14035,6 +17138,47 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "azure": {
+                    "properties": {
+                      "accountKeySecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "blob": {
+                        "type": "string"
+                      },
+                      "container": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "blob",
+                      "container",
+                      "endpoint"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "gcs": {
                     "properties": {
                       "bucket": {
@@ -14070,6 +17214,9 @@
                   },
                   "git": {
                     "properties": {
+                      "branch": {
+                        "type": "string"
+                      },
                       "depth": {
                         "format": "int64",
                         "type": "integer"
@@ -14109,6 +17256,9 @@
                       },
                       "revision": {
                         "type": "string"
+                      },
+                      "singleBranch": {
+                        "type": "boolean"
                       },
                       "sshPrivateKeySecret": {
                         "properties": {
@@ -14242,6 +17392,180 @@
                   },
                   "http": {
                     "properties": {
+                      "auth": {
+                        "properties": {
+                          "basicAuth": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "clientCert": {
+                            "properties": {
+                              "clientCertSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "oauth2": {
+                            "properties": {
+                              "clientIDSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "clientSecretSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpointParams": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenURLSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "headers": {
                         "items": {
                           "properties": {
@@ -14337,6 +17661,9 @@
                       },
                       "securityToken": {
                         "type": "string"
+                      },
+                      "useSDKCreds": {
+                        "type": "boolean"
                       }
                     },
                     "required": [
@@ -14379,6 +17706,24 @@
                       },
                       "bucket": {
                         "type": "string"
+                      },
+                      "caSecret": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "createBucketIfNotPresent": {
                         "properties": {
@@ -16537,6 +19882,42 @@
                                   "archiveLogs": {
                                     "type": "boolean"
                                   },
+                                  "artifactGC": {
+                                    "properties": {
+                                      "podMetadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "serviceAccountName": {
+                                        "type": "string"
+                                      },
+                                      "strategy": {
+                                        "enum": [
+                                          "",
+                                          "OnWorkflowCompletion",
+                                          "OnWorkflowDeletion",
+                                          "Never"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "artifactory": {
                                     "properties": {
                                       "passwordSecret": {
@@ -16585,6 +19966,50 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "azure": {
+                                    "properties": {
+                                      "accountKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "blob": {
+                                        "type": "string"
+                                      },
+                                      "container": {
+                                        "type": "string"
+                                      },
+                                      "endpoint": {
+                                        "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "blob",
+                                      "container",
+                                      "endpoint"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "deleted": {
+                                    "type": "boolean"
+                                  },
                                   "from": {
                                     "type": "string"
                                   },
@@ -16626,6 +20051,9 @@
                                   },
                                   "git": {
                                     "properties": {
+                                      "branch": {
+                                        "type": "string"
+                                      },
                                       "depth": {
                                         "format": "int64",
                                         "type": "integer"
@@ -16665,6 +20093,9 @@
                                       },
                                       "revision": {
                                         "type": "string"
+                                      },
+                                      "singleBranch": {
+                                        "type": "boolean"
                                       },
                                       "sshPrivateKeySecret": {
                                         "properties": {
@@ -16801,6 +20232,180 @@
                                   },
                                   "http": {
                                     "properties": {
+                                      "auth": {
+                                        "properties": {
+                                          "basicAuth": {
+                                            "properties": {
+                                              "passwordSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "usernameSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "clientCert": {
+                                            "properties": {
+                                              "clientCertSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientKeySecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "oauth2": {
+                                            "properties": {
+                                              "clientIDSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "clientSecretSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "endpointParams": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "scopes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "tokenURLSecret": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "headers": {
                                         "items": {
                                           "properties": {
@@ -16906,6 +20511,9 @@
                                       },
                                       "securityToken": {
                                         "type": "string"
+                                      },
+                                      "useSDKCreds": {
+                                        "type": "boolean"
                                       }
                                     },
                                     "required": [
@@ -16954,6 +20562,24 @@
                                       },
                                       "bucket": {
                                         "type": "string"
+                                      },
+                                      "caSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "createBucketIfNotPresent": {
                                         "properties": {
@@ -17188,6 +20814,42 @@
                                         "archiveLogs": {
                                           "type": "boolean"
                                         },
+                                        "artifactGC": {
+                                          "properties": {
+                                            "podMetadata": {
+                                              "properties": {
+                                                "annotations": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "labels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountName": {
+                                              "type": "string"
+                                            },
+                                            "strategy": {
+                                              "enum": [
+                                                "",
+                                                "OnWorkflowCompletion",
+                                                "OnWorkflowDeletion",
+                                                "Never"
+                                              ],
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "artifactory": {
                                           "properties": {
                                             "passwordSecret": {
@@ -17236,6 +20898,50 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
+                                        "azure": {
+                                          "properties": {
+                                            "accountKeySecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "blob": {
+                                              "type": "string"
+                                            },
+                                            "container": {
+                                              "type": "string"
+                                            },
+                                            "endpoint": {
+                                              "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "blob",
+                                            "container",
+                                            "endpoint"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "deleted": {
+                                          "type": "boolean"
+                                        },
                                         "from": {
                                           "type": "string"
                                         },
@@ -17277,6 +20983,9 @@
                                         },
                                         "git": {
                                           "properties": {
+                                            "branch": {
+                                              "type": "string"
+                                            },
                                             "depth": {
                                               "format": "int64",
                                               "type": "integer"
@@ -17316,6 +21025,9 @@
                                             },
                                             "revision": {
                                               "type": "string"
+                                            },
+                                            "singleBranch": {
+                                              "type": "boolean"
                                             },
                                             "sshPrivateKeySecret": {
                                               "properties": {
@@ -17452,6 +21164,180 @@
                                         },
                                         "http": {
                                           "properties": {
+                                            "auth": {
+                                              "properties": {
+                                                "basicAuth": {
+                                                  "properties": {
+                                                    "passwordSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "usernameSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "clientCert": {
+                                                  "properties": {
+                                                    "clientCertSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientKeySecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "oauth2": {
+                                                  "properties": {
+                                                    "clientIDSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "clientSecretSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "endpointParams": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "value": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "scopes": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "tokenURLSecret": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
                                             "headers": {
                                               "items": {
                                                 "properties": {
@@ -17557,6 +21443,9 @@
                                             },
                                             "securityToken": {
                                               "type": "string"
+                                            },
+                                            "useSDKCreds": {
+                                              "type": "boolean"
                                             }
                                           },
                                           "required": [
@@ -17605,6 +21494,24 @@
                                             },
                                             "bucket": {
                                               "type": "string"
+                                            },
+                                            "caSecret": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "createBucketIfNotPresent": {
                                               "properties": {
@@ -17807,9 +21714,6 @@
                                 "additionalProperties": false
                               }
                             },
-                            "required": [
-                              "template"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17941,6 +21845,42 @@
                           "archiveLogs": {
                             "type": "boolean"
                           },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "artifactory": {
                             "properties": {
                               "passwordSecret": {
@@ -17989,6 +21929,50 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
                           "from": {
                             "type": "string"
                           },
@@ -18030,6 +22014,9 @@
                           },
                           "git": {
                             "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
                               "depth": {
                                 "format": "int64",
                                 "type": "integer"
@@ -18069,6 +22056,9 @@
                               },
                               "revision": {
                                 "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
                               },
                               "sshPrivateKeySecret": {
                                 "properties": {
@@ -18205,6 +22195,180 @@
                           },
                           "http": {
                             "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "headers": {
                                 "items": {
                                   "properties": {
@@ -18310,6 +22474,9 @@
                               },
                               "securityToken": {
                                 "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -18358,6 +22525,24 @@
                               },
                               "bucket": {
                                 "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "createBucketIfNotPresent": {
                                 "properties": {
@@ -18512,6 +22697,16 @@
                 "properties": {
                   "body": {
                     "type": "string"
+                  },
+                  "bodyFrom": {
+                    "properties": {
+                      "bytes": {
+                        "format": "byte",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "headers": {
                     "items": {
@@ -19590,6 +23785,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -19638,6 +23869,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -19679,6 +23954,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -19718,6 +23996,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -19854,6 +24135,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -19959,6 +24414,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -20007,6 +24465,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -20268,6 +24744,9 @@
                         },
                         "gauge": {
                           "properties": {
+                            "operation": {
+                              "type": "string"
+                            },
                             "realtime": {
                               "type": "boolean"
                             },
@@ -20385,6 +24864,42 @@
                         "archiveLogs": {
                           "type": "boolean"
                         },
+                        "artifactGC": {
+                          "properties": {
+                            "podMetadata": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "strategy": {
+                              "enum": [
+                                "",
+                                "OnWorkflowCompletion",
+                                "OnWorkflowDeletion",
+                                "Never"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "artifactory": {
                           "properties": {
                             "passwordSecret": {
@@ -20433,6 +24948,50 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "azure": {
+                          "properties": {
+                            "accountKeySecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "blob": {
+                              "type": "string"
+                            },
+                            "container": {
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "blob",
+                            "container",
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "deleted": {
+                          "type": "boolean"
+                        },
                         "from": {
                           "type": "string"
                         },
@@ -20474,6 +25033,9 @@
                         },
                         "git": {
                           "properties": {
+                            "branch": {
+                              "type": "string"
+                            },
                             "depth": {
                               "format": "int64",
                               "type": "integer"
@@ -20513,6 +25075,9 @@
                             },
                             "revision": {
                               "type": "string"
+                            },
+                            "singleBranch": {
+                              "type": "boolean"
                             },
                             "sshPrivateKeySecret": {
                               "properties": {
@@ -20649,6 +25214,180 @@
                         },
                         "http": {
                           "properties": {
+                            "auth": {
+                              "properties": {
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "usernameSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "clientCert": {
+                                  "properties": {
+                                    "clientCertSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientKeySecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "oauth2": {
+                                  "properties": {
+                                    "clientIDSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "clientSecretSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "endpointParams": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "scopes": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "tokenURLSecret": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "key"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "headers": {
                               "items": {
                                 "properties": {
@@ -20754,6 +25493,9 @@
                             },
                             "securityToken": {
                               "type": "string"
+                            },
+                            "useSDKCreds": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
@@ -20802,6 +25544,24 @@
                             },
                             "bucket": {
                               "type": "string"
+                            },
+                            "caSecret": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "createBucketIfNotPresent": {
                               "properties": {
@@ -21021,6 +25781,833 @@
                   },
                   "manifest": {
                     "type": "string"
+                  },
+                  "manifestFrom": {
+                    "properties": {
+                      "artifact": {
+                        "properties": {
+                          "archive": {
+                            "properties": {
+                              "none": {
+                                "type": "object"
+                              },
+                              "tar": {
+                                "properties": {
+                                  "compressionLevel": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "zip": {
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "archiveLogs": {
+                            "type": "boolean"
+                          },
+                          "artifactGC": {
+                            "properties": {
+                              "podMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "serviceAccountName": {
+                                "type": "string"
+                              },
+                              "strategy": {
+                                "enum": [
+                                  "",
+                                  "OnWorkflowCompletion",
+                                  "OnWorkflowDeletion",
+                                  "Never"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "artifactory": {
+                            "properties": {
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azure": {
+                            "properties": {
+                              "accountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "blob": {
+                                "type": "string"
+                              },
+                              "container": {
+                                "type": "string"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "blob",
+                              "container",
+                              "endpoint"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "deleted": {
+                            "type": "boolean"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "fromExpression": {
+                            "type": "string"
+                          },
+                          "gcs": {
+                            "properties": {
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "serviceAccountKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "git": {
+                            "properties": {
+                              "branch": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "disableSubmodules": {
+                                "type": "boolean"
+                              },
+                              "fetch": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "insecureIgnoreHostKey": {
+                                "type": "boolean"
+                              },
+                              "passwordSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              },
+                              "singleBranch": {
+                                "type": "boolean"
+                              },
+                              "sshPrivateKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "usernameSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "repo"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "globalName": {
+                            "type": "string"
+                          },
+                          "hdfs": {
+                            "properties": {
+                              "addresses": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "force": {
+                                "type": "boolean"
+                              },
+                              "hdfsUser": {
+                                "type": "string"
+                              },
+                              "krbCCacheSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbConfigConfigMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbKeytabSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "krbRealm": {
+                                "type": "string"
+                              },
+                              "krbServicePrincipalName": {
+                                "type": "string"
+                              },
+                              "krbUsername": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "path"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "http": {
+                            "properties": {
+                              "auth": {
+                                "properties": {
+                                  "basicAuth": {
+                                    "properties": {
+                                      "passwordSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "usernameSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "clientCert": {
+                                    "properties": {
+                                      "clientCertSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientKeySecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "oauth2": {
+                                    "properties": {
+                                      "clientIDSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "clientSecretSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "endpointParams": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "scopes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tokenURLSecret": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "headers": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "mode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "oss": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "createBucketIfNotPresent": {
+                                "type": "boolean"
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "lifecycleRule": {
+                                "properties": {
+                                  "markDeletionAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "markInfrequentAccessAfterDays": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "securityToken": {
+                                "type": "string"
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "raw": {
+                            "properties": {
+                              "data": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "data"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "recurseMode": {
+                            "type": "boolean"
+                          },
+                          "s3": {
+                            "properties": {
+                              "accessKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "bucket": {
+                                "type": "string"
+                              },
+                              "caSecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "createBucketIfNotPresent": {
+                                "properties": {
+                                  "objectLocking": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "encryptionOptions": {
+                                "properties": {
+                                  "enableEncryption": {
+                                    "type": "boolean"
+                                  },
+                                  "kmsEncryptionContext": {
+                                    "type": "string"
+                                  },
+                                  "kmsKeyId": {
+                                    "type": "string"
+                                  },
+                                  "serverSideCustomerKeySecret": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "endpoint": {
+                                "type": "string"
+                              },
+                              "insecure": {
+                                "type": "boolean"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleARN": {
+                                "type": "string"
+                              },
+                              "secretKeySecret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "useSDKCreds": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "subPath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "artifact"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "mergeStrategy": {
                     "type": "string"
@@ -23183,6 +28770,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -23207,6 +28797,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "namespace": {
+                        "type": "string"
                       }
                     },
                     "type": "object",


### PR DESCRIPTION
Hi, thank you for maintaining this repository...! This is really helpful to improve our productivity by validating configurations before deploying it.

I tried to update Argo Workflow CRDs to v3.5.4 using the following script.

```bash

set -eu
set -o pipefail

ARGO_WORKFLOW_VERSION='3.5.4'
KUBECONFORM_DIR=<PATH to kubeconform repository>

kinds=(
  clusterworkflowtemplates
  cronworkflows
  workflowartifactgctasks
  workfloweventbindings
  workflows
  workflowtaskresults
  workflowtasksets
  workflowtemplates
)

for kind in "${kinds[@]}"; do
  python3 ${KUBECONFORM_DIR}/scripts/openapi2jsonschema.py https://raw.githubusercontent.com/argoproj/argo-workflows/v${ARGO_WORKFLOW_VERSION}/manifests/base/crds/full/argoproj.io_${kind}.yaml
done
```

CRDs-catalog has an utility tool to extract CRDs from an existing cluster, named CRD Extractor.
In most cases, we can use the tool to update CRDs. However, in Argo Workflow, we cannot utilize the tool for it.

There are 2 types of manifests in Argo Workflow.

- full : https://github.com/argoproj/argo-workflows/tree/v3.5.4/manifests/base/crds/full
  - `These CRDs have full schema validation. As a result, they are large and probably not suitable to be used in your cluster.` (cited from README.md)
- minimal : https://github.com/argoproj/argo-workflows/tree/v3.5.4/manifests/base/crds/minimal
  - `These CRDs omit schema validation.` (cited from README.md)

`full` has full schema validation. However, we cannot apply the manifest to a k8s cluster due to errors in applying the manifests. So, we cannot use CRD Extractor to update it.

`minimal` can be applied to a k8s cluster, but it doesn't have schema validation. So, using CRD Extractor against `minimal` manifest is meaningless.

Therefore, I directly used `openapi2jsonchema.py` in the kubeconform repository to update Argo Workflow's CRDs.