### PR TITLE
Update secrets.hashicorp.com

### DIFF
--- a/secrets.hashicorp.com/hcpauth_v1beta1.json
+++ b/secrets.hashicorp.com/hcpauth_v1beta1.json
@@ -1,0 +1,83 @@
+{
+  "description": "HCPAuth is the Schema for the hcpauths API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "HCPAuthSpec defines the desired state of HCPAuth",
+      "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces Kubernetes Namespaces which are allow-listed for use with this AuthMethod. This field allows administrators to customize which Kubernetes namespaces are authorized to use with this AuthMethod. While Vault will still enforce its own rules, this has the added configurability of restricting which HCPAuthMethods can be used by which namespaces. Accepted values: []{\"*\"} - wildcard, all namespaces. []{\"a\", \"b\"} - list of namespaces. unset - disallow all namespaces except the Operator's the HCPAuthMethod's namespace, this is the default behavior.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "method": {
+          "default": "servicePrincipal",
+          "description": "Method to use when authenticating to Vault.",
+          "enum": [
+            "servicePrincipal"
+          ],
+          "type": "string"
+        },
+        "organizationID": {
+          "description": "OrganizationID of the HCP organization.",
+          "type": "string"
+        },
+        "projectID": {
+          "description": "ProjectID of the HCP project.",
+          "type": "string"
+        },
+        "servicePrincipal": {
+          "description": "ServicePrincipal provides the necessary configuration for authenticating to HCP using a service principal. For security reasons, only project-level service principals should ever be used.",
+          "properties": {
+            "secretRef": {
+              "description": "SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID, and clientSecret. The secret data must have the following structure { \"clientID\": \"clientID\", \"clientSecret\": \"clientSecret\", }",
+              "type": "string"
+            }
+          },
+          "required": [
+            "secretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "organizationID",
+        "projectID"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "HCPAuthStatus defines the observed state of HCPAuth",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "valid": {
+          "description": "Valid auth mechanism.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "error",
+        "valid"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets.hashicorp.com/hcpvaultsecretsapp_v1beta1.json
+++ b/secrets.hashicorp.com/hcpvaultsecretsapp_v1beta1.json
@@ -1,5 +1,5 @@
 {
-  "description": "VaultStaticSecret is the Schema for the vaultstaticsecrets API",
+  "description": "HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,10 +13,14 @@
       "type": "object"
     },
     "spec": {
-      "description": "VaultStaticSecretSpec defines the desired state of VaultStaticSecret",
+      "description": "HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp",
       "properties": {
+        "appName": {
+          "description": "AppName of the Vault Secrets Application that is to be synced.",
+          "type": "string"
+        },
         "destination": {
-          "description": "Destination provides configuration necessary for syncing the Vault secret to Kubernetes.",
+          "description": "Destination provides configuration necessary for syncing the HCP Vault Application secrets to Kubernetes.",
           "properties": {
             "annotations": {
               "additionalProperties": {
@@ -51,30 +55,18 @@
           "type": "object",
           "additionalProperties": false
         },
-        "hmacSecretData": {
-          "default": true,
-          "description": "HMACSecretData determines whether the Operator computes the HMAC of the Secret's data. The MAC value will be stored in the resource's Status.SecretMac field, and will be used for drift detection and during incoming Vault secret comparison. Enabling this feature is recommended to ensure that Secret's data stays consistent with Vault.",
-          "type": "boolean"
-        },
-        "mount": {
-          "description": "Mount for the secret in Vault",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace to get the secret from in Vault",
-          "type": "string"
-        },
-        "path": {
-          "description": "Path of the secret in Vault, corresponds to the `path` parameter for, kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version",
+        "hcpAuthRef": {
+          "description": "HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in its own Kubernetes namespace. HCPAuthRef string `json:\"hcpAuthRef,omitempty\"`",
           "type": "string"
         },
         "refreshAfter": {
+          "default": "600s",
           "description": "RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h",
           "pattern": "^([0-9]+(\\.[0-9]+)?(s|m|h))$",
           "type": "string"
         },
         "rolloutRestartTargets": {
-          "description": "RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a \"rollout-restart\" for each target whenever the Vault secret changes between reconciliation events. All configured targets wil be ignored if HMACSecretData is set to false. See RolloutRestartTarget for more details.",
+          "description": "RolloutRestartTargets should be configured whenever the application(s) consuming the HCP Vault Secrets App does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a \"rollout-restart\" for each target whenever the Vault secret changes between reconciliation events. See RolloutRestartTarget for more details.",
           "items": {
             "description": "RolloutRestartTarget provides the configuration required to perform a rollout-restart of the supported resources upon Vault Secret rotation. The rollout-restart is triggered by patching the target resource's 'spec.template.metadata.annotations' to include 'vso.secrets.hashicorp.com/restartedAt' with a timestamp value of when the trigger was executed. E.g. vso.secrets.hashicorp.com/restartedAt: \"2023-03-23T13:39:31Z\" \n Supported resources: Deployment, DaemonSet, StatefulSet",
             "properties": {
@@ -98,50 +90,23 @@
             "additionalProperties": false
           },
           "type": "array"
-        },
-        "type": {
-          "description": "Type of the Vault static secret",
-          "enum": [
-            "kv-v1",
-            "kv-v2"
-          ],
-          "type": "string"
-        },
-        "vaultAuthRef": {
-          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
-          "type": "string"
-        },
-        "version": {
-          "description": "Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version",
-          "minimum": 0,
-          "type": "integer"
         }
       },
       "required": [
-        "destination",
-        "mount",
-        "path",
-        "type"
+        "appName",
+        "destination"
       ],
       "type": "object",
       "additionalProperties": false
     },
     "status": {
-      "description": "VaultStaticSecretStatus defines the observed state of VaultStaticSecret",
+      "description": "HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp",
       "properties": {
-        "lastGeneration": {
-          "description": "LastGeneration is the Generation of the last reconciled resource.",
-          "format": "int64",
-          "type": "integer"
-        },
         "secretMAC": {
-          "description": "SecretMAC used when deciding whether new Vault secret data should be synced. \n The controller will compare the \"new\" Vault secret data to this value using HMAC, if they are different, then the data will be synced to the Destination. \n The SecretMac is also used to detect drift in the Destination Secret's Data. If drift is detected the data will be synced to the Destination.",
+          "description": "SecretMAC used when deciding whether new Vault secret data should be synced. \n The controller will compare the \"new\" HCP Vault Secrets App data to this value using HMAC, if they are different, then the data will be synced to the Destination. \n The SecretMac is also used to detect drift in the Destination Secret's Data. If drift is detected the data will be synced to the Destination.",
           "type": "string"
         }
       },
-      "required": [
-        "lastGeneration"
-      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/secrets.hashicorp.com/vaultauth_v1beta1.json
+++ b/secrets.hashicorp.com/vaultauth_v1beta1.json
@@ -15,6 +15,13 @@
     "spec": {
       "description": "VaultAuthSpec defines the desired state of VaultAuth",
       "properties": {
+        "allowedNamespaces": {
+          "description": "AllowedNamespaces Kubernetes Namespaces which are allow-listed for use with this AuthMethod. This field allows administrators to customize which Kubernetes namespaces are authorized to use with this AuthMethod. While Vault will still enforce its own rules, this has the added configurability of restricting which VaultAuthMethods can be used by which namespaces. Accepted values: []{\"*\"} - wildcard, all namespaces. []{\"a\", \"b\"} - list of namespaces. unset - disallow all namespaces except the Operator's the VaultAuthMethod's namespace, this is the default behavior.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "appRole": {
           "description": "AppRole specific auth configuration, requires that the Method be set to `appRole`.",
           "properties": {
@@ -72,6 +79,37 @@
           },
           "required": [
             "role"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gcp": {
+          "description": "GCP specific auth configuration, requires that Method be set to `gcp`.",
+          "properties": {
+            "clusterName": {
+              "description": "GKE cluster name. Defaults to the cluster-name returned from the operator pod's local metadata server.",
+              "type": "string"
+            },
+            "projectID": {
+              "description": "GCP project ID. Defaults to the project-id returned from the operator pod's local metadata server.",
+              "type": "string"
+            },
+            "region": {
+              "description": "GCP Region of the GKE cluster's identity provider. Defaults to the region returned from the operator pod's local metadata server.",
+              "type": "string"
+            },
+            "role": {
+              "description": "Vault role to use for authenticating",
+              "type": "string"
+            },
+            "workloadIdentityServiceAccount": {
+              "description": "WorkloadIdentityServiceAccount is the name of a Kubernetes service account (in the same Kubernetes namespace as the Vault*Secret referencing this resource) which has been configured for workload identity in GKE. Should be annotated with \"iam.gke.io/gcp-service-account\".",
+              "type": "string"
+            }
+          },
+          "required": [
+            "role",
+            "workloadIdentityServiceAccount"
           ],
           "type": "object",
           "additionalProperties": false
@@ -158,7 +196,8 @@
             "kubernetes",
             "jwt",
             "appRole",
-            "aws"
+            "aws",
+            "gcp"
           ],
           "type": "string"
         },
@@ -178,7 +217,7 @@
           "type": "object"
         },
         "storageEncryption": {
-          "description": "StorageEncryption provides the necessary configuration to encrypt the client storage cache. This should only be configured when client cache persistence with encryption is enabled. This is done by passing setting the manager's commandline argument --client-cache-persistence-model=direct-encrypted. Typically there should only ever be one VaultAuth configured with StorageEncryption in the Cluster, and it should have the label: cacheStorageEncryption=true",
+          "description": "StorageEncryption provides the necessary configuration to encrypt the client storage cache. This should only be configured when client cache persistence with encryption is enabled. This is done by passing setting the manager's commandline argument --client-cache-persistence-model=direct-encrypted. Typically, there should only ever be one VaultAuth configured with StorageEncryption in the Cluster, and it should have the label: cacheStorageEncryption=true",
           "properties": {
             "keyName": {
               "description": "KeyName to use for encrypt/decrypt operations via Vault Transit.",
@@ -197,7 +236,7 @@
           "additionalProperties": false
         },
         "vaultConnectionRef": {
-          "description": "VaultConnectionRef of the corresponding VaultConnection CustomResource. If no value is specified the Operator will default to the `default` VaultConnection, configured in its own Kubernetes namespace.",
+          "description": "VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to\t`default` VaultConnection, configured in its own Kubernetes namespace.",
           "type": "string"
         }
       },

--- a/secrets.hashicorp.com/vaultconnection_v1beta1.json
+++ b/secrets.hashicorp.com/vaultconnection_v1beta1.json
@@ -31,6 +31,7 @@
           "type": "object"
         },
         "skipTLSVerify": {
+          "default": false,
           "description": "SkipTLSVerify for TLS connections.",
           "type": "boolean"
         },
@@ -40,7 +41,8 @@
         }
       },
       "required": [
-        "address"
+        "address",
+        "skipTLSVerify"
       ],
       "type": "object",
       "additionalProperties": false

--- a/secrets.hashicorp.com/vaultdynamicsecret_v1beta1.json
+++ b/secrets.hashicorp.com/vaultdynamicsecret_v1beta1.json
@@ -121,7 +121,7 @@
           "type": "array"
         },
         "vaultAuthRef": {
-          "description": "VaultAuthRef to the VaultAuth resource If no value is specified the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
+          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
           "type": "string"
         }
       },
@@ -196,6 +196,10 @@
               "format": "int64",
               "type": "integer"
             },
+            "rotationSchedule": {
+              "description": "RotationSchedule is a \"cron style\" string representing the allowed schedule for each rotation. e.g. \"1 0 * * *\" would rotate at one minute past midnight (00:01) every day.",
+              "type": "string"
+            },
             "ttl": {
               "description": "TTL is the seconds remaining before the next rotation.",
               "format": "int64",
@@ -205,6 +209,7 @@
           "required": [
             "lastVaultRotation",
             "rotationPeriod",
+            "rotationSchedule",
             "ttl"
           ],
           "type": "object",

--- a/secrets.hashicorp.com/vaultpkisecret_v1beta1.json
+++ b/secrets.hashicorp.com/vaultpkisecret_v1beta1.json
@@ -31,7 +31,7 @@
           "type": "string"
         },
         "destination": {
-          "description": "Destination provides configuration necessary for syncing the Vault secret to Kubernetes. If the type is set to \"kubernetes.io/tls\", the Vault response fields \"certificate\" and \"private_key\" will be copied to fields \"tls.crt\" and \"tls.key\", respectively, in the Kubernetes secret.",
+          "description": "Destination provides configuration necessary for syncing the Vault secret to Kubernetes. If the type is set to \"kubernetes.io/tls\", \"tls.key\" will be set to the \"private_key\" response from Vault, and \"tls.crt\" will be set to \"certificate\" + \"ca_chain\" from the Vault response (\"issuing_ca\" is used when \"ca_chain\" is empty). The \"remove_roots_from_chain=true\" option is used with Vault to exclude the root CA from the Vault response.",
           "properties": {
             "annotations": {
               "additionalProperties": {
@@ -71,7 +71,8 @@
           "type": "boolean"
         },
         "expiryOffset": {
-          "description": "ExpiryOffset to use for computing when the certificate should be renewed. The rotation time will be difference between the expiration and the offset. Should be in duration notation e.g. 30s, 120s, etc. Set to empty string \"\" to prevent certificate rotation.",
+          "description": "ExpiryOffset to use for computing when the certificate should be renewed. The rotation time will be difference between the expiration and the offset. Should be in duration notation e.g. 30s, 120s, etc.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(s|m|h))$",
           "type": "string"
         },
         "format": {
@@ -148,6 +149,7 @@
         },
         "ttl": {
           "description": "TTL for the certificate; sets the expiration date. If not specified the Vault role's default, backend default, or system default TTL is used, in that order. Cannot be larger than the mount's max TTL. Note: this only has an effect when generating a CA cert or signing a CA cert, not when generating a CSR for an intermediate CA. Should be in duration notation e.g. 120s, 2h, etc.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(s|m|h))$",
           "type": "string"
         },
         "uriSans": {
@@ -158,7 +160,7 @@
           "type": "array"
         },
         "vaultAuthRef": {
-          "description": "VaultAuthRef of the VaultAuth resource If no value is specified the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
+          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
           "type": "string"
         }
       },
@@ -180,6 +182,20 @@
           "format": "int64",
           "type": "integer"
         },
+        "lastGeneration": {
+          "description": "LastGeneration is the Generation of the last reconciled resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "lastRotation": {
+          "description": "LastLastRotation of the certificate.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "secretMAC": {
+          "description": "SecretMAC used when deciding whether new Vault secret data should be synced. \n The controller will compare the \"new\" Vault secret data to this value using HMAC, if they are different, then the data will be synced to the Destination. \n The SecretMac is also used to detect drift in the Destination Secret's Data. If drift is detected the data will be synced to the Destination.",
+          "type": "string"
+        },
         "serialNumber": {
           "type": "string"
         },
@@ -189,6 +205,8 @@
       },
       "required": [
         "error",
+        "lastGeneration",
+        "lastRotation",
         "valid"
       ],
       "type": "object",


### PR DESCRIPTION
Pulled from https://github.com/hashicorp/vault-secrets-operator/tree/main/chart/crds with `openapi2jsonschema.py`.

Adds support for HCP Vault Secrets CRDS:
- HCPAuth
- HCPVaultSecretsApp