### PR TITLE
fix: update karpenter crds

### DIFF
--- a/karpenter.k8s.aws/ec2nodeclass_v1beta1.json
+++ b/karpenter.k8s.aws/ec2nodeclass_v1beta1.json
@@ -73,10 +73,6 @@
             {
               "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
               "rule": "!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))"
-            },
-            {
-              "message": "'owner' cannot be set with 'tags'",
-              "rule": "!self.all(x, has(x.owner) && has(x.tags))"
             }
           ]
         },
@@ -185,6 +181,16 @@
           "description": "DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched",
           "type": "boolean"
         },
+        "instanceProfile": {
+          "description": "InstanceProfile is the AWS entity that instances use. This field is mutually exclusive from role. The instance profile should already have a role assigned to it that Karpenter has PassRole permission on for instance launch using this instanceProfile to succeed.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "instanceProfile cannot be empty",
+              "rule": "self != ''"
+            }
+          ]
+        },
         "metadataOptions": {
           "default": {
             "httpEndpoint": "enabled",
@@ -234,7 +240,7 @@
           "additionalProperties": false
         },
         "role": {
-          "description": "Role is the AWS identity that nodes use. This field is immutable. Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances. This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented for the old instance profiles on an update.",
+          "description": "Role is the AWS identity that nodes use. This field is immutable. This field is mutually exclusive from instanceProfile. Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances. This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented for the old instance profiles on an update.",
           "type": "string",
           "x-kubernetes-validations": [
             {
@@ -381,7 +387,6 @@
       },
       "required": [
         "amiFamily",
-        "role",
         "securityGroupSelectorTerms",
         "subnetSelectorTerms"
       ],
@@ -390,6 +395,14 @@
         {
           "message": "amiSelectorTerms is required when amiFamily == 'Custom'",
           "rule": "self.amiFamily == 'Custom' ? self.amiSelectorTerms.size() != 0 : true"
+        },
+        {
+          "message": "must specify exactly one of ['role', 'instanceProfile']",
+          "rule": "(has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))"
+        },
+        {
+          "message": "changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.",
+          "rule": "(has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))"
         }
       ],
       "additionalProperties": false

--- a/karpenter.sh/nodeclaim_v1beta1.json
+++ b/karpenter.sh/nodeclaim_v1beta1.json
@@ -201,16 +201,16 @@
               "key": {
                 "description": "The label key that the selector applies to.",
                 "maxLength": 316,
-                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                 "type": "string",
                 "x-kubernetes-validations": [
                   {
                     "message": "label domain \"kubernetes.io\" is restricted",
-                    "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.startsWith(\"node.kubernetes.io/\") || self.startsWith(\"node-restriction.kubernetes.io/\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
+                    "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.find(\"^([^/]+)\").endsWith(\"node.kubernetes.io\") || self.find(\"^([^/]+)\").endsWith(\"node-restriction.kubernetes.io\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
                   },
                   {
                     "message": "label domain \"k8s.io\" is restricted",
-                    "rule": "self.startsWith(\"kops.k8s.io/\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
+                    "rule": "self.find(\"^([^/]+)\").endsWith(\"kops.k8s.io\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
                   },
                   {
                     "message": "label domain \"karpenter.sh\" is restricted",
@@ -308,7 +308,7 @@
               "key": {
                 "description": "Required. The taint key to be applied to a node.",
                 "minLength": 1,
-                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                 "type": "string"
               },
               "timeAdded": {
@@ -318,7 +318,7 @@
               },
               "value": {
                 "description": "The taint value corresponding to the taint key.",
-                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                 "type": "string"
               }
             },
@@ -348,7 +348,7 @@
               "key": {
                 "description": "Required. The taint key to be applied to a node.",
                 "minLength": 1,
-                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                 "type": "string"
               },
               "timeAdded": {
@@ -358,7 +358,7 @@
               },
               "value": {
                 "description": "The taint value corresponding to the taint key.",
-                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                 "type": "string"
               }
             },

--- a/karpenter.sh/nodepool_v1beta1.json
+++ b/karpenter.sh/nodepool_v1beta1.json
@@ -96,11 +96,11 @@
                   "x-kubernetes-validations": [
                     {
                       "message": "label domain \"kubernetes.io\" is restricted",
-                      "rule": "self.all(x, x in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\",  \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || x.startsWith(\"node.kubernetes.io\") || x.startsWith(\"node-restriction.kubernetes.io\") || !x.find(\"^([^/]+)\").endsWith(\"kubernetes.io\"))"
+                      "rule": "self.all(x, x in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\",  \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || x.find(\"^([^/]+)\").endsWith(\"node.kubernetes.io\") || x.find(\"^([^/]+)\").endsWith(\"node-restriction.kubernetes.io\") || !x.find(\"^([^/]+)\").endsWith(\"kubernetes.io\"))"
                     },
                     {
                       "message": "label domain \"k8s.io\" is restricted",
-                      "rule": "self.all(x, x.startsWith(\"kops.k8s.io\") || !x.find(\"^([^/]+)\").endsWith(\"k8s.io\"))"
+                      "rule": "self.all(x, x.find(\"^([^/]+)\").endsWith(\"kops.k8s.io\") || !x.find(\"^([^/]+)\").endsWith(\"k8s.io\"))"
                     },
                     {
                       "message": "label domain \"karpenter.sh\" is restricted",
@@ -313,16 +313,16 @@
                       "key": {
                         "description": "The label key that the selector applies to.",
                         "maxLength": 316,
-                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                         "type": "string",
                         "x-kubernetes-validations": [
                           {
                             "message": "label domain \"kubernetes.io\" is restricted",
-                            "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.startsWith(\"node.kubernetes.io/\") || self.startsWith(\"node-restriction.kubernetes.io/\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
+                            "rule": "self in [\"beta.kubernetes.io/instance-type\", \"failure-domain.beta.kubernetes.io/region\", \"beta.kubernetes.io/os\", \"beta.kubernetes.io/arch\", \"failure-domain.beta.kubernetes.io/zone\", \"topology.kubernetes.io/zone\", \"topology.kubernetes.io/region\", \"node.kubernetes.io/instance-type\", \"kubernetes.io/arch\", \"kubernetes.io/os\", \"node.kubernetes.io/windows-build\"] || self.find(\"^([^/]+)\").endsWith(\"node.kubernetes.io\") || self.find(\"^([^/]+)\").endsWith(\"node-restriction.kubernetes.io\") || !self.find(\"^([^/]+)\").endsWith(\"kubernetes.io\")"
                           },
                           {
                             "message": "label domain \"k8s.io\" is restricted",
-                            "rule": "self.startsWith(\"kops.k8s.io/\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
+                            "rule": "self.find(\"^([^/]+)\").endsWith(\"kops.k8s.io\") || !self.find(\"^([^/]+)\").endsWith(\"k8s.io\")"
                           },
                           {
                             "message": "label domain \"karpenter.sh\" is restricted",
@@ -424,7 +424,7 @@
                       "key": {
                         "description": "Required. The taint key to be applied to a node.",
                         "minLength": 1,
-                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                         "type": "string"
                       },
                       "timeAdded": {
@@ -434,7 +434,7 @@
                       },
                       "value": {
                         "description": "The taint value corresponding to the taint key.",
-                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                         "type": "string"
                       }
                     },
@@ -464,7 +464,7 @@
                       "key": {
                         "description": "Required. The taint key to be applied to a node.",
                         "minLength": 1,
-                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                         "type": "string"
                       },
                       "timeAdded": {
@@ -474,7 +474,7 @@
                       },
                       "value": {
                         "description": "The taint value corresponding to the taint key.",
-                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$",
                         "type": "string"
                       }
                     },
@@ -496,6 +496,9 @@
               "additionalProperties": false
             }
           },
+          "required": [
+            "spec"
+          ],
           "type": "object",
           "additionalProperties": false
         },
@@ -507,6 +510,9 @@
           "type": "integer"
         }
       },
+      "required": [
+        "template"
+      ],
       "type": "object",
       "additionalProperties": false
     },


### PR DESCRIPTION
This updates the Karpenter CRDs to the ones shipped with Karpenter v0.32.9, this is the last version that still includes the v1alpha CRDs.