### PR TITLE
 [acid.zalan.do] Update Zalando Postgres Operator Schemas

### DIFF
--- a/acid.zalan.do/operatorconfiguration_v1.json
+++ b/acid.zalan.do/operatorconfiguration_v1.json
@@ -30,7 +30,7 @@
         },
         "docker_image": {
           "type": "string",
-          "default": "ghcr.io/zalando/spilo-15:3.0-p1"
+          "default": "ghcr.io/zalando/spilo-16:3.2-p3"
         },
         "enable_crd_registration": {
           "type": "boolean",
@@ -163,11 +163,11 @@
             },
             "minimal_major_version": {
               "type": "string",
-              "default": "11"
+              "default": "12"
             },
             "target_major_version": {
               "type": "string",
-              "default": "15"
+              "default": "16"
             }
           },
           "additionalProperties": false
@@ -220,7 +220,19 @@
               "type": "boolean",
               "default": false
             },
+            "enable_finalizers": {
+              "type": "boolean",
+              "default": false
+            },
             "enable_init_containers": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_secrets_deletion": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_persistent_volume_claim_deletion": {
               "type": "boolean",
               "default": true
             },
@@ -321,9 +333,33 @@
               "type": "string",
               "default": "postgresql-operator"
             },
+            "pdb_master_label_selector": {
+              "type": "boolean",
+              "default": true
+            },
             "pdb_name_format": {
               "type": "string",
               "default": "postgres-{cluster}-pdb"
+            },
+            "persistent_volume_claim_retention_policy": {
+              "type": "object",
+              "properties": {
+                "when_deleted": {
+                  "type": "string",
+                  "enum": [
+                    "delete",
+                    "retain"
+                  ]
+                },
+                "when_scaled": {
+                  "type": "string",
+                  "enum": [
+                    "delete",
+                    "retain"
+                  ]
+                }
+              },
+              "additionalProperties": false
             },
             "pod_antiaffinity_preferred_during_scheduling": {
               "type": "boolean",
@@ -422,23 +458,19 @@
           "properties": {
             "default_cpu_limit": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
-              "default": "1"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
             },
             "default_cpu_request": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
-              "default": "100m"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
             },
             "default_memory_limit": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
-              "default": "500Mi"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
             },
             "default_memory_request": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
-              "default": "100Mi"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
             },
             "max_cpu_request": {
               "type": "string",
@@ -450,13 +482,11 @@
             },
             "min_cpu_limit": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
-              "default": "250m"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
             },
             "min_memory_limit": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
-              "default": "250Mi"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
             }
           },
           "additionalProperties": false
@@ -620,7 +650,7 @@
             },
             "logical_backup_docker_image": {
               "type": "string",
-              "default": "registry.opensource.zalan.do/acid/logical-backup:v1.10.0"
+              "default": "ghcr.io/zalando/postgres-operator/logical-backup:v1.12.2"
             },
             "logical_backup_google_application_credentials": {
               "type": "string"
@@ -652,6 +682,9 @@
             "logical_backup_s3_bucket": {
               "type": "string"
             },
+            "logical_backup_s3_bucket_prefix": {
+              "type": "string"
+            },
             "logical_backup_s3_endpoint": {
               "type": "string"
             },
@@ -671,6 +704,9 @@
               "type": "string",
               "pattern": "^(\\d+|\\*)(/\\d+)?(\\s+(\\d+|\\*)(/\\d+)?){4}$",
               "default": "30 00 * * *"
+            },
+            "logical_backup_cronjob_environment_secret": {
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -831,7 +867,7 @@
             },
             "connection_pooler_image": {
               "type": "string",
-              "default": "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+              "default": "registry.opensource.zalan.do/acid/pgbouncer:master-32"
             },
             "connection_pooler_max_db_connections": {
               "type": "integer",
@@ -852,23 +888,19 @@
             },
             "connection_pooler_default_cpu_limit": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
-              "default": "1"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
             },
             "connection_pooler_default_cpu_request": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
-              "default": "500m"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
             },
             "connection_pooler_default_memory_limit": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
-              "default": "100Mi"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
             },
             "connection_pooler_default_memory_request": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
-              "default": "100Mi"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
             }
           },
           "additionalProperties": false

--- a/acid.zalan.do/postgresql_v1.json
+++ b/acid.zalan.do/postgresql_v1.json
@@ -37,10 +37,16 @@
               "volumeSource"
             ],
             "properties": {
+              "isSubPathExpr": {
+                "type": "boolean"
+              },
               "name": {
                 "type": "string"
               },
               "mountPath": {
+                "type": "string"
+              },
+              "subPath": {
                 "type": "string"
               },
               "targetContainers": {
@@ -53,9 +59,6 @@
               "volumeSource": {
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
-              },
-              "subPath": {
-                "type": "string"
               }
             },
             "additionalProperties": false
@@ -224,6 +227,9 @@
             "type": "object",
             "x-kubernetes-preserve-unknown-fields": true
           }
+        },
+        "logicalBackupRetention": {
+          "type": "string"
         },
         "logicalBackupSchedule": {
           "type": "string",
@@ -466,12 +472,12 @@
             "version": {
               "type": "string",
               "enum": [
-                "10",
                 "11",
                 "12",
                 "13",
                 "14",
-                "15"
+                "15",
+                "16"
               ]
             },
             "parameters": {
@@ -542,6 +548,14 @@
                 "memory": {
                   "type": "string",
                   "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                },
+                "hugepages-2Mi": {
+                  "type": "string",
+                  "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                },
+                "hugepages-1Gi": {
+                  "type": "string",
+                  "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
                 }
               },
               "additionalProperties": false
@@ -554,6 +568,14 @@
                   "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
                 },
                 "memory": {
+                  "type": "string",
+                  "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                },
+                "hugepages-2Mi": {
+                  "type": "string",
+                  "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                },
+                "hugepages-1Gi": {
                   "type": "string",
                   "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
                 }
@@ -643,6 +665,9 @@
               "database": {
                 "type": "string"
               },
+              "enableRecovery": {
+                "type": "boolean"
+              },
               "filter": {
                 "type": "object",
                 "additionalProperties": {
@@ -664,6 +689,9 @@
                       "type": "string"
                     },
                     "payloadColumn": {
+                      "type": "string"
+                    },
+                    "recoveryEventType": {
                       "type": "string"
                     }
                   },
@@ -778,6 +806,13 @@
             }
           }
         },
+        "usersIgnoringSecretRotation": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "usersWithInPlaceSecretRotation": {
           "type": "array",
           "nullable": true,
@@ -798,6 +833,9 @@
             "size"
           ],
           "properties": {
+            "isSubPathExpr": {
+              "type": "boolean"
+            },
             "iops": {
               "type": "integer"
             },


### PR DESCRIPTION
Identically as in #168, regenerated the Schemas for the Zalando Postgres Operator after the release of version 1.12.2: https://github.com/zalando/postgres-operator/releases/tag/v1.12.2

Reference: https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator/crds
Source: https://github.com/zalando/postgres-operator/tree/master
