### PR TITLE
feat: add keep_firing_for to vmrule

### DIFF
--- a/operator.victoriametrics.com/vmrule_v1beta1.json
+++ b/operator.victoriametrics.com/vmrule_v1beta1.json
@@ -102,6 +102,10 @@
                       "description": "For evaluation interval in time.Duration format 30s, 1m, 1h  or nanoseconds",
                       "type": "string"
                     },
+                    "keep_firing_for": {
+                      "description": "KeepFiringFor will make alert continue firing for this long even when the alerting expression no longer has results. Use time.Duration format, 30s, 1m, 1h  or nanoseconds",
+                      "type": "string"
+                    },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"


### PR DESCRIPTION
Support `keep_firing_for` field that Victoria Metrics supports.
[Commit](https://github.com/VictoriaMetrics/operator/commit/76acb80997672f041ac2f8f3fe63f6cece9f4cf1) adding `keep_firing_for`