### PR TITLE
Update secrets.hashicorp.com CRDs to v0.5.2

### DIFF
--- a/secrets.hashicorp.com/hcpvaultsecretsapp_v1beta1.json
+++ b/secrets.hashicorp.com/hcpvaultsecretsapp_v1beta1.json
@@ -30,6 +30,7 @@
               "type": "object"
             },
             "create": {
+              "default": false,
               "description": "Create the destination Secret. If the Secret already exists this should be set to false.",
               "type": "boolean"
             },
@@ -44,6 +45,110 @@
               "description": "Name of the Secret",
               "type": "string"
             },
+            "overwrite": {
+              "default": false,
+              "description": "Overwrite the destination Secret if it exists and Create is true. This is useful when migrating to VSO from a previous secret deployment strategy.",
+              "type": "boolean"
+            },
+            "transformation": {
+              "description": "Transformation provides configuration for transforming the secret data before it is stored in the Destination.",
+              "properties": {
+                "excludeRaw": {
+                  "description": "ExcludeRaw data from the destination Secret. Exclusion policy can be set globally by including 'exclude-raw` in the '--global-transformation-options' command line flag. If set, the command line flag always takes precedence over this configuration.",
+                  "type": "boolean"
+                },
+                "excludes": {
+                  "description": "Excludes contains regex patterns used to filter top-level source secret data fields for exclusion from the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied before any inclusion patterns. To exclude all source secret data fields, you can configure the single pattern \".*\".",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "includes": {
+                  "description": "Includes contains regex patterns used to filter top-level source secret data fields for inclusion in the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied last.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "templates": {
+                  "additionalProperties": {
+                    "description": "Template provides templating configuration.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the Template",
+                        "type": "string"
+                      },
+                      "text": {
+                        "description": "Text contains the Go text template format. The template references attributes from the data structure of the source secret. Refer to https://pkg.go.dev/text/template for more information.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "text"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "Templates maps a template name to its Template. Templates are always included in the rendered K8s Secret, and take precedence over templates defined in a SecretTransformation.",
+                  "type": "object"
+                },
+                "transformationRefs": {
+                  "description": "TransformationRefs contain references to template configuration from SecretTransformation.",
+                  "items": {
+                    "description": "TransformationRef contains the configuration for accessing templates from an SecretTransformation resource. TransformationRefs can be shared across all syncable secret custom resources.",
+                    "properties": {
+                      "ignoreExcludes": {
+                        "description": "IgnoreExcludes controls whether to use the SecretTransformation's Excludes data key filters.",
+                        "type": "boolean"
+                      },
+                      "ignoreIncludes": {
+                        "description": "IgnoreIncludes controls whether to use the SecretTransformation's Includes data key filters.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "templateRefs": {
+                        "description": "TemplateRefs map to a Template found in this TransformationRef. If empty, then all templates from the SecretTransformation will be rendered to the K8s Secret.",
+                        "items": {
+                          "description": "TemplateRef points to templating text that is stored in a SecretTransformation custom resource.",
+                          "properties": {
+                            "keyOverride": {
+                              "description": "KeyOverride to the rendered template in the Destination secret. If Key is empty, then the Key from reference spec will be used. Set this to override the Key set from the reference spec.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the Template in SecretTransformationSpec.Templates. the rendered secret data.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "type": {
               "description": "Type of Kubernetes Secret. Requires Create to be set to true. Defaults to Opaque.",
               "type": "string"
@@ -56,7 +161,7 @@
           "additionalProperties": false
         },
         "hcpAuthRef": {
-          "description": "HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in its own Kubernetes namespace. HCPAuthRef string `json:\"hcpAuthRef,omitempty\"`",
+          "description": "HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in the operator's namespace.",
           "type": "string"
         },
         "refreshAfter": {
@@ -102,11 +207,19 @@
     "status": {
       "description": "HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp",
       "properties": {
+        "lastGeneration": {
+          "description": "LastGeneration is the Generation of the last reconciled resource.",
+          "format": "int64",
+          "type": "integer"
+        },
         "secretMAC": {
           "description": "SecretMAC used when deciding whether new Vault secret data should be synced. \n The controller will compare the \"new\" HCP Vault Secrets App data to this value using HMAC, if they are different, then the data will be synced to the Destination. \n The SecretMac is also used to detect drift in the Destination Secret's Data. If drift is detected the data will be synced to the Destination.",
           "type": "string"
         }
       },
+      "required": [
+        "lastGeneration"
+      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/secrets.hashicorp.com/secrettransformation_v1beta1.json
+++ b/secrets.hashicorp.com/secrettransformation_v1beta1.json
@@ -1,0 +1,98 @@
+{
+  "description": "SecretTransformation is the Schema for the secrettransformations API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "SecretTransformationSpec defines the desired state of SecretTransformation",
+      "properties": {
+        "excludes": {
+          "description": "Excludes contains regex patterns used to filter top-level source secret data fields for exclusion from the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied before any inclusion patterns. To exclude all source secret data fields, you can configure the single pattern \".*\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "includes": {
+          "description": "Includes contains regex patterns used to filter top-level source secret data fields for inclusion in the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied last.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sourceTemplates": {
+          "description": "SourceTemplates are never included in the rendered K8s Secret, they can be used to provide common template definitions, etc.",
+          "items": {
+            "description": "SourceTemplate provides source templating configuration.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "text": {
+                "description": "Text contains the Go text template format. The template references attributes from the data structure of the source secret. Refer to https://pkg.go.dev/text/template for more information.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "templates": {
+          "additionalProperties": {
+            "description": "Template provides templating configuration.",
+            "properties": {
+              "name": {
+                "description": "Name of the Template",
+                "type": "string"
+              },
+              "text": {
+                "description": "Text contains the Go text template format. The template references attributes from the data structure of the source secret. Refer to https://pkg.go.dev/text/template for more information.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "Templates maps a template name to its Template. Templates are always included in the rendered K8s Secret with the specified key.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "SecretTransformationStatus defines the observed state of SecretTransformation",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "valid": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "error",
+        "valid"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/secrets.hashicorp.com/vaultauth_v1beta1.json
+++ b/secrets.hashicorp.com/vaultauth_v1beta1.json
@@ -65,7 +65,7 @@
               "type": "string"
             },
             "secretRef": {
-              "description": "SecretRef is the name of a Kubernetes Secret which holds credentials for AWS. Expected keys include `access_key_id`, `secret_access_key`, `session_token`",
+              "description": "SecretRef is the name of a Kubernetes Secret in the consumer's (VDS/VSS/PKI) namespace which holds credentials for AWS. Expected keys include `access_key_id`, `secret_access_key`, `session_token`",
               "type": "string"
             },
             "sessionName": {
@@ -172,7 +172,7 @@
               "type": "string"
             },
             "serviceAccount": {
-              "description": "ServiceAccount to use when authenticating to Vault's kubernetes authentication backend.",
+              "description": "ServiceAccount to use when authenticating to Vault's authentication backend. This must reside in the consuming secret's (VDS/VSS/PKI) namespace.",
               "type": "string"
             },
             "tokenExpirationSeconds": {
@@ -236,7 +236,7 @@
           "additionalProperties": false
         },
         "vaultConnectionRef": {
-          "description": "VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to\t`default` VaultConnection, configured in its own Kubernetes namespace.",
+          "description": "VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to the `default` VaultConnection, configured in the operator's namespace.",
           "type": "string"
         }
       },

--- a/secrets.hashicorp.com/vaultdynamicsecret_v1beta1.json
+++ b/secrets.hashicorp.com/vaultdynamicsecret_v1beta1.json
@@ -30,6 +30,7 @@
               "type": "object"
             },
             "create": {
+              "default": false,
               "description": "Create the destination Secret. If the Secret already exists this should be set to false.",
               "type": "boolean"
             },
@@ -43,6 +44,110 @@
             "name": {
               "description": "Name of the Secret",
               "type": "string"
+            },
+            "overwrite": {
+              "default": false,
+              "description": "Overwrite the destination Secret if it exists and Create is true. This is useful when migrating to VSO from a previous secret deployment strategy.",
+              "type": "boolean"
+            },
+            "transformation": {
+              "description": "Transformation provides configuration for transforming the secret data before it is stored in the Destination.",
+              "properties": {
+                "excludeRaw": {
+                  "description": "ExcludeRaw data from the destination Secret. Exclusion policy can be set globally by including 'exclude-raw` in the '--global-transformation-options' command line flag. If set, the command line flag always takes precedence over this configuration.",
+                  "type": "boolean"
+                },
+                "excludes": {
+                  "description": "Excludes contains regex patterns used to filter top-level source secret data fields for exclusion from the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied before any inclusion patterns. To exclude all source secret data fields, you can configure the single pattern \".*\".",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "includes": {
+                  "description": "Includes contains regex patterns used to filter top-level source secret data fields for inclusion in the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied last.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "templates": {
+                  "additionalProperties": {
+                    "description": "Template provides templating configuration.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the Template",
+                        "type": "string"
+                      },
+                      "text": {
+                        "description": "Text contains the Go text template format. The template references attributes from the data structure of the source secret. Refer to https://pkg.go.dev/text/template for more information.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "text"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "Templates maps a template name to its Template. Templates are always included in the rendered K8s Secret, and take precedence over templates defined in a SecretTransformation.",
+                  "type": "object"
+                },
+                "transformationRefs": {
+                  "description": "TransformationRefs contain references to template configuration from SecretTransformation.",
+                  "items": {
+                    "description": "TransformationRef contains the configuration for accessing templates from an SecretTransformation resource. TransformationRefs can be shared across all syncable secret custom resources.",
+                    "properties": {
+                      "ignoreExcludes": {
+                        "description": "IgnoreExcludes controls whether to use the SecretTransformation's Excludes data key filters.",
+                        "type": "boolean"
+                      },
+                      "ignoreIncludes": {
+                        "description": "IgnoreIncludes controls whether to use the SecretTransformation's Includes data key filters.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "templateRefs": {
+                        "description": "TemplateRefs map to a Template found in this TransformationRef. If empty, then all templates from the SecretTransformation will be rendered to the K8s Secret.",
+                        "items": {
+                          "description": "TemplateRef points to templating text that is stored in a SecretTransformation custom resource.",
+                          "properties": {
+                            "keyOverride": {
+                              "description": "KeyOverride to the rendered template in the Destination secret. If Key is empty, then the Key from reference spec will be used. Set this to override the Key set from the reference spec.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the Template in SecretTransformationSpec.Templates. the rendered secret data.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "type": {
               "description": "Type of Kubernetes Secret. Requires Create to be set to true. Defaults to Opaque.",
@@ -72,6 +177,11 @@
         },
         "path": {
           "description": "Path in Vault to get the credentials for, and is relative to Mount. Please consult https://developer.hashicorp.com/vault/docs/secrets if you are uncertain about what 'path' should be set to.",
+          "type": "string"
+        },
+        "refreshAfter": {
+          "description": "RefreshAfter a period of time for VSO to sync the source secret data, in duration notation e.g. 30s, 1m, 24h. This value only needs to be set when syncing from a secret's engine that does not provide a lease TTL in its response. The value should be within the secret engine's configured ttl or max_ttl. The source secret's lease duration takes precedence over this configuration when it is greater than 0.",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(s|m|h))$",
           "type": "string"
         },
         "renewalPercent": {
@@ -121,7 +231,7 @@
           "type": "array"
         },
         "vaultAuthRef": {
-          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
+          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace.",
           "type": "string"
         }
       },
@@ -209,7 +319,6 @@
           "required": [
             "lastVaultRotation",
             "rotationPeriod",
-            "rotationSchedule",
             "ttl"
           ],
           "type": "object",

--- a/secrets.hashicorp.com/vaultpkisecret_v1beta1.json
+++ b/secrets.hashicorp.com/vaultpkisecret_v1beta1.json
@@ -41,6 +41,7 @@
               "type": "object"
             },
             "create": {
+              "default": false,
               "description": "Create the destination Secret. If the Secret already exists this should be set to false.",
               "type": "boolean"
             },
@@ -54,6 +55,110 @@
             "name": {
               "description": "Name of the Secret",
               "type": "string"
+            },
+            "overwrite": {
+              "default": false,
+              "description": "Overwrite the destination Secret if it exists and Create is true. This is useful when migrating to VSO from a previous secret deployment strategy.",
+              "type": "boolean"
+            },
+            "transformation": {
+              "description": "Transformation provides configuration for transforming the secret data before it is stored in the Destination.",
+              "properties": {
+                "excludeRaw": {
+                  "description": "ExcludeRaw data from the destination Secret. Exclusion policy can be set globally by including 'exclude-raw` in the '--global-transformation-options' command line flag. If set, the command line flag always takes precedence over this configuration.",
+                  "type": "boolean"
+                },
+                "excludes": {
+                  "description": "Excludes contains regex patterns used to filter top-level source secret data fields for exclusion from the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied before any inclusion patterns. To exclude all source secret data fields, you can configure the single pattern \".*\".",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "includes": {
+                  "description": "Includes contains regex patterns used to filter top-level source secret data fields for inclusion in the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied last.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "templates": {
+                  "additionalProperties": {
+                    "description": "Template provides templating configuration.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the Template",
+                        "type": "string"
+                      },
+                      "text": {
+                        "description": "Text contains the Go text template format. The template references attributes from the data structure of the source secret. Refer to https://pkg.go.dev/text/template for more information.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "text"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "Templates maps a template name to its Template. Templates are always included in the rendered K8s Secret, and take precedence over templates defined in a SecretTransformation.",
+                  "type": "object"
+                },
+                "transformationRefs": {
+                  "description": "TransformationRefs contain references to template configuration from SecretTransformation.",
+                  "items": {
+                    "description": "TransformationRef contains the configuration for accessing templates from an SecretTransformation resource. TransformationRefs can be shared across all syncable secret custom resources.",
+                    "properties": {
+                      "ignoreExcludes": {
+                        "description": "IgnoreExcludes controls whether to use the SecretTransformation's Excludes data key filters.",
+                        "type": "boolean"
+                      },
+                      "ignoreIncludes": {
+                        "description": "IgnoreIncludes controls whether to use the SecretTransformation's Includes data key filters.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "templateRefs": {
+                        "description": "TemplateRefs map to a Template found in this TransformationRef. If empty, then all templates from the SecretTransformation will be rendered to the K8s Secret.",
+                        "items": {
+                          "description": "TemplateRef points to templating text that is stored in a SecretTransformation custom resource.",
+                          "properties": {
+                            "keyOverride": {
+                              "description": "KeyOverride to the rendered template in the Destination secret. If Key is empty, then the Key from reference spec will be used. Set this to override the Key set from the reference spec.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the Template in SecretTransformationSpec.Templates. the rendered secret data.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "type": {
               "description": "Type of Kubernetes Secret. Requires Create to be set to true. Defaults to Opaque.",
@@ -159,8 +264,15 @@
           },
           "type": "array"
         },
+        "userIDs": {
+          "description": "User ID (OID 0.9.2342.19200300.100.1.1) Subject values to be placed on the signed certificate.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "vaultAuthRef": {
-          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
+          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace.",
           "type": "string"
         }
       },

--- a/secrets.hashicorp.com/vaultstaticsecret_v1beta1.json
+++ b/secrets.hashicorp.com/vaultstaticsecret_v1beta1.json
@@ -26,6 +26,7 @@
               "type": "object"
             },
             "create": {
+              "default": false,
               "description": "Create the destination Secret. If the Secret already exists this should be set to false.",
               "type": "boolean"
             },
@@ -39,6 +40,110 @@
             "name": {
               "description": "Name of the Secret",
               "type": "string"
+            },
+            "overwrite": {
+              "default": false,
+              "description": "Overwrite the destination Secret if it exists and Create is true. This is useful when migrating to VSO from a previous secret deployment strategy.",
+              "type": "boolean"
+            },
+            "transformation": {
+              "description": "Transformation provides configuration for transforming the secret data before it is stored in the Destination.",
+              "properties": {
+                "excludeRaw": {
+                  "description": "ExcludeRaw data from the destination Secret. Exclusion policy can be set globally by including 'exclude-raw` in the '--global-transformation-options' command line flag. If set, the command line flag always takes precedence over this configuration.",
+                  "type": "boolean"
+                },
+                "excludes": {
+                  "description": "Excludes contains regex patterns used to filter top-level source secret data fields for exclusion from the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied before any inclusion patterns. To exclude all source secret data fields, you can configure the single pattern \".*\".",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "includes": {
+                  "description": "Includes contains regex patterns used to filter top-level source secret data fields for inclusion in the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied last.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "templates": {
+                  "additionalProperties": {
+                    "description": "Template provides templating configuration.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the Template",
+                        "type": "string"
+                      },
+                      "text": {
+                        "description": "Text contains the Go text template format. The template references attributes from the data structure of the source secret. Refer to https://pkg.go.dev/text/template for more information.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "text"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "description": "Templates maps a template name to its Template. Templates are always included in the rendered K8s Secret, and take precedence over templates defined in a SecretTransformation.",
+                  "type": "object"
+                },
+                "transformationRefs": {
+                  "description": "TransformationRefs contain references to template configuration from SecretTransformation.",
+                  "items": {
+                    "description": "TransformationRef contains the configuration for accessing templates from an SecretTransformation resource. TransformationRefs can be shared across all syncable secret custom resources.",
+                    "properties": {
+                      "ignoreExcludes": {
+                        "description": "IgnoreExcludes controls whether to use the SecretTransformation's Excludes data key filters.",
+                        "type": "boolean"
+                      },
+                      "ignoreIncludes": {
+                        "description": "IgnoreIncludes controls whether to use the SecretTransformation's Includes data key filters.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the SecretTransformation resource.",
+                        "type": "string"
+                      },
+                      "templateRefs": {
+                        "description": "TemplateRefs map to a Template found in this TransformationRef. If empty, then all templates from the SecretTransformation will be rendered to the K8s Secret.",
+                        "items": {
+                          "description": "TemplateRef points to templating text that is stored in a SecretTransformation custom resource.",
+                          "properties": {
+                            "keyOverride": {
+                              "description": "KeyOverride to the rendered template in the Destination secret. If Key is empty, then the Key from reference spec will be used. Set this to override the Key set from the reference spec.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the Template in SecretTransformationSpec.Templates. the rendered secret data.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "type": {
               "description": "Type of Kubernetes Secret. Requires Create to be set to true. Defaults to Opaque.",
@@ -108,7 +213,7 @@
           "type": "string"
         },
         "vaultAuthRef": {
-          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace.",
+          "description": "VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace.",
           "type": "string"
         },
         "version": {


### PR DESCRIPTION
Pulled from https://github.com/hashicorp/vault-secrets-operator/tree/v0.5.2/chart/crds, converted with `openapi2jsonschema.py`.

Supersedes #283.