### PR TITLE
add latest argo-cd application and applicationset CRDs for v2.10.4

### DIFF
--- a/argoproj.io/application_v1alpha1.json
+++ b/argoproj.io/application_v1alpha1.json
@@ -332,6 +332,13 @@
                       "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                       "type": "object"
                     },
+                    "components": {
+                      "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
                     "forceCommonAnnotations": {
                       "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                       "type": "boolean"
@@ -729,6 +736,13 @@
                         },
                         "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                         "type": "object"
+                      },
+                      "components": {
+                        "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "forceCommonAnnotations": {
                         "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
@@ -1268,6 +1282,13 @@
                   "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                   "type": "object"
                 },
+                "components": {
+                  "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "forceCommonAnnotations": {
                   "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                   "type": "boolean"
@@ -1665,6 +1686,13 @@
                     },
                     "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                     "type": "object"
+                  },
+                  "components": {
+                    "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
                   },
                   "forceCommonAnnotations": {
                     "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
@@ -2237,6 +2265,13 @@
                         "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                         "type": "object"
                       },
+                      "components": {
+                        "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "forceCommonAnnotations": {
                         "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                         "type": "boolean"
@@ -2634,6 +2669,13 @@
                           },
                           "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                           "type": "object"
+                        },
+                        "components": {
+                          "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
                         },
                         "forceCommonAnnotations": {
                           "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
@@ -3186,6 +3228,13 @@
                               "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                               "type": "object"
                             },
+                            "components": {
+                              "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "forceCommonAnnotations": {
                               "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                               "type": "boolean"
@@ -3583,6 +3632,13 @@
                                 },
                                 "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                                 "type": "object"
+                              },
+                              "components": {
+                                "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "forceCommonAnnotations": {
                                 "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
@@ -4131,6 +4187,13 @@
                           "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                           "type": "object"
                         },
+                        "components": {
+                          "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                           "type": "boolean"
@@ -4528,6 +4591,13 @@
                             },
                             "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                             "type": "object"
+                          },
+                          "components": {
+                            "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
                           },
                           "forceCommonAnnotations": {
                             "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
@@ -5110,6 +5180,13 @@
                           "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                           "type": "object"
                         },
+                        "components": {
+                          "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                           "type": "boolean"
@@ -5507,6 +5584,13 @@
                             },
                             "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                             "type": "object"
+                          },
+                          "components": {
+                            "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
                           },
                           "forceCommonAnnotations": {
                             "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",

--- a/argoproj.io/applicationset_v1alpha1.json
+++ b/argoproj.io/applicationset_v1alpha1.json
@@ -343,6 +343,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -680,6 +686,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -1276,6 +1288,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -1613,6 +1631,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -2215,6 +2239,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -2552,6 +2582,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -3121,6 +3157,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -3459,6 +3501,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -3726,9 +3774,6 @@
                     "additionalProperties": false
                   }
                 },
-                "required": [
-                  "elements"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -4062,6 +4107,12 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
                                             },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
@@ -4400,6 +4451,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -4996,6 +5053,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -5333,6 +5396,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -5935,6 +6004,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -6272,6 +6347,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -6841,6 +6922,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -7179,6 +7266,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -7446,9 +7539,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "elements"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -7765,6 +7855,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -8102,6 +8198,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -8973,6 +9075,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -9310,6 +9418,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -10174,6 +10288,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -10511,6 +10631,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -11108,6 +11234,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -11445,6 +11577,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -12050,6 +12188,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -12387,6 +12531,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -12983,6 +13133,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -13320,6 +13476,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -13922,6 +14084,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -14259,6 +14427,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -14828,6 +15002,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -15166,6 +15346,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -15433,9 +15619,6 @@
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "elements"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -15752,6 +15935,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -16089,6 +16278,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -16960,6 +17155,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -17297,6 +17498,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -18161,6 +18368,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -18498,6 +18711,12 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
                                               },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
@@ -19101,6 +19320,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -19438,6 +19663,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -20020,6 +20251,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -20357,6 +20594,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -21228,6 +21471,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -21565,6 +21814,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -22429,6 +22684,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -22766,6 +23027,12 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
                                     },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
@@ -23488,6 +23755,12 @@
                           },
                           "type": "object"
                         },
+                        "components": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "type": "boolean"
                         },
@@ -23826,6 +24099,12 @@
                             },
                             "type": "object"
                           },
+                          "components": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "forceCommonAnnotations": {
                             "type": "boolean"
                           },
@@ -24091,6 +24370,9 @@
           ],
           "type": "object",
           "additionalProperties": false
+        },
+        "templatePatch": {
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
Add latest argo-cd application and applicationset CRDs for v2.10.4, which includes [templatePatch](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Template/#template-patch) as a feature for ApplicationSets.