### PR TITLE
Update Traefik CRDs to Traefik v2.11

### DIFF
--- a/traefik.io/ingressroute_v1alpha1.json
+++ b/traefik.io/ingressroute_v1alpha1.json
@@ -2,11 +2,11 @@
   "description": "IngressRoute is the CRD implementation of a Traefik HTTP Router.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "IngressRouteSpec defines the desired state of IngressRoute.",
       "properties": {
         "entryPoints": {
-          "description": "EntryPoints defines the list of entry point names to bind to. Entry points have to be configured in the static configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/ Default: all.",
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/\nDefault: all.",
           "items": {
             "type": "string"
           },
@@ -28,18 +28,18 @@
             "description": "Route holds the HTTP route configuration.",
             "properties": {
               "kind": {
-                "description": "Kind defines the kind of the route. Rule is the only supported kind.",
+                "description": "Kind defines the kind of the route.\nRule is the only supported kind.",
                 "enum": [
                   "Rule"
                 ],
                 "type": "string"
               },
               "match": {
-                "description": "Match defines the router's rule. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#rule",
+                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule",
                 "type": "string"
               },
               "middlewares": {
-                "description": "Middlewares defines the list of references to Middleware resources. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-middleware",
+                "description": "Middlewares defines the list of references to Middleware resources.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-middleware",
                 "items": {
                   "description": "MiddlewareRef is a reference to a Middleware resource.",
                   "properties": {
@@ -61,11 +61,11 @@
                 "type": "array"
               },
               "priority": {
-                "description": "Priority defines the router's priority. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#priority",
+                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority",
                 "type": "integer"
               },
               "services": {
-                "description": "Services defines the list of Service. It can contain any combination of TraefikService and/or reference to a Kubernetes Service.",
+                "description": "Services defines the list of Service.\nIt can contain any combination of TraefikService and/or reference to a Kubernetes Service.",
                 "items": {
                   "description": "Service defines an upstream HTTP service to proxy traffic to.",
                   "properties": {
@@ -78,7 +78,7 @@
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name defines the name of the referenced Kubernetes Service or TraefikService. The differentiation between the two is specified in the Kind field.",
+                      "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
                       "type": "string"
                     },
                     "namespace": {
@@ -86,11 +86,11 @@
                       "type": "string"
                     },
                     "nativeLB": {
-                      "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+                      "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
                       "type": "boolean"
                     },
                     "passHostHeader": {
-                      "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service. By default, passHostHeader is true.",
+                      "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
                       "type": "boolean"
                     },
                     "port": {
@@ -102,14 +102,14 @@
                           "type": "string"
                         }
                       ],
-                      "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+                      "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
                       "x-kubernetes-int-or-string": true
                     },
                     "responseForwarding": {
                       "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
                       "properties": {
                         "flushInterval": {
-                          "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body. A negative value means to flush immediately after each write to the client. This configuration is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately. Default: 100ms",
+                          "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
                           "type": "string"
                         }
                       },
@@ -117,15 +117,15 @@
                       "additionalProperties": false
                     },
                     "scheme": {
-                      "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service. It defaults to https when Kubernetes Service port is 443, http otherwise.",
+                      "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
                       "type": "string"
                     },
                     "serversTransport": {
-                      "description": "ServersTransport defines the name of ServersTransport resource to use. It allows to configure the transport between Traefik and your servers. Can only be used on a Kubernetes Service.",
+                      "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
                       "type": "string"
                     },
                     "sticky": {
-                      "description": "Sticky defines the sticky sessions configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions",
+                      "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#sticky-sessions",
                       "properties": {
                         "cookie": {
                           "description": "Cookie defines the sticky cookie configuration.",
@@ -139,7 +139,7 @@
                               "type": "string"
                             },
                             "sameSite": {
-                              "description": "SameSite defines the same site policy. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                              "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
                               "type": "string"
                             },
                             "secure": {
@@ -155,11 +155,11 @@
                       "additionalProperties": false
                     },
                     "strategy": {
-                      "description": "Strategy defines the load balancing strategy between the servers. RoundRobin is the only supported value at the moment.",
+                      "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
                       "type": "string"
                     },
                     "weight": {
-                      "description": "Weight defines the weight and should only be specified when Name references a TraefikService object (and to be precise, one that embeds a Weighted Round Robin).",
+                      "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
                       "type": "integer"
                     }
                   },
@@ -182,14 +182,14 @@
           "type": "array"
         },
         "tls": {
-          "description": "TLS defines the TLS configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#tls",
+          "description": "TLS defines the TLS configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls",
           "properties": {
             "certResolver": {
-              "description": "CertResolver defines the name of the certificate resolver to use. Cert resolvers have to be configured in the static configuration. More info: https://doc.traefik.io/traefik/v2.10/https/acme/#certificate-resolvers",
+              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers",
               "type": "string"
             },
             "domains": {
-              "description": "Domains defines the list of domains that will be used to issue certificates. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#domains",
+              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#domains",
               "items": {
                 "description": "Domain holds a domain name with SANs.",
                 "properties": {
@@ -211,14 +211,14 @@
               "type": "array"
             },
             "options": {
-              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection. If not defined, the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options",
+              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options",
               "properties": {
                 "name": {
-                  "description": "Name defines the name of the referenced TLSOption. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsoption",
+                  "description": "Name defines the name of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-tlsoption",
                   "type": "string"
                 },
                 "namespace": {
-                  "description": "Namespace defines the namespace of the referenced TLSOption. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsoption",
+                  "description": "Namespace defines the namespace of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-tlsoption",
                   "type": "string"
                 }
               },
@@ -233,14 +233,14 @@
               "type": "string"
             },
             "store": {
-              "description": "Store defines the reference to the TLSStore, that will be used to store certificates. Please note that only `default` TLSStore can be used.",
+              "description": "Store defines the reference to the TLSStore, that will be used to store certificates.\nPlease note that only `default` TLSStore can be used.",
               "properties": {
                 "name": {
-                  "description": "Name defines the name of the referenced TLSStore. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsstore",
+                  "description": "Name defines the name of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-tlsstore",
                   "type": "string"
                 },
                 "namespace": {
-                  "description": "Namespace defines the namespace of the referenced TLSStore. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-tlsstore",
+                  "description": "Namespace defines the namespace of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-tlsstore",
                   "type": "string"
                 }
               },

--- a/traefik.io/ingressroutetcp_v1alpha1.json
+++ b/traefik.io/ingressroutetcp_v1alpha1.json
@@ -2,11 +2,11 @@
   "description": "IngressRouteTCP is the CRD implementation of a Traefik TCP Router.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "IngressRouteTCPSpec defines the desired state of IngressRouteTCP.",
       "properties": {
         "entryPoints": {
-          "description": "EntryPoints defines the list of entry point names to bind to. Entry points have to be configured in the static configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/ Default: all.",
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/\nDefault: all.",
           "items": {
             "type": "string"
           },
@@ -28,7 +28,7 @@
             "description": "RouteTCP holds the TCP route configuration.",
             "properties": {
               "match": {
-                "description": "Match defines the router's rule. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#rule_1",
+                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#rule_1",
                 "type": "string"
               },
               "middlewares": {
@@ -54,7 +54,7 @@
                 "type": "array"
               },
               "priority": {
-                "description": "Priority defines the router's priority. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#priority_1",
+                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#priority_1",
                 "type": "integer"
               },
               "services": {
@@ -71,7 +71,7 @@
                       "type": "string"
                     },
                     "nativeLB": {
-                      "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+                      "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
                       "type": "boolean"
                     },
                     "port": {
@@ -83,11 +83,11 @@
                           "type": "string"
                         }
                       ],
-                      "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+                      "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
                       "x-kubernetes-int-or-string": true
                     },
                     "proxyProtocol": {
-                      "description": "ProxyProtocol defines the PROXY protocol configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#proxy-protocol",
+                      "description": "ProxyProtocol defines the PROXY protocol configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#proxy-protocol",
                       "properties": {
                         "version": {
                           "description": "Version defines the PROXY Protocol version to use.",
@@ -98,7 +98,7 @@
                       "additionalProperties": false
                     },
                     "terminationDelay": {
-                      "description": "TerminationDelay defines the deadline that the proxy sets, after one of its connected peers indicates it has closed the writing capability of its connection, to close the reading capability as well, hence fully terminating the connection. It is a duration in milliseconds, defaulting to 100. A negative value means an infinite deadline (i.e. the reading capability is never closed).",
+                      "description": "TerminationDelay defines the deadline that the proxy sets, after one of its connected peers indicates\nit has closed the writing capability of its connection, to close the reading capability as well,\nhence fully terminating the connection.\nIt is a duration in milliseconds, defaulting to 100.\nA negative value means an infinite deadline (i.e. the reading capability is never closed).",
                       "type": "integer"
                     },
                     "weight": {
@@ -125,14 +125,14 @@
           "type": "array"
         },
         "tls": {
-          "description": "TLS defines the TLS configuration on a layer 4 / TCP Route. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#tls_1",
+          "description": "TLS defines the TLS configuration on a layer 4 / TCP Route.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#tls_1",
           "properties": {
             "certResolver": {
-              "description": "CertResolver defines the name of the certificate resolver to use. Cert resolvers have to be configured in the static configuration. More info: https://doc.traefik.io/traefik/v2.10/https/acme/#certificate-resolvers",
+              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/https/acme/#certificate-resolvers",
               "type": "string"
             },
             "domains": {
-              "description": "Domains defines the list of domains that will be used to issue certificates. More info: https://doc.traefik.io/traefik/v2.10/routing/routers/#domains",
+              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/routers/#domains",
               "items": {
                 "description": "Domain holds a domain name with SANs.",
                 "properties": {
@@ -154,7 +154,7 @@
               "type": "array"
             },
             "options": {
-              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection. If not defined, the `default` TLSOption is used. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options",
+              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options",
               "properties": {
                 "name": {
                   "description": "Name defines the name of the referenced Traefik resource.",
@@ -180,7 +180,7 @@
               "type": "string"
             },
             "store": {
-              "description": "Store defines the reference to the TLSStore, that will be used to store certificates. Please note that only `default` TLSStore can be used.",
+              "description": "Store defines the reference to the TLSStore, that will be used to store certificates.\nPlease note that only `default` TLSStore can be used.",
               "properties": {
                 "name": {
                   "description": "Name defines the name of the referenced Traefik resource.",

--- a/traefik.io/ingressrouteudp_v1alpha1.json
+++ b/traefik.io/ingressrouteudp_v1alpha1.json
@@ -2,11 +2,11 @@
   "description": "IngressRouteUDP is a CRD implementation of a Traefik UDP Router.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "IngressRouteUDPSpec defines the desired state of a IngressRouteUDP.",
       "properties": {
         "entryPoints": {
-          "description": "EntryPoints defines the list of entry point names to bind to. Entry points have to be configured in the static configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/entrypoints/ Default: all.",
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/entrypoints/\nDefault: all.",
           "items": {
             "type": "string"
           },
@@ -41,7 +41,7 @@
                       "type": "string"
                     },
                     "nativeLB": {
-                      "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+                      "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
                       "type": "boolean"
                     },
                     "port": {
@@ -53,7 +53,7 @@
                           "type": "string"
                         }
                       ],
-                      "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+                      "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
                       "x-kubernetes-int-or-string": true
                     },
                     "weight": {

--- a/traefik.io/middleware_v1alpha1.json
+++ b/traefik.io/middleware_v1alpha1.json
@@ -1,12 +1,12 @@
 {
-  "description": "Middleware is the CRD implementation of a Traefik Middleware. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/overview/",
+  "description": "Middleware is the CRD implementation of a Traefik Middleware.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/overview/",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,10 +16,10 @@
       "description": "MiddlewareSpec defines the desired state of a Middleware.",
       "properties": {
         "addPrefix": {
-          "description": "AddPrefix holds the add prefix middleware configuration. This middleware updates the path of a request before forwarding it. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/addprefix/",
+          "description": "AddPrefix holds the add prefix middleware configuration.\nThis middleware updates the path of a request before forwarding it.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/addprefix/",
           "properties": {
             "prefix": {
-              "description": "Prefix is the string to add before the current path in the requested URL. It should include a leading slash (/).",
+              "description": "Prefix is the string to add before the current path in the requested URL.\nIt should include a leading slash (/).",
               "type": "string"
             }
           },
@@ -27,18 +27,18 @@
           "additionalProperties": false
         },
         "basicAuth": {
-          "description": "BasicAuth holds the basic auth middleware configuration. This middleware restricts access to your services to known users. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/basicauth/",
+          "description": "BasicAuth holds the basic auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/",
           "properties": {
             "headerField": {
-              "description": "HeaderField defines a header field to store the authenticated user. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/basicauth/#headerfield",
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield",
               "type": "string"
             },
             "realm": {
-              "description": "Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme. Default: traefik.",
+              "description": "Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.\nDefault: traefik.",
               "type": "string"
             },
             "removeHeader": {
-              "description": "RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service. Default: false.",
+              "description": "RemoveHeader sets the removeHeader option to true to remove the authorization header before forwarding the request to your service.\nDefault: false.",
               "type": "boolean"
             },
             "secret": {
@@ -50,30 +50,30 @@
           "additionalProperties": false
         },
         "buffering": {
-          "description": "Buffering holds the buffering middleware configuration. This middleware retries or limits the size of requests that can be forwarded to backends. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/buffering/#maxrequestbodybytes",
+          "description": "Buffering holds the buffering middleware configuration.\nThis middleware retries or limits the size of requests that can be forwarded to backends.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#maxrequestbodybytes",
           "properties": {
             "maxRequestBodyBytes": {
-              "description": "MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes). If the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response. Default: 0 (no maximum).",
+              "description": "MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).\nIf the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.\nDefault: 0 (no maximum).",
               "format": "int64",
               "type": "integer"
             },
             "maxResponseBodyBytes": {
-              "description": "MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes). If the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead. Default: 0 (no maximum).",
+              "description": "MaxResponseBodyBytes defines the maximum allowed response size from the service (in bytes).\nIf the response exceeds the allowed size, it is not forwarded to the client. The client gets a 500 (Internal Server Error) response instead.\nDefault: 0 (no maximum).",
               "format": "int64",
               "type": "integer"
             },
             "memRequestBodyBytes": {
-              "description": "MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory. Default: 1048576 (1Mi).",
+              "description": "MemRequestBodyBytes defines the threshold (in bytes) from which the request will be buffered on disk instead of in memory.\nDefault: 1048576 (1Mi).",
               "format": "int64",
               "type": "integer"
             },
             "memResponseBodyBytes": {
-              "description": "MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory. Default: 1048576 (1Mi).",
+              "description": "MemResponseBodyBytes defines the threshold (in bytes) from which the response will be buffered on disk instead of in memory.\nDefault: 1048576 (1Mi).",
               "format": "int64",
               "type": "integer"
             },
             "retryExpression": {
-              "description": "RetryExpression defines the retry conditions. It is a logical combination of functions with operators AND (&&) and OR (||). More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/buffering/#retryexpression",
+              "description": "RetryExpression defines the retry conditions.\nIt is a logical combination of functions with operators AND (&&) and OR (||).\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/buffering/#retryexpression",
               "type": "string"
             }
           },
@@ -81,7 +81,7 @@
           "additionalProperties": false
         },
         "chain": {
-          "description": "Chain holds the configuration of the chain middleware. This middleware enables to define reusable combinations of other pieces of middleware. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/chain/",
+          "description": "Chain holds the configuration of the chain middleware.\nThis middleware enables to define reusable combinations of other pieces of middleware.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/chain/",
           "properties": {
             "middlewares": {
               "description": "Middlewares is the list of MiddlewareRef which composes the chain.",
@@ -157,7 +157,7 @@
           "additionalProperties": false
         },
         "compress": {
-          "description": "Compress holds the compress middleware configuration. This middleware compresses responses before sending them to the client, using gzip compression. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/compress/",
+          "description": "Compress holds the compress middleware configuration.\nThis middleware compresses responses before sending them to the client, using gzip compression.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/compress/",
           "properties": {
             "excludedContentTypes": {
               "description": "ExcludedContentTypes defines the list of content types to compare the Content-Type header of the incoming requests and responses before compressing.",
@@ -167,7 +167,7 @@
               "type": "array"
             },
             "minResponseBodyBytes": {
-              "description": "MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed. Default: 1024.",
+              "description": "MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.\nDefault: 1024.",
               "type": "integer"
             }
           },
@@ -175,10 +175,10 @@
           "additionalProperties": false
         },
         "contentType": {
-          "description": "ContentType holds the content-type middleware configuration. This middleware exists to enable the correct behavior until at least the default one can be changed in a future version.",
+          "description": "ContentType holds the content-type middleware configuration.\nThis middleware exists to enable the correct behavior until at least the default one can be changed in a future version.",
           "properties": {
             "autoDetect": {
-              "description": "AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend, be automatically set to a value derived from the contents of the response. As a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it. However, the historic default was to always auto-detect and set the header if it was nil, and it is going to be kept that way in order to support users currently relying on it.",
+              "description": "AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,\nbe automatically set to a value derived from the contents of the response.\nAs a proxy, the default behavior should be to leave the header alone, regardless of what the backend did with it.\nHowever, the historic default was to always auto-detect and set the header if it was nil,\nand it is going to be kept that way in order to support users currently relying on it.",
               "type": "boolean"
             }
           },
@@ -186,14 +186,14 @@
           "additionalProperties": false
         },
         "digestAuth": {
-          "description": "DigestAuth holds the digest auth middleware configuration. This middleware restricts access to your services to known users. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/digestauth/",
+          "description": "DigestAuth holds the digest auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/digestauth/",
           "properties": {
             "headerField": {
-              "description": "HeaderField defines a header field to store the authenticated user. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/basicauth/#headerfield",
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/basicauth/#headerfield",
               "type": "string"
             },
             "realm": {
-              "description": "Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme. Default: traefik.",
+              "description": "Realm allows the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme.\nDefault: traefik.",
               "type": "string"
             },
             "removeHeader": {
@@ -209,14 +209,14 @@
           "additionalProperties": false
         },
         "errors": {
-          "description": "ErrorPage holds the custom error middleware configuration. This middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/errorpages/",
+          "description": "ErrorPage holds the custom error middleware configuration.\nThis middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/",
           "properties": {
             "query": {
-              "description": "Query defines the URL for the error page (hosted by service). The {status} variable can be used in order to insert the status code in the URL.",
+              "description": "Query defines the URL for the error page (hosted by service).\nThe {status} variable can be used in order to insert the status code in the URL.",
               "type": "string"
             },
             "service": {
-              "description": "Service defines the reference to a Kubernetes Service that will serve the error page. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/errorpages/#service",
+              "description": "Service defines the reference to a Kubernetes Service that will serve the error page.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/errorpages/#service",
               "properties": {
                 "kind": {
                   "description": "Kind defines the kind of the Service.",
@@ -227,7 +227,7 @@
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name defines the name of the referenced Kubernetes Service or TraefikService. The differentiation between the two is specified in the Kind field.",
+                  "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
                   "type": "string"
                 },
                 "namespace": {
@@ -235,11 +235,11 @@
                   "type": "string"
                 },
                 "nativeLB": {
-                  "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+                  "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
                   "type": "boolean"
                 },
                 "passHostHeader": {
-                  "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service. By default, passHostHeader is true.",
+                  "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
                   "type": "boolean"
                 },
                 "port": {
@@ -251,14 +251,14 @@
                       "type": "string"
                     }
                   ],
-                  "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+                  "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
                   "x-kubernetes-int-or-string": true
                 },
                 "responseForwarding": {
                   "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
                   "properties": {
                     "flushInterval": {
-                      "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body. A negative value means to flush immediately after each write to the client. This configuration is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately. Default: 100ms",
+                      "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
                       "type": "string"
                     }
                   },
@@ -266,15 +266,15 @@
                   "additionalProperties": false
                 },
                 "scheme": {
-                  "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service. It defaults to https when Kubernetes Service port is 443, http otherwise.",
+                  "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
                   "type": "string"
                 },
                 "serversTransport": {
-                  "description": "ServersTransport defines the name of ServersTransport resource to use. It allows to configure the transport between Traefik and your servers. Can only be used on a Kubernetes Service.",
+                  "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
                   "type": "string"
                 },
                 "sticky": {
-                  "description": "Sticky defines the sticky sessions configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions",
+                  "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#sticky-sessions",
                   "properties": {
                     "cookie": {
                       "description": "Cookie defines the sticky cookie configuration.",
@@ -288,7 +288,7 @@
                           "type": "string"
                         },
                         "sameSite": {
-                          "description": "SameSite defines the same site policy. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                          "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
                           "type": "string"
                         },
                         "secure": {
@@ -304,11 +304,11 @@
                   "additionalProperties": false
                 },
                 "strategy": {
-                  "description": "Strategy defines the load balancing strategy between the servers. RoundRobin is the only supported value at the moment.",
+                  "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
                   "type": "string"
                 },
                 "weight": {
-                  "description": "Weight defines the weight and should only be specified when Name references a TraefikService object (and to be precise, one that embeds a Weighted Round Robin).",
+                  "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
                   "type": "integer"
                 }
               },
@@ -319,7 +319,7 @@
               "additionalProperties": false
             },
             "status": {
-              "description": "Status defines which status or range of statuses should result in an error page. It can be either a status code as a number (500), as multiple comma-separated numbers (500,502), as ranges by separating two codes with a dash (500-599), or a combination of the two (404,418,500-599).",
+              "description": "Status defines which status or range of statuses should result in an error page.\nIt can be either a status code as a number (500),\nas multiple comma-separated numbers (500,502),\nas ranges by separating two codes with a dash (500-599),\nor a combination of the two (404,418,500-599).",
               "items": {
                 "type": "string"
               },
@@ -330,14 +330,14 @@
           "additionalProperties": false
         },
         "forwardAuth": {
-          "description": "ForwardAuth holds the forward auth middleware configuration. This middleware delegates the request authentication to a Service. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/forwardauth/",
+          "description": "ForwardAuth holds the forward auth middleware configuration.\nThis middleware delegates the request authentication to a Service.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/",
           "properties": {
             "address": {
               "description": "Address defines the authentication server address.",
               "type": "string"
             },
             "authRequestHeaders": {
-              "description": "AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server. If not set or empty then all request headers are passed.",
+              "description": "AuthRequestHeaders defines the list of the headers to copy from the request to the authentication server.\nIf not set or empty then all request headers are passed.",
               "items": {
                 "type": "string"
               },
@@ -351,7 +351,7 @@
               "type": "array"
             },
             "authResponseHeadersRegex": {
-              "description": "AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/forwardauth/#authresponseheadersregex",
+              "description": "AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/forwardauth/#authresponseheadersregex",
               "type": "string"
             },
             "tls": {
@@ -361,11 +361,11 @@
                   "type": "boolean"
                 },
                 "caSecret": {
-                  "description": "CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate. The CA certificate is extracted from key `tls.ca` or `ca.crt`.",
+                  "description": "CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.\nThe CA certificate is extracted from key `tls.ca` or `ca.crt`.",
                   "type": "string"
                 },
                 "certSecret": {
-                  "description": "CertSecret is the name of the referenced Kubernetes Secret containing the client certificate. The client certificate is extracted from the keys `tls.crt` and `tls.key`.",
+                  "description": "CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.\nThe client certificate is extracted from the keys `tls.crt` and `tls.key`.",
                   "type": "string"
                 },
                 "insecureSkipVerify": {
@@ -385,7 +385,7 @@
           "additionalProperties": false
         },
         "headers": {
-          "description": "Headers holds the headers middleware configuration. This middleware manages the requests and responses headers. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/headers/#customrequestheaders",
+          "description": "Headers holds the headers middleware configuration.\nThis middleware manages the requests and responses headers.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/headers/#customrequestheaders",
           "properties": {
             "accessControlAllowCredentials": {
               "description": "AccessControlAllowCredentials defines whether the request can include user credentials.",
@@ -455,11 +455,11 @@
               "type": "boolean"
             },
             "customBrowserXSSValue": {
-              "description": "CustomBrowserXSSValue defines the X-XSS-Protection header value. This overrides the BrowserXssFilter option.",
+              "description": "CustomBrowserXSSValue defines the X-XSS-Protection header value.\nThis overrides the BrowserXssFilter option.",
               "type": "string"
             },
             "customFrameOptionsValue": {
-              "description": "CustomFrameOptionsValue defines the X-Frame-Options header value. This overrides the FrameDeny option.",
+              "description": "CustomFrameOptionsValue defines the X-Frame-Options header value.\nThis overrides the FrameDeny option.",
               "type": "string"
             },
             "customRequestHeaders": {
@@ -496,11 +496,11 @@
               "type": "array"
             },
             "isDevelopment": {
-              "description": "IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing. Usually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain. If you would like your development environment to mimic production with complete Host blocking, SSL redirects, and STS headers, leave this as false.",
+              "description": "IsDevelopment defines whether to mitigate the unwanted effects of the AllowedHosts, SSL, and STS options when developing.\nUsually testing takes place using HTTP, not HTTPS, and on localhost, not your production domain.\nIf you would like your development environment to mimic production with complete Host blocking, SSL redirects,\nand STS headers, leave this as false.",
               "type": "boolean"
             },
             "permissionsPolicy": {
-              "description": "PermissionsPolicy defines the Permissions-Policy header value. This allows sites to control browser features.",
+              "description": "PermissionsPolicy defines the Permissions-Policy header value.\nThis allows sites to control browser features.",
               "type": "string"
             },
             "publicKey": {
@@ -508,7 +508,7 @@
               "type": "string"
             },
             "referrerPolicy": {
-              "description": "ReferrerPolicy defines the Referrer-Policy header value. This allows sites to control whether browsers forward the Referer header to other sites.",
+              "description": "ReferrerPolicy defines the Referrer-Policy header value.\nThis allows sites to control whether browsers forward the Referer header to other sites.",
               "type": "string"
             },
             "sslForceHost": {
@@ -523,7 +523,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request. It can be useful when using other proxies (example: \"X-Forwarded-Proto\": \"https\").",
+              "description": "SSLProxyHeaders defines the header keys with associated values that would indicate a valid HTTPS request.\nIt can be useful when using other proxies (example: \"X-Forwarded-Proto\": \"https\").",
               "type": "object"
             },
             "sslRedirect": {
@@ -543,7 +543,7 @@
               "type": "boolean"
             },
             "stsSeconds": {
-              "description": "STSSeconds defines the max-age of the Strict-Transport-Security header. If set to 0, the header is not set.",
+              "description": "STSSeconds defines the max-age of the Strict-Transport-Security header.\nIf set to 0, the header is not set.",
               "format": "int64",
               "type": "integer"
             }
@@ -552,18 +552,18 @@
           "additionalProperties": false
         },
         "inFlightReq": {
-          "description": "InFlightReq holds the in-flight request middleware configuration. This middleware limits the number of requests being processed and served concurrently. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/inflightreq/",
+          "description": "InFlightReq holds the in-flight request middleware configuration.\nThis middleware limits the number of requests being processed and served concurrently.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/inflightreq/",
           "properties": {
             "amount": {
-              "description": "Amount defines the maximum amount of allowed simultaneous in-flight request. The middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).",
+              "description": "Amount defines the maximum amount of allowed simultaneous in-flight request.\nThe middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).",
               "format": "int64",
               "type": "integer"
             },
             "sourceCriterion": {
-              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source. If several strategies are defined at the same time, an error will be raised. If none are set, the default is to use the requestHost. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/inflightreq/#sourcecriterion",
+              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the requestHost.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/inflightreq/#sourcecriterion",
               "properties": {
                 "ipStrategy": {
-                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/#ipstrategy",
+                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipallowlist/#ipstrategy",
                   "properties": {
                     "depth": {
                       "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
@@ -596,11 +596,43 @@
           "type": "object",
           "additionalProperties": false
         },
-        "ipWhiteList": {
-          "description": "IPWhiteList holds the IP whitelist middleware configuration. This middleware accepts / refuses requests based on the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/",
+        "ipAllowList": {
+          "description": "IPAllowList holds the IP allowlist middleware configuration.\nThis middleware accepts / refuses requests based on the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipallowlist/",
           "properties": {
             "ipStrategy": {
-              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/#ipstrategy",
+              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipallowlist/#ipstrategy",
+              "properties": {
+                "depth": {
+                  "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                  "type": "integer"
+                },
+                "excludedIPs": {
+                  "description": "ExcludedIPs configures Traefik to scan the X-Forwarded-For header and select the first IP not in the list.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sourceRange": {
+              "description": "SourceRange defines the set of allowed IPs (or ranges of allowed IPs by using CIDR notation).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ipWhiteList": {
+          "description": "IPWhiteList holds the IP whitelist middleware configuration.\nThis middleware accepts / refuses requests based on the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipwhitelist/\nDeprecated: please use IPAllowList instead.",
+          "properties": {
+            "ipStrategy": {
+              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipallowlist/#ipstrategy",
               "properties": {
                 "depth": {
                   "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
@@ -629,7 +661,7 @@
           "additionalProperties": false
         },
         "passTLSClientCert": {
-          "description": "PassTLSClientCert holds the pass TLS client cert middleware configuration. This middleware adds the selected data from the passed client TLS certificate to a header. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/passtlsclientcert/",
+          "description": "PassTLSClientCert holds the pass TLS client cert middleware configuration.\nThis middleware adds the selected data from the passed client TLS certificate to a header.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/passtlsclientcert/",
           "properties": {
             "info": {
               "description": "Info selects the specific client certificate details you want to add to the X-Forwarded-Tls-Client-Cert-Info header.",
@@ -740,19 +772,19 @@
           "additionalProperties": {
             "x-kubernetes-preserve-unknown-fields": true
           },
-          "description": "Plugin defines the middleware plugin configuration. More info: https://doc.traefik.io/traefik/plugins/",
+          "description": "Plugin defines the middleware plugin configuration.\nMore info: https://doc.traefik.io/traefik/plugins/",
           "type": "object"
         },
         "rateLimit": {
-          "description": "RateLimit holds the rate limit configuration. This middleware ensures that services will receive a fair amount of requests, and allows one to define what fair is. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ratelimit/",
+          "description": "RateLimit holds the rate limit configuration.\nThis middleware ensures that services will receive a fair amount of requests, and allows one to define what fair is.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ratelimit/",
           "properties": {
             "average": {
-              "description": "Average is the maximum rate, by default in requests/s, allowed for the given source. It defaults to 0, which means no rate limiting. The rate is actually defined by dividing Average by Period. So for a rate below 1req/s, one needs to define a Period larger than a second.",
+              "description": "Average is the maximum rate, by default in requests/s, allowed for the given source.\nIt defaults to 0, which means no rate limiting.\nThe rate is actually defined by dividing Average by Period. So for a rate below 1req/s,\none needs to define a Period larger than a second.",
               "format": "int64",
               "type": "integer"
             },
             "burst": {
-              "description": "Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time. It defaults to 1.",
+              "description": "Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.\nIt defaults to 1.",
               "format": "int64",
               "type": "integer"
             },
@@ -765,14 +797,14 @@
                   "type": "string"
                 }
               ],
-              "description": "Period, in combination with Average, defines the actual maximum rate, such as: r = Average / Period. It defaults to a second.",
+              "description": "Period, in combination with Average, defines the actual maximum rate, such as:\nr = Average / Period. It defaults to a second.",
               "x-kubernetes-int-or-string": true
             },
             "sourceCriterion": {
-              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source. If several strategies are defined at the same time, an error will be raised. If none are set, the default is to use the request's remote address field (as an ipStrategy).",
+              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the request's remote address field (as an ipStrategy).",
               "properties": {
                 "ipStrategy": {
-                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/ipwhitelist/#ipstrategy",
+                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/ipallowlist/#ipstrategy",
                   "properties": {
                     "depth": {
                       "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
@@ -806,7 +838,7 @@
           "additionalProperties": false
         },
         "redirectRegex": {
-          "description": "RedirectRegex holds the redirect regex middleware configuration. This middleware redirects a request using regex matching and replacement. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/redirectregex/#regex",
+          "description": "RedirectRegex holds the redirect regex middleware configuration.\nThis middleware redirects a request using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectregex/#regex",
           "properties": {
             "permanent": {
               "description": "Permanent defines whether the redirection is permanent (301).",
@@ -825,7 +857,7 @@
           "additionalProperties": false
         },
         "redirectScheme": {
-          "description": "RedirectScheme holds the redirect scheme middleware configuration. This middleware redirects requests from a scheme/port to another. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/redirectscheme/",
+          "description": "RedirectScheme holds the redirect scheme middleware configuration.\nThis middleware redirects requests from a scheme/port to another.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/redirectscheme/",
           "properties": {
             "permanent": {
               "description": "Permanent defines whether the redirection is permanent (301).",
@@ -844,7 +876,7 @@
           "additionalProperties": false
         },
         "replacePath": {
-          "description": "ReplacePath holds the replace path middleware configuration. This middleware replaces the path of the request URL and store the original path in an X-Replaced-Path header. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/replacepath/",
+          "description": "ReplacePath holds the replace path middleware configuration.\nThis middleware replaces the path of the request URL and store the original path in an X-Replaced-Path header.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/replacepath/",
           "properties": {
             "path": {
               "description": "Path defines the path to use as replacement in the request URL.",
@@ -855,7 +887,7 @@
           "additionalProperties": false
         },
         "replacePathRegex": {
-          "description": "ReplacePathRegex holds the replace path regex middleware configuration. This middleware replaces the path of a URL using regex matching and replacement. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/replacepathregex/",
+          "description": "ReplacePathRegex holds the replace path regex middleware configuration.\nThis middleware replaces the path of a URL using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/replacepathregex/",
           "properties": {
             "regex": {
               "description": "Regex defines the regular expression used to match and capture the path from the request URL.",
@@ -870,7 +902,7 @@
           "additionalProperties": false
         },
         "retry": {
-          "description": "Retry holds the retry middleware configuration. This middleware reissues requests a given number of times to a backend server if that server does not reply. As soon as the server answers, the middleware stops retrying, regardless of the response status. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/retry/",
+          "description": "Retry holds the retry middleware configuration.\nThis middleware reissues requests a given number of times to a backend server if that server does not reply.\nAs soon as the server answers, the middleware stops retrying, regardless of the response status.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/retry/",
           "properties": {
             "attempts": {
               "description": "Attempts defines how many times the request should be retried.",
@@ -885,7 +917,7 @@
                   "type": "string"
                 }
               ],
-              "description": "InitialInterval defines the first wait time in the exponential backoff series. The maximum interval is calculated as twice the initialInterval. If unspecified, requests will be retried immediately. The value of initialInterval should be provided in seconds or as a valid duration format, see https://pkg.go.dev/time#ParseDuration.",
+              "description": "InitialInterval defines the first wait time in the exponential backoff series.\nThe maximum interval is calculated as twice the initialInterval.\nIf unspecified, requests will be retried immediately.\nThe value of initialInterval should be provided in seconds or as a valid duration format,\nsee https://pkg.go.dev/time#ParseDuration.",
               "x-kubernetes-int-or-string": true
             }
           },
@@ -893,10 +925,10 @@
           "additionalProperties": false
         },
         "stripPrefix": {
-          "description": "StripPrefix holds the strip prefix middleware configuration. This middleware removes the specified prefixes from the URL path. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/stripprefix/",
+          "description": "StripPrefix holds the strip prefix middleware configuration.\nThis middleware removes the specified prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefix/",
           "properties": {
             "forceSlash": {
-              "description": "ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary. Default: true.",
+              "description": "ForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.\nDefault: true.",
               "type": "boolean"
             },
             "prefixes": {
@@ -911,7 +943,7 @@
           "additionalProperties": false
         },
         "stripPrefixRegex": {
-          "description": "StripPrefixRegex holds the strip prefix regex middleware configuration. This middleware removes the matching prefixes from the URL path. More info: https://doc.traefik.io/traefik/v2.10/middlewares/http/stripprefixregex/",
+          "description": "StripPrefixRegex holds the strip prefix regex middleware configuration.\nThis middleware removes the matching prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/http/stripprefixregex/",
           "properties": {
             "regex": {
               "description": "Regex defines the regular expression to match the path prefix from the request URL.",

--- a/traefik.io/middlewaretcp_v1alpha1.json
+++ b/traefik.io/middlewaretcp_v1alpha1.json
@@ -1,12 +1,12 @@
 {
-  "description": "MiddlewareTCP is the CRD implementation of a Traefik TCP middleware. More info: https://doc.traefik.io/traefik/v2.10/middlewares/overview/",
+  "description": "MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/overview/",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "description": "InFlightConn defines the InFlightConn middleware configuration.",
           "properties": {
             "amount": {
-              "description": "Amount defines the maximum amount of allowed simultaneous connections. The middleware closes the connection if there are already amount connections opened.",
+              "description": "Amount defines the maximum amount of allowed simultaneous connections.\nThe middleware closes the connection if there are already amount connections opened.",
               "format": "int64",
               "type": "integer"
             }
@@ -27,8 +27,22 @@
           "type": "object",
           "additionalProperties": false
         },
+        "ipAllowList": {
+          "description": "IPAllowList defines the IPAllowList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/tcp/ipallowlist/",
+          "properties": {
+            "sourceRange": {
+              "description": "SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "ipWhiteList": {
-          "description": "IPWhiteList defines the IPWhiteList middleware configuration.",
+          "description": "IPWhiteList defines the IPWhiteList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nDeprecated: please use IPAllowList instead.\nMore info: https://doc.traefik.io/traefik/v2.11/middlewares/tcp/ipwhitelist/",
           "properties": {
             "sourceRange": {
               "description": "SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).",

--- a/traefik.io/serverstransport_v1alpha1.json
+++ b/traefik.io/serverstransport_v1alpha1.json
@@ -1,12 +1,12 @@
 {
-  "description": "ServersTransport is the CRD implementation of a ServersTransport. If no serversTransport is specified, the default@internal will be used. The default@internal serversTransport is created from the static configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#serverstransport_1",
+  "description": "ServersTransport is the CRD implementation of a ServersTransport.\nIf no serversTransport is specified, the default@internal will be used.\nThe default@internal serversTransport is created from the static configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#serverstransport_1",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {

--- a/traefik.io/serverstransporttcp_v1alpha1.json
+++ b/traefik.io/serverstransporttcp_v1alpha1.json
@@ -1,0 +1,115 @@
+{
+  "description": "ServersTransportTCP is the CRD implementation of a TCPServersTransport.\nIf no tcpServersTransport is specified, a default one named default@internal will be used.\nThe default@internal tcpServersTransport can be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.0/routing/services/#serverstransport_3",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ServersTransportTCPSpec defines the desired state of a ServersTransportTCP.",
+      "properties": {
+        "dialKeepAlive": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "DialKeepAlive is the interval between keep-alive probes for an active network connection. If zero, keep-alive probes are sent with a default value (currently 15 seconds), if supported by the protocol and operating system. Network protocols or operating systems that do not support keep-alives ignore this field. If negative, keep-alive probes are disabled.",
+          "x-kubernetes-int-or-string": true
+        },
+        "dialTimeout": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "DialTimeout is the amount of time to wait until a connection to a backend server can be established.",
+          "x-kubernetes-int-or-string": true
+        },
+        "terminationDelay": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "TerminationDelay defines the delay to wait before fully terminating the connection, after one connected peer has closed its writing capability.",
+          "x-kubernetes-int-or-string": true
+        },
+        "tls": {
+          "description": "TLS defines the TLS configuration",
+          "properties": {
+            "certificatesSecrets": {
+              "description": "CertificatesSecrets defines a list of secret storing client certificates for mTLS.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "insecureSkipVerify": {
+              "description": "InsecureSkipVerify disables TLS certificate verification.",
+              "type": "boolean"
+            },
+            "peerCertURI": {
+              "description": "MaxIdleConnsPerHost controls the maximum idle (keep-alive) to keep per-host.\nPeerCertURI defines the peer cert URI used to match against SAN URI during the peer certificate verification.",
+              "type": "string"
+            },
+            "rootCAsSecrets": {
+              "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificates.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "serverName": {
+              "description": "ServerName defines the server name used to contact the server.",
+              "type": "string"
+            },
+            "spiffe": {
+              "description": "Spiffe defines the SPIFFE configuration.",
+              "properties": {
+                "ids": {
+                  "description": "IDs defines the allowed SPIFFE IDs (takes precedence over the SPIFFE TrustDomain).",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "trustDomain": {
+                  "description": "TrustDomain defines the allowed SPIFFE trust domain.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object"
+}

--- a/traefik.io/tlsoption_v1alpha1.json
+++ b/traefik.io/tlsoption_v1alpha1.json
@@ -1,12 +1,12 @@
 {
-  "description": "TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#tls-options",
+  "description": "TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#tls-options",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,14 +16,14 @@
       "description": "TLSOptionSpec defines the desired state of a TLSOption.",
       "properties": {
         "alpnProtocols": {
-          "description": "ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#alpn-protocols",
+          "description": "ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#alpn-protocols",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "cipherSuites": {
-          "description": "CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#cipher-suites",
+          "description": "CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#cipher-suites",
           "items": {
             "type": "string"
           },
@@ -55,22 +55,22 @@
           "additionalProperties": false
         },
         "curvePreferences": {
-          "description": "CurvePreferences defines the preferred elliptic curves in a specific order. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#curve-preferences",
+          "description": "CurvePreferences defines the preferred elliptic curves in a specific order.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#curve-preferences",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "maxVersion": {
-          "description": "MaxVersion defines the maximum TLS version that Traefik will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. Default: None.",
+          "description": "MaxVersion defines the maximum TLS version that Traefik will accept.\nPossible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\nDefault: None.",
           "type": "string"
         },
         "minVersion": {
-          "description": "MinVersion defines the minimum TLS version that Traefik will accept. Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. Default: VersionTLS10.",
+          "description": "MinVersion defines the minimum TLS version that Traefik will accept.\nPossible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\nDefault: VersionTLS10.",
           "type": "string"
         },
         "preferServerCipherSuites": {
-          "description": "PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's. It is enabled automatically when minVersion or maxVersion is set. Deprecated: https://github.com/golang/go/issues/45430",
+          "description": "PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.\nIt is enabled automatically when minVersion or maxVersion is set.\nDeprecated: https://github.com/golang/go/issues/45430",
           "type": "boolean"
         },
         "sniStrict": {

--- a/traefik.io/tlsstore_v1alpha1.json
+++ b/traefik.io/tlsstore_v1alpha1.json
@@ -1,12 +1,12 @@
 {
-  "description": "TLSStore is the CRD implementation of a Traefik TLS Store. For the time being, only the TLSStore named default is supported. This means that you cannot have two stores that are named default in different Kubernetes namespaces. More info: https://doc.traefik.io/traefik/v2.10/https/tls/#certificates-stores",
+  "description": "TLSStore is the CRD implementation of a Traefik TLS Store.\nFor the time being, only the TLSStore named default is supported.\nThis means that you cannot have two stores that are named default in different Kubernetes namespaces.\nMore info: https://doc.traefik.io/traefik/v2.11/https/tls/#certificates-stores",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {

--- a/traefik.io/traefikservice_v1alpha1.json
+++ b/traefik.io/traefikservice_v1alpha1.json
@@ -1,12 +1,12 @@
 {
-  "description": "TraefikService is the CRD implementation of a Traefik Service. TraefikService object allows to: - Apply weight to Services on load-balancing - Mirror traffic on services More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#kind-traefikservice",
+  "description": "TraefikService is the CRD implementation of a Traefik Service.\nTraefikService object allows to:\n- Apply weight to Services on load-balancing\n- Mirror traffic on services\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#kind-traefikservice",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -27,7 +27,7 @@
               "type": "string"
             },
             "maxBodySize": {
-              "description": "MaxBodySize defines the maximum size allowed for the body of the request. If the body is larger, the request is not mirrored. Default value is -1, which means unlimited size.",
+              "description": "MaxBodySize defines the maximum size allowed for the body of the request.\nIf the body is larger, the request is not mirrored.\nDefault value is -1, which means unlimited size.",
               "format": "int64",
               "type": "integer"
             },
@@ -45,7 +45,7 @@
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService. The differentiation between the two is specified in the Kind field.",
+                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
                     "type": "string"
                   },
                   "namespace": {
@@ -53,15 +53,15 @@
                     "type": "string"
                   },
                   "nativeLB": {
-                    "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+                    "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
                     "type": "boolean"
                   },
                   "passHostHeader": {
-                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service. By default, passHostHeader is true.",
+                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
                     "type": "boolean"
                   },
                   "percent": {
-                    "description": "Percent defines the part of the traffic to mirror. Supported values: 0 to 100.",
+                    "description": "Percent defines the part of the traffic to mirror.\nSupported values: 0 to 100.",
                     "type": "integer"
                   },
                   "port": {
@@ -73,14 +73,14 @@
                         "type": "string"
                       }
                     ],
-                    "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+                    "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
                     "x-kubernetes-int-or-string": true
                   },
                   "responseForwarding": {
                     "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
                     "properties": {
                       "flushInterval": {
-                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body. A negative value means to flush immediately after each write to the client. This configuration is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately. Default: 100ms",
+                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
                         "type": "string"
                       }
                     },
@@ -88,15 +88,15 @@
                     "additionalProperties": false
                   },
                   "scheme": {
-                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service. It defaults to https when Kubernetes Service port is 443, http otherwise.",
+                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
                     "type": "string"
                   },
                   "serversTransport": {
-                    "description": "ServersTransport defines the name of ServersTransport resource to use. It allows to configure the transport between Traefik and your servers. Can only be used on a Kubernetes Service.",
+                    "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
                     "type": "string"
                   },
                   "sticky": {
-                    "description": "Sticky defines the sticky sessions configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions",
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#sticky-sessions",
                     "properties": {
                       "cookie": {
                         "description": "Cookie defines the sticky cookie configuration.",
@@ -110,7 +110,7 @@
                             "type": "string"
                           },
                           "sameSite": {
-                            "description": "SameSite defines the same site policy. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
                             "type": "string"
                           },
                           "secure": {
@@ -126,11 +126,11 @@
                     "additionalProperties": false
                   },
                   "strategy": {
-                    "description": "Strategy defines the load balancing strategy between the servers. RoundRobin is the only supported value at the moment.",
+                    "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
                     "type": "string"
                   },
                   "weight": {
-                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object (and to be precise, one that embeds a Weighted Round Robin).",
+                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
                     "type": "integer"
                   }
                 },
@@ -143,7 +143,7 @@
               "type": "array"
             },
             "name": {
-              "description": "Name defines the name of the referenced Kubernetes Service or TraefikService. The differentiation between the two is specified in the Kind field.",
+              "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
               "type": "string"
             },
             "namespace": {
@@ -151,11 +151,11 @@
               "type": "string"
             },
             "nativeLB": {
-              "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+              "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
               "type": "boolean"
             },
             "passHostHeader": {
-              "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service. By default, passHostHeader is true.",
+              "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
               "type": "boolean"
             },
             "port": {
@@ -167,14 +167,14 @@
                   "type": "string"
                 }
               ],
-              "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+              "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
               "x-kubernetes-int-or-string": true
             },
             "responseForwarding": {
               "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
               "properties": {
                 "flushInterval": {
-                  "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body. A negative value means to flush immediately after each write to the client. This configuration is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately. Default: 100ms",
+                  "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
                   "type": "string"
                 }
               },
@@ -182,15 +182,15 @@
               "additionalProperties": false
             },
             "scheme": {
-              "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service. It defaults to https when Kubernetes Service port is 443, http otherwise.",
+              "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
               "type": "string"
             },
             "serversTransport": {
-              "description": "ServersTransport defines the name of ServersTransport resource to use. It allows to configure the transport between Traefik and your servers. Can only be used on a Kubernetes Service.",
+              "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
               "type": "string"
             },
             "sticky": {
-              "description": "Sticky defines the sticky sessions configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions",
+              "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#sticky-sessions",
               "properties": {
                 "cookie": {
                   "description": "Cookie defines the sticky cookie configuration.",
@@ -204,7 +204,7 @@
                       "type": "string"
                     },
                     "sameSite": {
-                      "description": "SameSite defines the same site policy. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                      "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
                       "type": "string"
                     },
                     "secure": {
@@ -220,11 +220,11 @@
               "additionalProperties": false
             },
             "strategy": {
-              "description": "Strategy defines the load balancing strategy between the servers. RoundRobin is the only supported value at the moment.",
+              "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
               "type": "string"
             },
             "weight": {
-              "description": "Weight defines the weight and should only be specified when Name references a TraefikService object (and to be precise, one that embeds a Weighted Round Robin).",
+              "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
               "type": "integer"
             }
           },
@@ -251,7 +251,7 @@
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService. The differentiation between the two is specified in the Kind field.",
+                    "description": "Name defines the name of the referenced Kubernetes Service or TraefikService.\nThe differentiation between the two is specified in the Kind field.",
                     "type": "string"
                   },
                   "namespace": {
@@ -259,11 +259,11 @@
                     "type": "string"
                   },
                   "nativeLB": {
-                    "description": "NativeLB controls, when creating the load-balancer, whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP. The Kubernetes Service itself does load-balance to the pods. By default, NativeLB is false.",
+                    "description": "NativeLB controls, when creating the load-balancer,\nwhether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.\nThe Kubernetes Service itself does load-balance to the pods.\nBy default, NativeLB is false.",
                     "type": "boolean"
                   },
                   "passHostHeader": {
-                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service. By default, passHostHeader is true.",
+                    "description": "PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.\nBy default, passHostHeader is true.",
                     "type": "boolean"
                   },
                   "port": {
@@ -275,14 +275,14 @@
                         "type": "string"
                       }
                     ],
-                    "description": "Port defines the port of a Kubernetes Service. This can be a reference to a named port.",
+                    "description": "Port defines the port of a Kubernetes Service.\nThis can be a reference to a named port.",
                     "x-kubernetes-int-or-string": true
                   },
                   "responseForwarding": {
                     "description": "ResponseForwarding defines how Traefik forwards the response from the upstream Kubernetes Service to the client.",
                     "properties": {
                       "flushInterval": {
-                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body. A negative value means to flush immediately after each write to the client. This configuration is ignored when ReverseProxy recognizes a response as a streaming response; for such responses, writes are flushed to the client immediately. Default: 100ms",
+                        "description": "FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.\nA negative value means to flush immediately after each write to the client.\nThis configuration is ignored when ReverseProxy recognizes a response as a streaming response;\nfor such responses, writes are flushed to the client immediately.\nDefault: 100ms",
                         "type": "string"
                       }
                     },
@@ -290,15 +290,15 @@
                     "additionalProperties": false
                   },
                   "scheme": {
-                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service. It defaults to https when Kubernetes Service port is 443, http otherwise.",
+                    "description": "Scheme defines the scheme to use for the request to the upstream Kubernetes Service.\nIt defaults to https when Kubernetes Service port is 443, http otherwise.",
                     "type": "string"
                   },
                   "serversTransport": {
-                    "description": "ServersTransport defines the name of ServersTransport resource to use. It allows to configure the transport between Traefik and your servers. Can only be used on a Kubernetes Service.",
+                    "description": "ServersTransport defines the name of ServersTransport resource to use.\nIt allows to configure the transport between Traefik and your servers.\nCan only be used on a Kubernetes Service.",
                     "type": "string"
                   },
                   "sticky": {
-                    "description": "Sticky defines the sticky sessions configuration. More info: https://doc.traefik.io/traefik/v2.10/routing/services/#sticky-sessions",
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/services/#sticky-sessions",
                     "properties": {
                       "cookie": {
                         "description": "Cookie defines the sticky cookie configuration.",
@@ -312,7 +312,7 @@
                             "type": "string"
                           },
                           "sameSite": {
-                            "description": "SameSite defines the same site policy. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
                             "type": "string"
                           },
                           "secure": {
@@ -328,11 +328,11 @@
                     "additionalProperties": false
                   },
                   "strategy": {
-                    "description": "Strategy defines the load balancing strategy between the servers. RoundRobin is the only supported value at the moment.",
+                    "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
                     "type": "string"
                   },
                   "weight": {
-                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object (and to be precise, one that embeds a Weighted Round Robin).",
+                    "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
                     "type": "integer"
                   }
                 },
@@ -345,7 +345,7 @@
               "type": "array"
             },
             "sticky": {
-              "description": "Sticky defines whether sticky sessions are enabled. More info: https://doc.traefik.io/traefik/v2.10/routing/providers/kubernetes-crd/#stickiness-and-load-balancing",
+              "description": "Sticky defines whether sticky sessions are enabled.\nMore info: https://doc.traefik.io/traefik/v2.11/routing/providers/kubernetes-crd/#stickiness-and-load-balancing",
               "properties": {
                 "cookie": {
                   "description": "Cookie defines the sticky cookie configuration.",
@@ -359,7 +359,7 @@
                       "type": "string"
                     },
                     "sameSite": {
-                      "description": "SameSite defines the same site policy. More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                      "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
                       "type": "string"
                     },
                     "secure": {


### PR DESCRIPTION
Current Traefik CRDs are outdated and don't support the new `ipAllowList` Middleware type.