### PR TITLE
Update argo-rollouts to v1.6.6

### DIFF
--- a/argoproj.io/analysisrun_v1alpha1.json
+++ b/argoproj.io/analysisrun_v1alpha1.json
@@ -255,6 +255,9 @@
                   },
                   "datadog": {
                     "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
                       "interval": {
                         "type": "string"
                       },
@@ -271,6 +274,18 @@
                   "graphite": {
                     "properties": {
                       "address": {
+                        "type": "string"
+                      },
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "influxdb": {
+                    "properties": {
+                      "profile": {
                         "type": "string"
                       },
                       "query": {
@@ -324,6 +339,76 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "podFailurePolicy": {
+                            "properties": {
+                              "rules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "onExitCodes": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "required": [
+                                        "operator",
+                                        "values"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "onPodConditions": {
+                                      "items": {
+                                        "properties": {
+                                          "status": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "status",
+                                          "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "action",
+                                    "onPodConditions"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "rules"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "selector": {
                             "properties": {
                               "matchExpressions": {
@@ -359,6 +444,7 @@
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "suspend": {
@@ -451,6 +537,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
@@ -524,6 +611,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "type": "array"
@@ -533,6 +621,7 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           }
                                         },
@@ -581,6 +670,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
@@ -618,6 +708,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
@@ -688,6 +779,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
@@ -725,6 +817,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
@@ -791,6 +884,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
@@ -828,6 +922,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
@@ -898,6 +993,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
@@ -935,6 +1031,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
@@ -1008,6 +1105,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -1023,6 +1121,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -1050,6 +1149,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -1068,6 +1168,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -1096,6 +1197,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -1111,6 +1213,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -2002,6 +2105,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -2017,6 +2121,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -2044,6 +2149,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -2062,6 +2168,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -2090,6 +2197,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -2105,6 +2213,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -2945,6 +3054,9 @@
                                   "hostPID": {
                                     "type": "boolean"
                                   },
+                                  "hostUsers": {
+                                    "type": "boolean"
+                                  },
                                   "hostname": {
                                     "type": "string"
                                   },
@@ -2956,6 +3068,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "type": "array"
@@ -3002,6 +3115,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -3017,6 +3131,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -3044,6 +3159,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -3062,6 +3178,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -3090,6 +3207,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -3105,6 +3223,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -4169,11 +4288,29 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
+                                        },
+                                        "matchLabelKeys": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "maxSkew": {
                                           "format": "int32",
                                           "type": "integer"
+                                        },
+                                        "minDomains": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "nodeAffinityPolicy": {
+                                          "type": "string"
+                                        },
+                                        "nodeTaintsPolicy": {
+                                          "type": "string"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -4371,9 +4508,75 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "plugin": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "prometheus": {
                     "properties": {
                       "address": {
+                        "type": "string"
+                      },
+                      "authentication": {
+                        "properties": {
+                          "sigv4": {
+                            "properties": {
+                              "profile": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleArn": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headers": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "skywalking": {
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "interval": {
                         "type": "string"
                       },
                       "query": {
@@ -4421,6 +4624,10 @@
                       },
                       "insecure": {
                         "type": "boolean"
+                      },
+                      "jsonBody": {
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "jsonPath": {
                         "type": "string"

--- a/argoproj.io/analysistemplate_v1alpha1.json
+++ b/argoproj.io/analysistemplate_v1alpha1.json
@@ -255,6 +255,9 @@
                   },
                   "datadog": {
                     "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
                       "interval": {
                         "type": "string"
                       },
@@ -271,6 +274,18 @@
                   "graphite": {
                     "properties": {
                       "address": {
+                        "type": "string"
+                      },
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "influxdb": {
+                    "properties": {
+                      "profile": {
                         "type": "string"
                       },
                       "query": {
@@ -324,6 +339,76 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "podFailurePolicy": {
+                            "properties": {
+                              "rules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "onExitCodes": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "required": [
+                                        "operator",
+                                        "values"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "onPodConditions": {
+                                      "items": {
+                                        "properties": {
+                                          "status": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "status",
+                                          "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "action",
+                                    "onPodConditions"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "rules"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "selector": {
                             "properties": {
                               "matchExpressions": {
@@ -359,6 +444,7 @@
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "suspend": {
@@ -451,6 +537,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
@@ -524,6 +611,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "type": "array"
@@ -533,6 +621,7 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           }
                                         },
@@ -581,6 +670,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
@@ -618,6 +708,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
@@ -688,6 +779,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
@@ -725,6 +817,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
@@ -791,6 +884,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
@@ -828,6 +922,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
@@ -898,6 +993,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
@@ -935,6 +1031,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
@@ -1008,6 +1105,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -1023,6 +1121,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -1050,6 +1149,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -1068,6 +1168,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -1096,6 +1197,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -1111,6 +1213,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -2002,6 +2105,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -2017,6 +2121,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -2044,6 +2149,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -2062,6 +2168,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -2090,6 +2197,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -2105,6 +2213,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -2945,6 +3054,9 @@
                                   "hostPID": {
                                     "type": "boolean"
                                   },
+                                  "hostUsers": {
+                                    "type": "boolean"
+                                  },
                                   "hostname": {
                                     "type": "string"
                                   },
@@ -2956,6 +3068,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "type": "array"
@@ -3002,6 +3115,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -3017,6 +3131,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -3044,6 +3159,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -3062,6 +3178,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -3090,6 +3207,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -3105,6 +3223,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -4169,11 +4288,29 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
+                                        },
+                                        "matchLabelKeys": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "maxSkew": {
                                           "format": "int32",
                                           "type": "integer"
+                                        },
+                                        "minDomains": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "nodeAffinityPolicy": {
+                                          "type": "string"
+                                        },
+                                        "nodeTaintsPolicy": {
+                                          "type": "string"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -4371,9 +4508,75 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "plugin": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "prometheus": {
                     "properties": {
                       "address": {
+                        "type": "string"
+                      },
+                      "authentication": {
+                        "properties": {
+                          "sigv4": {
+                            "properties": {
+                              "profile": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleArn": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headers": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "skywalking": {
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "interval": {
                         "type": "string"
                       },
                       "query": {
@@ -4421,6 +4624,10 @@
                       },
                       "insecure": {
                         "type": "boolean"
+                      },
+                      "jsonBody": {
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "jsonPath": {
                         "type": "string"

--- a/argoproj.io/clusteranalysistemplate_v1alpha1.json
+++ b/argoproj.io/clusteranalysistemplate_v1alpha1.json
@@ -256,30 +256,18 @@
                   "datadog": {
                     "properties": {
                       "apiVersion": {
-                        "default": "v1",
-                        "enum": [
-                          "v1",
-                          "v2"
-                        ],
-                        "type": "string"
-                      },
-                      "formula": {
                         "type": "string"
                       },
                       "interval": {
-                        "default": "5m",
                         "type": "string"
-                      },
-                      "queries": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
                       },
                       "query": {
                         "type": "string"
                       }
                     },
+                    "required": [
+                      "query"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4531,27 +4519,6 @@
                       },
                       "authentication": {
                         "properties": {
-                          "oauth2": {
-                            "properties": {
-                              "clientId": {
-                                "type": "string"
-                              },
-                              "clientSecret": {
-                                "type": "string"
-                              },
-                              "scopes": {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              "tokenUrl": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
                           "sigv4": {
                             "properties": {
                               "profile": {
@@ -4633,48 +4600,6 @@
                   },
                   "web": {
                     "properties": {
-                      "authentication": {
-                        "properties": {
-                          "oauth2": {
-                            "properties": {
-                              "clientId": {
-                                "type": "string"
-                              },
-                              "clientSecret": {
-                                "type": "string"
-                              },
-                              "scopes": {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              "tokenUrl": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "sigv4": {
-                            "properties": {
-                              "profile": {
-                                "type": "string"
-                              },
-                              "region": {
-                                "type": "string"
-                              },
-                              "roleArn": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
                       "body": {
                         "type": "string"
                       },

--- a/argoproj.io/experiment_v1alpha1.json
+++ b/argoproj.io/experiment_v1alpha1.json
@@ -183,10 +183,17 @@
                   }
                 },
                 "type": "object",
+                "x-kubernetes-map-type": "atomic",
                 "additionalProperties": false
               },
               "service": {
-                "type": "object"
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               },
               "template": {
                 "properties": {
@@ -275,6 +282,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "weight": {
@@ -348,6 +356,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "type": "array"
@@ -357,6 +366,7 @@
                                   "nodeSelectorTerms"
                                 ],
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               }
                             },
@@ -405,6 +415,7 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
                                         },
                                         "namespaceSelector": {
@@ -442,6 +453,7 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
                                         },
                                         "namespaces": {
@@ -512,6 +524,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "namespaceSelector": {
@@ -549,6 +562,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "namespaces": {
@@ -615,6 +629,7 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
                                         },
                                         "namespaceSelector": {
@@ -652,6 +667,7 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
                                         },
                                         "namespaces": {
@@ -722,6 +738,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "namespaceSelector": {
@@ -759,6 +776,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "namespaces": {
@@ -832,6 +850,7 @@
                                           "key"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "fieldRef": {
@@ -847,6 +866,7 @@
                                           "fieldPath"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "resourceFieldRef": {
@@ -874,6 +894,7 @@
                                           "resource"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "secretKeyRef": {
@@ -892,6 +913,7 @@
                                           "key"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
@@ -920,6 +942,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "prefix": {
@@ -935,6 +958,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   }
                                 },
@@ -1826,6 +1850,7 @@
                                           "key"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "fieldRef": {
@@ -1841,6 +1866,7 @@
                                           "fieldPath"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "resourceFieldRef": {
@@ -1868,6 +1894,7 @@
                                           "resource"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "secretKeyRef": {
@@ -1886,6 +1913,7 @@
                                           "key"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
@@ -1914,6 +1942,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "prefix": {
@@ -1929,6 +1958,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   }
                                 },
@@ -2769,6 +2799,9 @@
                       "hostPID": {
                         "type": "boolean"
                       },
+                      "hostUsers": {
+                        "type": "boolean"
+                      },
                       "hostname": {
                         "type": "string"
                       },
@@ -2780,6 +2813,7 @@
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "type": "array"
@@ -2826,6 +2860,7 @@
                                           "key"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "fieldRef": {
@@ -2841,6 +2876,7 @@
                                           "fieldPath"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "resourceFieldRef": {
@@ -2868,6 +2904,7 @@
                                           "resource"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "secretKeyRef": {
@@ -2886,6 +2923,7 @@
                                           "key"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
@@ -2914,6 +2952,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "prefix": {
@@ -2929,6 +2968,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   }
                                 },
@@ -3993,11 +4033,29 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
+                            },
+                            "matchLabelKeys": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "maxSkew": {
                               "format": "int32",
                               "type": "integer"
+                            },
+                            "minDomains": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "nodeAffinityPolicy": {
+                              "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                              "type": "string"
                             },
                             "topologyKey": {
                               "type": "string"

--- a/argoproj.io/rollout_v1alpha1.json
+++ b/argoproj.io/rollout_v1alpha1.json
@@ -96,6 +96,7 @@
             }
           },
           "type": "object",
+          "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
         "strategy": {
@@ -921,6 +922,7 @@
                                     }
                                   },
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "service": {
@@ -1123,6 +1125,12 @@
                         "ingress": {
                           "type": "string"
                         },
+                        "ingresses": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "rootService": {
                           "type": "string"
                         },
@@ -1149,7 +1157,6 @@
                         }
                       },
                       "required": [
-                        "ingress",
                         "servicePort"
                       ],
                       "type": "object",
@@ -1547,6 +1554,7 @@
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "weight": {
@@ -1620,6 +1628,7 @@
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "type": "array"
@@ -1629,6 +1638,7 @@
                             "nodeSelectorTerms"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
@@ -1677,6 +1687,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "namespaceSelector": {
@@ -1714,6 +1725,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "namespaces": {
@@ -1784,6 +1796,7 @@
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
@@ -1821,6 +1834,7 @@
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "namespaces": {
@@ -1887,6 +1901,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "namespaceSelector": {
@@ -1924,6 +1939,7 @@
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "namespaces": {
@@ -1994,6 +2010,7 @@
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "namespaceSelector": {
@@ -2031,6 +2048,7 @@
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "namespaces": {
@@ -2104,6 +2122,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
@@ -2119,6 +2138,7 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
@@ -2146,6 +2166,7 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
@@ -2164,6 +2185,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -2192,6 +2214,7 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
@@ -2207,6 +2230,7 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -3098,6 +3122,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
@@ -3113,6 +3138,7 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
@@ -3140,6 +3166,7 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
@@ -3158,6 +3185,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -3186,6 +3214,7 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
@@ -3201,6 +3230,7 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -4055,6 +4085,7 @@
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "type": "array"
@@ -4101,6 +4132,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
@@ -4116,6 +4148,7 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
@@ -4143,6 +4176,7 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
@@ -4161,6 +4195,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -4189,6 +4224,7 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
@@ -4204,6 +4240,7 @@
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -5268,6 +5305,7 @@
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "matchLabelKeys": {
@@ -5378,11 +5416,13 @@
               },
               "required": [
                 "arn",
-                "fullName",
                 "name"
               ],
               "type": "object",
               "additionalProperties": false
+            },
+            "ingress": {
+              "type": "string"
             },
             "loadBalancer": {
               "properties": {
@@ -5398,7 +5438,6 @@
               },
               "required": [
                 "arn",
-                "fullName",
                 "name"
               ],
               "type": "object",
@@ -5418,7 +5457,6 @@
               },
               "required": [
                 "arn",
-                "fullName",
                 "name"
               ],
               "type": "object",
@@ -5427,6 +5465,75 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "albs": {
+          "items": {
+            "properties": {
+              "canaryTargetGroup": {
+                "properties": {
+                  "arn": {
+                    "type": "string"
+                  },
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "arn",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ingress": {
+                "type": "string"
+              },
+              "loadBalancer": {
+                "properties": {
+                  "arn": {
+                    "type": "string"
+                  },
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "arn",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stableTargetGroup": {
+                "properties": {
+                  "arn": {
+                    "type": "string"
+                  },
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "arn",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
         },
         "availableReplicas": {
           "format": "int32",


### PR DESCRIPTION
I tried to update Argo Workflow CRDs to v3.5.4 using the following script.

```bash
set -eu
set -o pipefail

ARGO_ROLLOUTS_VERSION='1.6.6'
KUBECONFORM_DIR=<path to kubeconform>

kinds=(
  analysis-run-crd
  analysis-template-crd
  cluster-analysis-template-crd
  experiment-crd
  kustomization
  rollout-crd
)

for kind in "${kinds[@]}"; do
  python3 ${KUBECONFORM_DIR}/scripts/openapi2jsonschema.py https://raw.githubusercontent.com/argoproj/argo-rollouts/v${ARGO_ROLLOUTS_VERSION}/manifests/crds/${kind}.yaml
done
```

CRDs-catalog has an utility tool to extract CRDs from an existing cluster, named CRD Extractor. In most cases, we can use the tool to update CRDs. However I wasn't able to point it at a cluster due to networking issues.

Therefore, I directly used openapi2jsonchema.py in the kubeconform repository to update Argo Workflow's CRDs.