### PR TITLE
feat: add tekton CD crd schemas

### DIFF
--- a/tekton.dev/clustertask_v1beta1.json
+++ b/tekton.dev/clustertask_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/customrun_v1beta1.json
+++ b/tekton.dev/customrun_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/pipeline_v1.json
+++ b/tekton.dev/pipeline_v1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/pipeline_v1beta1.json
+++ b/tekton.dev/pipeline_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/pipelinerun_v1.json
+++ b/tekton.dev/pipelinerun_v1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/pipelinerun_v1beta1.json
+++ b/tekton.dev/pipelinerun_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/stepaction_v1alpha1.json
+++ b/tekton.dev/stepaction_v1alpha1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/stepaction_v1beta1.json
+++ b/tekton.dev/stepaction_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/task_v1.json
+++ b/tekton.dev/task_v1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/task_v1beta1.json
+++ b/tekton.dev/task_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/taskrun_v1.json
+++ b/tekton.dev/taskrun_v1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/taskrun_v1beta1.json
+++ b/tekton.dev/taskrun_v1beta1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}

--- a/tekton.dev/verificationpolicy_v1alpha1.json
+++ b/tekton.dev/verificationpolicy_v1alpha1.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "x-kubernetes-preserve-unknown-fields": true
+}


### PR DESCRIPTION
As per title. 
This adds the schemas fetched from here: https://github.com/tektoncd/pipeline/tree/main/config/300-crds