### PR TITLE
fix: corrupted scrapeconfig_v1alpha1.json

### DIFF
--- a/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+++ b/monitoring.coreos.com/scrapeconfig_v1alpha1.json
@@ -122,7 +122,6 @@
             "additionalProperties": false
           },
           "type": "array"
-          }
         },
         "basicAuth": {
           "description": "BasicAuth information to use on every scrape request.",


### PR DESCRIPTION
https://github.com/datreeio/CRDs-catalog/pull/299 introduced azureSDConfigs into the schema but added an additional `}`. Afterwards the schema was not usable anymore. 

yaml-ls reports the following error when using the schema with 
`yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/scrapeconfig_v1alpha1.json`

`Unable to parse content from 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/scrapeconfig_v1alpha1.json': Parse error at offset 72328.`