### PR TITLE
feat: Update crunchy postgres-operator CRDs to latest v1beta1

### DIFF
--- a/postgres-operator.crunchydata.com/pgupgrade_v1beta1.json
+++ b/postgres-operator.crunchydata.com/pgupgrade_v1beta1.json
@@ -697,7 +697,7 @@
         },
         "fromPostgresVersion": {
           "description": "The major version of PostgreSQL before the upgrade.",
-          "maximum": 15,
+          "maximum": 16,
           "minimum": 10,
           "type": "integer"
         },
@@ -802,7 +802,7 @@
         },
         "toPostgresVersion": {
           "description": "The major version of PostgreSQL to be upgraded to.",
-          "maximum": 15,
+          "maximum": 16,
           "minimum": 10,
           "type": "integer"
         },

--- a/postgres-operator.crunchydata.com/postgrescluster_v1beta1.json
+++ b/postgres-operator.crunchydata.com/postgrescluster_v1beta1.json
@@ -8611,7 +8611,7 @@
         },
         "postgresVersion": {
           "description": "The major version of PostgreSQL installed in the PostgreSQL image",
-          "maximum": 15,
+          "maximum": 16,
           "minimum": 10,
           "type": "integer"
         },
@@ -12888,12 +12888,26 @@
           "type": "object",
           "additionalProperties": false
         },
+        "registrationRequired": {
+          "description": "Version information for installations with a registration requirement.",
+          "properties": {
+            "pgoVersion": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "startupInstance": {
           "description": "The instance that should be started first when bootstrapping and/or starting a PostgresCluster.",
           "type": "string"
         },
         "startupInstanceSet": {
           "description": "The instance set associated with the startupInstance",
+          "type": "string"
+        },
+        "tokenRequired": {
+          "description": "Signals the need for a token to be applied when registration is required.",
           "type": "string"
         },
         "userInterface": {


### PR DESCRIPTION
Fixes #272 

Update CrunchyData CRDs to latest v1beta1

Group: postgres-operator.crunchydata.com

List of CRDs:

- `PGUpgrade`
- `PostgresCluster`

Here are the commands that I used to generate them:

```
python openapi2jsonschema.py https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/config/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml

python openapi2jsonschema.py https://raw.githubusercontent.com/CrunchyData/postgres-operator/master/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
```

Reference: [CrunchyData/postgres-operator/config/crd/bases@master](https://github.com/CrunchyData/postgres-operator/tree/eedf513582b7d90c7763f64eb55c5bb266d729f5/config/crd/bases)
Source: [CrunchyData/postgres-operator@master](https://github.com/CrunchyData/postgres-operator/tree/eedf513582b7d90c7763f64eb55c5bb266d729f5)