### PR TITLE
Update Strimzi/Kafka CRDs to Strimzi 0.41

### DIFF
--- a/kafka.strimzi.io/kafka_v1beta2.json
+++ b/kafka.strimzi.io/kafka_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the Kafka and ZooKeeper clusters, and Topic Operator.",
       "properties": {
@@ -146,16 +157,18 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "The docker image for the pods.",
+              "description": "The container image used for Cruise Control pods. If no image name is explicitly specified, the image name corresponds to the name specified in the Cluster Operator configuration. If an image name is not defined in the Cluster Operator configuration, a default value is used.",
               "type": "string"
             },
             "jvmOptions": {
               "description": "JVM Options for the Cruise Control container.",
               "properties": {
                 "-XX": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "A map of -XX options to the JVM.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "-Xms": {
                   "description": "-Xms option to to the JVM.",
@@ -229,9 +242,11 @@
               "description": "Logging configuration (Log4j 2) for Cruise Control.",
               "properties": {
                 "loggers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "A Map from logger name to logger level.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "type": {
                   "description": "Logging type, must be either 'inline' or 'external'.",
@@ -282,7 +297,7 @@
                   "type": "string"
                 },
                 "valueFrom": {
-                  "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.",
+                  "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. ",
                   "properties": {
                     "configMapKeyRef": {
                       "description": "Reference to the key in the ConfigMap containing the configuration.",
@@ -347,13 +362,47 @@
             "resources": {
               "description": "CPU and memory resources to reserve for the Cruise Control container.",
               "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "limits": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 },
                 "requests": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -366,7 +415,7 @@
                   "description": "Template for Cruise Control API `Service`.",
                   "properties": {
                     "ipFamilies": {
-                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                       "items": {
                         "enum": [
                           "IPv4",
@@ -377,7 +426,7 @@
                       "type": "array"
                     },
                     "ipFamilyPolicy": {
-                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                       "enum": [
                         "SingleStack",
                         "PreferDualStack",
@@ -389,14 +438,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -528,18 +581,30 @@
                 "deployment": {
                   "description": "Template for Cruise Control `Deployment`.",
                   "properties": {
+                    "deploymentStrategy": {
+                      "description": "Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.",
+                      "enum": [
+                        "RollingUpdate",
+                        "Recreate"
+                      ],
+                      "type": "string"
+                    },
                     "metadata": {
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -709,12 +774,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -740,8 +819,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -796,12 +877,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -827,8 +922,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -884,12 +981,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -915,8 +1026,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -971,12 +1084,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1002,8 +1129,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1072,21 +1201,25 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "priorityClassName": {
-                      "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                      "description": "The name of the priority class used to assign priority to the pods. ",
                       "type": "string"
                     },
                     "schedulerName": {
@@ -1247,8 +1380,10 @@
                                 "type": "array"
                               },
                               "matchLabels": {
-                                "type": "object",
-                                "x-kubernetes-preserve-unknown-fields": true
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
                               }
                             },
                             "type": "object",
@@ -1300,14 +1435,18 @@
                       "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -1324,14 +1463,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -1552,13 +1695,47 @@
                 "resources": {
                   "description": "CPU and memory resources to reserve.",
                   "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "limits": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     },
                     "requests": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1581,18 +1758,30 @@
                 "deployment": {
                   "description": "Template for Entity Operator `Deployment`.",
                   "properties": {
+                    "deploymentStrategy": {
+                      "description": "Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.",
+                      "enum": [
+                        "RollingUpdate",
+                        "Recreate"
+                      ],
+                      "type": "string"
+                    },
                     "metadata": {
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -1609,14 +1798,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -1786,12 +1979,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -1817,8 +2024,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -1873,12 +2082,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1904,8 +2127,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1961,12 +2186,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -1992,8 +2231,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -2048,12 +2289,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -2079,8 +2334,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -2149,21 +2406,25 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "priorityClassName": {
-                      "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                      "description": "The name of the priority class used to assign priority to the pods. ",
                       "type": "string"
                     },
                     "schedulerName": {
@@ -2324,8 +2585,10 @@
                                 "type": "array"
                               },
                               "matchLabels": {
-                                "type": "object",
-                                "x-kubernetes-preserve-unknown-fields": true
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
                               }
                             },
                             "type": "object",
@@ -2372,14 +2635,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -2634,14 +2901,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -2777,14 +3048,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -2886,13 +3161,47 @@
                 "resources": {
                   "description": "CPU and memory resources to reserve.",
                   "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "limits": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     },
                     "requests": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2913,9 +3222,11 @@
                   "description": "JVM Options for pods.",
                   "properties": {
                     "-XX": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
                       "description": "A map of -XX options to the JVM.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "type": "object"
                     },
                     "-Xms": {
                       "description": "-Xms option to to the JVM.",
@@ -2989,9 +3300,11 @@
                   "description": "Logging configuration.",
                   "properties": {
                     "loggers": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
                       "description": "A Map from logger name to logger level.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "type": "object"
                     },
                     "type": {
                       "description": "Logging type, must be either 'inline' or 'external'.",
@@ -3071,13 +3384,47 @@
                 "resources": {
                   "description": "CPU and memory resources to reserve.",
                   "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "limits": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     },
                     "requests": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -3144,9 +3491,11 @@
                   "description": "JVM Options for pods.",
                   "properties": {
                     "-XX": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
                       "description": "A map of -XX options to the JVM.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "type": "object"
                     },
                     "-Xms": {
                       "description": "-Xms option to to the JVM.",
@@ -3220,9 +3569,11 @@
                   "description": "Logging configuration.",
                   "properties": {
                     "loggers": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
                       "description": "A Map from logger name to logger level.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "type": "object"
                     },
                     "type": {
                       "description": "Logging type, must be either 'inline' or 'external'.",
@@ -3302,13 +3653,47 @@
                 "resources": {
                   "description": "CPU and memory resources to reserve.",
                   "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "limits": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     },
                     "requests": {
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -3336,7 +3721,7 @@
           "additionalProperties": false
         },
         "jmxTrans": {
-          "description": "Configuration for JmxTrans. When the property is present a JmxTrans deployment is created for gathering JMX metrics from each Kafka broker. For more information see https://github.com/jmxtrans/jmxtrans[JmxTrans GitHub].",
+          "description": "As of Strimzi 0.35.0, JMXTrans is not supported anymore and this option is ignored.",
           "properties": {
             "image": {
               "description": "The image to use for the JmxTrans.",
@@ -3423,13 +3808,47 @@
             "resources": {
               "description": "CPU and memory resources to reserve.",
               "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "limits": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 },
                 "requests": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -3560,18 +3979,30 @@
                 "deployment": {
                   "description": "Template for JmxTrans `Deployment`.",
                   "properties": {
+                    "deploymentStrategy": {
+                      "description": "Pod replacement strategy for deployment configuration changes. Valid values are `RollingUpdate` and `Recreate`. Defaults to `RollingUpdate`.",
+                      "enum": [
+                        "RollingUpdate",
+                        "Recreate"
+                      ],
+                      "type": "string"
+                    },
                     "metadata": {
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -3741,12 +4172,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -3772,8 +4217,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -3828,12 +4275,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -3859,8 +4320,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -3916,12 +4379,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -3947,8 +4424,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -4003,12 +4482,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -4034,8 +4527,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -4104,21 +4599,25 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "priorityClassName": {
-                      "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                      "description": "The name of the priority class used to assign priority to the pods. ",
                       "type": "string"
                     },
                     "schedulerName": {
@@ -4279,8 +4778,10 @@
                                 "type": "array"
                               },
                               "matchLabels": {
-                                "type": "object",
-                                "x-kubernetes-preserve-unknown-fields": true
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
                               }
                             },
                             "type": "object",
@@ -4327,14 +4828,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -4388,11 +4893,25 @@
                   "type": "boolean"
                 },
                 "enableMetrics": {
-                  "description": "Enable or disable OAuth metrics. Default value is `false`.",
+                  "description": "Enable or disable OAuth metrics. The default value is `false`.",
                   "type": "boolean"
                 },
                 "expireAfterMs": {
                   "description": "The expiration of the records kept in the local cache to avoid querying the Open Policy Agent for every request. Defines how often the cached authorization decisions are reloaded from the Open Policy Agent server. In milliseconds. Defaults to `3600000`.",
+                  "type": "integer"
+                },
+                "grantsAlwaysLatest": {
+                  "description": "Controls whether the latest grants are fetched for a new session. When enabled, grants are retrieved from Keycloak and cached for the user. The default value is `false`.",
+                  "type": "boolean"
+                },
+                "grantsGcPeriodSeconds": {
+                  "description": "The time, in seconds, between consecutive runs of a job that cleans stale grants from the cache. The default value is 300.",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "grantsMaxIdleTimeSeconds": {
+                  "description": "The time, in seconds, after which an idle grant can be evicted from the cache. The default value is 300.",
+                  "minimum": 1,
                   "type": "integer"
                 },
                 "grantsRefreshPeriodSeconds": {
@@ -4404,6 +4923,15 @@
                   "description": "The number of threads to use to refresh grants for active sessions. The more threads, the more parallelism, so the sooner the job completes. However, using more threads places a heavier load on the authorization server. The default value is 5.",
                   "minimum": 1,
                   "type": "integer"
+                },
+                "httpRetries": {
+                  "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "includeAcceptHeader": {
+                  "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+                  "type": "boolean"
                 },
                 "initialCacheCapacity": {
                   "description": "Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.",
@@ -4443,8 +4971,8 @@
                       }
                     },
                     "required": [
-                      "certificate",
-                      "secretName"
+                      "secretName",
+                      "certificate"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -4456,7 +4984,7 @@
                   "type": "string"
                 },
                 "type": {
-                  "description": "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization.",
+                  "description": "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization.",
                   "enum": [
                     "simple",
                     "opa",
@@ -4482,12 +5010,12 @@
               "type": "string"
             },
             "config": {
-              "description": "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers,node.id, process.roles, controller. (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size,ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas,controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms).",
+              "description": "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms).",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "The docker image for the pods. The default value depends on the configured `Kafka.spec.kafka.version`.",
+              "description": "The container image used for Kafka pods. If the property is not set, the default Kafka image version is determined based on the `version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration. Changing the Kafka image version does not automatically update the image versions for other components, such as Kafka Exporter. ",
               "type": "string"
             },
             "jmxOptions": {
@@ -4518,9 +5046,11 @@
               "description": "JVM Options for pods.",
               "properties": {
                 "-XX": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "A map of -XX options to the JVM.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "-Xms": {
                   "description": "-Xms option to to the JVM.",
@@ -4660,6 +5190,18 @@
                         "description": "A delimiter used to parse groups when they are extracted as a single String value rather than a JSON array. Default value is ',' (comma).",
                         "type": "string"
                       },
+                      "httpRetries": {
+                        "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+                        "type": "integer"
+                      },
+                      "httpRetryPauseMs": {
+                        "description": "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.",
+                        "type": "integer"
+                      },
+                      "includeAcceptHeader": {
+                        "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+                        "type": "boolean"
+                      },
                       "introspectionEndpointUri": {
                         "description": "URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.",
                         "type": "string"
@@ -4740,8 +5282,8 @@
                             }
                           },
                           "required": [
-                            "certificate",
-                            "secretName"
+                            "secretName",
+                            "certificate"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -4799,18 +5341,29 @@
                             "type": "array"
                           },
                           "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
                             "description": "Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.",
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "type": "object"
+                          },
+                          "externalIPs": {
+                            "description": "External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This field is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. This field can only be used with `nodeport` type listener.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
                           },
                           "host": {
                             "description": "The bootstrap host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.",
                             "type": "string"
                           },
                           "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
                             "description": "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.",
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "type": "object"
                           },
                           "loadBalancerIP": {
                             "description": "The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.",
@@ -4841,9 +5394,9 @@
                           }
                         },
                         "required": [
-                          "certificate",
                           "key",
-                          "secretName"
+                          "secretName",
+                          "certificate"
                         ],
                         "type": "object",
                         "additionalProperties": false
@@ -4853,30 +5406,41 @@
                         "items": {
                           "properties": {
                             "advertisedHost": {
-                              "description": "The host name which will be used in the brokers' `advertised.brokers`.",
+                              "description": "The host name used in the brokers' `advertised.listeners`.",
                               "type": "string"
                             },
                             "advertisedPort": {
-                              "description": "The port number which will be used in the brokers' `advertised.brokers`.",
+                              "description": "The port number used in the brokers' `advertised.listeners`.",
                               "type": "integer"
                             },
                             "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
                               "description": "Annotations that will be added to the `Ingress` or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, or `ingress` type listeners.",
-                              "type": "object",
-                              "x-kubernetes-preserve-unknown-fields": true
+                              "type": "object"
                             },
                             "broker": {
                               "description": "ID of the kafka broker (broker identifier). Broker IDs start from 0 and correspond to the number of broker replicas.",
                               "type": "integer"
+                            },
+                            "externalIPs": {
+                              "description": "External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This field is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. This field can only be used with `nodeport` type listener.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
                             },
                             "host": {
                               "description": "The broker host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.",
                               "type": "string"
                             },
                             "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
                               "description": "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners.",
-                              "type": "object",
-                              "x-kubernetes-preserve-unknown-fields": true
+                              "type": "object"
                             },
                             "loadBalancerIP": {
                               "description": "The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.",
@@ -4919,7 +5483,7 @@
                         "type": "array"
                       },
                       "ipFamilies": {
-                        "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                        "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                         "items": {
                           "enum": [
                             "IPv4",
@@ -4930,7 +5494,7 @@
                         "type": "array"
                       },
                       "ipFamilyPolicy": {
-                        "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                        "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                         "enum": [
                           "SingleStack",
                           "PreferDualStack",
@@ -5020,8 +5584,10 @@
                               "type": "array"
                             },
                             "matchLabels": {
-                              "type": "object",
-                              "x-kubernetes-preserve-unknown-fields": true
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -5051,8 +5617,10 @@
                               "type": "array"
                             },
                             "matchLabels": {
-                              "type": "object",
-                              "x-kubernetes-preserve-unknown-fields": true
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -5074,7 +5642,7 @@
                     "type": "boolean"
                   },
                   "type": {
-                    "description": "Type of the listener. Currently the supported types are `internal`, `route`, `loadbalancer`, `nodeport` and `ingress`. \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka with TLS passthrough.\n* `cluster-ip` type uses a per-broker `ClusterIP` service.\n",
+                    "description": "Type of the listener. The supported types are as follows: \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka with TLS passthrough.\n* `cluster-ip` type uses a per-broker `ClusterIP` service.\n",
                     "enum": [
                       "internal",
                       "route",
@@ -5134,9 +5702,11 @@
               "description": "Logging configuration for Kafka.",
               "properties": {
                 "loggers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "A Map from logger name to logger level.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "type": {
                   "description": "Logging type, must be either 'inline' or 'external'.",
@@ -5176,6 +5746,10 @@
               "type": "object",
               "additionalProperties": false
             },
+            "metadataVersion": {
+              "description": "The KRaft metadata version used by the Kafka cluster. This property is ignored when running in ZooKeeper mode. If the property is not set, it defaults to the metadata version that corresponds to the `version` property.",
+              "type": "string"
+            },
             "metricsConfig": {
               "description": "Metrics configuration.",
               "properties": {
@@ -5187,7 +5761,7 @@
                   "type": "string"
                 },
                 "valueFrom": {
-                  "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.",
+                  "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. ",
                   "properties": {
                     "configMapKeyRef": {
                       "description": "Reference to the key in the ConfigMap containing the configuration.",
@@ -5221,7 +5795,7 @@
               "description": "Configuration of the `broker.rack` broker config.",
               "properties": {
                 "topologyKey": {
-                  "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0.",
+                  "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.",
                   "example": "topology.kubernetes.io/zone",
                   "type": "string"
                 }
@@ -5265,27 +5839,61 @@
               "additionalProperties": false
             },
             "replicas": {
-              "description": "The number of pods in the cluster.",
+              "description": "The number of pods in the cluster. This property is required when node pools are not used.",
               "minimum": 1,
               "type": "integer"
             },
             "resources": {
               "description": "CPU and memory resources to reserve.",
               "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "limits": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 },
                 "requests": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
             "storage": {
-              "description": "Storage configuration (disk). Cannot be updated.",
+              "description": "Storage configuration (disk). Cannot be updated. This property is required when node pools are not used.",
               "properties": {
                 "class": {
                   "description": "The storage class to use for dynamic volume allocation.",
@@ -5299,6 +5907,13 @@
                   "description": "Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.",
                   "minimum": 0,
                   "type": "integer"
+                },
+                "kraftMetadata": {
+                  "description": "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set.",
+                  "enum": [
+                    "shared"
+                  ],
+                  "type": "string"
                 },
                 "overrides": {
                   "description": "Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.",
@@ -5319,12 +5934,14 @@
                   "type": "array"
                 },
                 "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "size": {
-                  "description": "When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.",
+                  "description": "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`.",
                   "type": "string"
                 },
                 "sizeLimit": {
@@ -5354,9 +5971,16 @@
                         "type": "boolean"
                       },
                       "id": {
-                        "description": "Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.",
+                        "description": "Storage identification number. Mandatory for storage volumes defined with a `jbod` storage type configuration.",
                         "minimum": 0,
                         "type": "integer"
+                      },
+                      "kraftMetadata": {
+                        "description": "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set.",
+                        "enum": [
+                          "shared"
+                        ],
+                        "type": "string"
                       },
                       "overrides": {
                         "description": "Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.",
@@ -5377,12 +6001,14 @@
                         "type": "array"
                       },
                       "selector": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
                         "description": "Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.",
-                        "type": "object",
-                        "x-kubernetes-preserve-unknown-fields": true
+                        "type": "object"
                       },
                       "size": {
-                        "description": "When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.",
+                        "description": "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`.",
                         "type": "string"
                       },
                       "sizeLimit": {
@@ -5415,13 +6041,13 @@
               "additionalProperties": false
             },
             "template": {
-              "description": "Template for Kafka cluster resources. The template allows users to specify how the `StatefulSet`, `Pods`, and `Services` are generated.",
+              "description": "Template for Kafka cluster resources. The template allows users to specify how the Kubernetes resources are generated.",
               "properties": {
                 "bootstrapService": {
                   "description": "Template for Kafka bootstrap `Service`.",
                   "properties": {
                     "ipFamilies": {
-                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                       "items": {
                         "enum": [
                           "IPv4",
@@ -5432,7 +6058,7 @@
                       "type": "array"
                     },
                     "ipFamilyPolicy": {
-                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                       "enum": [
                         "SingleStack",
                         "PreferDualStack",
@@ -5444,14 +6070,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5465,7 +6095,7 @@
                   "description": "Template for Kafka broker `Service`.",
                   "properties": {
                     "ipFamilies": {
-                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                       "items": {
                         "enum": [
                           "IPv4",
@@ -5476,7 +6106,7 @@
                       "type": "array"
                     },
                     "ipFamilyPolicy": {
-                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                       "enum": [
                         "SingleStack",
                         "PreferDualStack",
@@ -5488,14 +6118,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5512,14 +6146,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5536,14 +6174,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5560,14 +6202,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5584,14 +6230,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5608,14 +6258,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5751,14 +6405,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5894,14 +6552,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5918,14 +6580,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5942,14 +6608,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -5966,14 +6636,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -6143,12 +6817,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -6174,8 +6862,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -6230,12 +6920,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -6261,8 +6965,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -6318,12 +7024,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -6349,8 +7069,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -6405,12 +7127,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -6436,8 +7172,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -6506,21 +7244,25 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "priorityClassName": {
-                      "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                      "description": "The name of the priority class used to assign priority to the pods. ",
                       "type": "string"
                     },
                     "schedulerName": {
@@ -6681,8 +7423,10 @@
                                 "type": "array"
                               },
                               "matchLabels": {
-                                "type": "object",
-                                "x-kubernetes-preserve-unknown-fields": true
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
                               }
                             },
                             "type": "object",
@@ -6734,14 +7478,18 @@
                       "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -6758,14 +7506,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -6782,14 +7534,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -6806,14 +7562,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -6835,15 +7595,52 @@
               "type": "object",
               "additionalProperties": false
             },
+            "tieredStorage": {
+              "description": "Configure the tiered storage feature for Kafka brokers.",
+              "properties": {
+                "remoteStorageManager": {
+                  "description": "Configuration for the Remote Storage Manager.",
+                  "properties": {
+                    "className": {
+                      "description": "The class name for the `RemoteStorageManager` implementation.",
+                      "type": "string"
+                    },
+                    "classPath": {
+                      "description": "The class path for the `RemoteStorageManager` implementation.",
+                      "type": "string"
+                    },
+                    "config": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "The additional configuration map for the `RemoteStorageManager` implementation. Keys will be automatically prefixed with `rsm.config.`, and added to Kafka broker configuration.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "Storage type, only 'custom' is supported at the moment.",
+                  "enum": [
+                    "custom"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "version": {
-              "description": "The kafka broker version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.",
+              "description": "The Kafka broker version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.",
               "type": "string"
             }
           },
           "required": [
-            "replicas",
-            "listeners",
-            "storage"
+            "listeners"
           ],
           "type": "object",
           "additionalProperties": false
@@ -6855,12 +7652,16 @@
               "description": "Enable Sarama logging, a Go client library used by the Kafka Exporter.",
               "type": "boolean"
             },
+            "groupExcludeRegex": {
+              "description": "Regular expression to specify which consumer groups to exclude.",
+              "type": "string"
+            },
             "groupRegex": {
               "description": "Regular expression to specify which consumer groups to collect. Default value is `.*`.",
               "type": "string"
             },
             "image": {
-              "description": "The docker image for the pods.",
+              "description": "The container image used for the Kafka Exporter pods. If no image name is explicitly specified, the image name corresponds to the version specified in the Cluster Operator configuration. If an image name is not defined in the Cluster Operator configuration, a default value is used.",
               "type": "string"
             },
             "livenessProbe": {
@@ -6934,17 +7735,55 @@
             "resources": {
               "description": "CPU and memory resources to reserve.",
               "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "limits": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 },
                 "requests": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "showAllOffsets": {
+              "description": "Whether show the offset/lag for all consumer group, otherwise, only show connected consumer groups.",
+              "type": "boolean"
             },
             "template": {
               "description": "Customization of deployment templates and pods.",
@@ -7083,14 +7922,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -7260,12 +8103,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -7291,8 +8148,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -7347,12 +8206,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -7378,8 +8251,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -7435,12 +8310,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -7466,8 +8355,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -7522,12 +8413,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -7553,8 +8458,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -7623,21 +8530,25 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "priorityClassName": {
-                      "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                      "description": "The name of the priority class used to assign priority to the pods. ",
                       "type": "string"
                     },
                     "schedulerName": {
@@ -7798,8 +8709,10 @@
                                 "type": "array"
                               },
                               "matchLabels": {
-                                "type": "object",
-                                "x-kubernetes-preserve-unknown-fields": true
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
                               }
                             },
                             "type": "object",
@@ -7846,14 +8759,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -7870,14 +8787,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -7890,6 +8811,10 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "topicExcludeRegex": {
+              "description": "Regular expression to specify which topics to exclude.",
+              "type": "string"
             },
             "topicRegex": {
               "description": "Regular expression to specify which topics to collect. Default value is `.*`.",
@@ -7907,7 +8832,7 @@
           "type": "array"
         },
         "zookeeper": {
-          "description": "Configuration of the ZooKeeper cluster.",
+          "description": "Configuration of the ZooKeeper cluster. This section is required when running a ZooKeeper-based Apache Kafka cluster.",
           "properties": {
             "config": {
               "description": "The ZooKeeper broker config. Properties with the following prefixes cannot be set: server., dataDir, dataLogDir, clientPort, authProvider, quorum.auth, requireClientAuthScheme, snapshot.trust.empty, standaloneEnabled, reconfigEnabled, 4lw.commands.whitelist, secureClientPort, ssl., serverCnxnFactory, sslQuorum (with the exception of: ssl.protocol, ssl.quorum.protocol, ssl.enabledProtocols, ssl.quorum.enabledProtocols, ssl.ciphersuites, ssl.quorum.ciphersuites, ssl.hostnameVerification, ssl.quorum.hostnameVerification).",
@@ -7915,7 +8840,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "The docker image for the pods.",
+              "description": "The container image used for ZooKeeper pods. If no image name is explicitly specified, it is determined based on the Kafka version set in `spec.kafka.version`. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration.",
               "type": "string"
             },
             "jmxOptions": {
@@ -7946,9 +8871,11 @@
               "description": "JVM Options for pods.",
               "properties": {
                 "-XX": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "A map of -XX options to the JVM.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "-Xms": {
                   "description": "-Xms option to to the JVM.",
@@ -8022,9 +8949,11 @@
               "description": "Logging configuration for ZooKeeper.",
               "properties": {
                 "loggers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "A Map from logger name to logger level.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "type": {
                   "description": "Logging type, must be either 'inline' or 'external'.",
@@ -8075,7 +9004,7 @@
                   "type": "string"
                 },
                 "valueFrom": {
-                  "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.",
+                  "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. ",
                   "properties": {
                     "configMapKeyRef": {
                       "description": "Reference to the key in the ConfigMap containing the configuration.",
@@ -8145,13 +9074,47 @@
             "resources": {
               "description": "CPU and memory resources to reserve.",
               "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "limits": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 },
                 "requests": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -8169,9 +9132,16 @@
                   "type": "boolean"
                 },
                 "id": {
-                  "description": "Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.",
+                  "description": "Storage identification number. Mandatory for storage volumes defined with a `jbod` storage type configuration.",
                   "minimum": 0,
                   "type": "integer"
+                },
+                "kraftMetadata": {
+                  "description": "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set.",
+                  "enum": [
+                    "shared"
+                  ],
+                  "type": "string"
                 },
                 "overrides": {
                   "description": "Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.",
@@ -8192,12 +9162,14 @@
                   "type": "array"
                 },
                 "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "description": "Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "type": "object"
                 },
                 "size": {
-                  "description": "When type=persistent-claim, defines the size of the persistent volume claim (i.e 1Gi). Mandatory when type=persistent-claim.",
+                  "description": "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`.",
                   "type": "string"
                 },
                 "sizeLimit": {
@@ -8221,13 +9193,13 @@
               "additionalProperties": false
             },
             "template": {
-              "description": "Template for ZooKeeper cluster resources. The template allows users to specify how the `StatefulSet`, `Pods`, and `Services` are generated.",
+              "description": "Template for ZooKeeper cluster resources. The template allows users to specify how the Kubernetes resources are generated.",
               "properties": {
                 "clientService": {
                   "description": "Template for ZooKeeper client `Service`.",
                   "properties": {
                     "ipFamilies": {
-                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                       "items": {
                         "enum": [
                           "IPv4",
@@ -8238,7 +9210,7 @@
                       "type": "array"
                     },
                     "ipFamilyPolicy": {
-                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                       "enum": [
                         "SingleStack",
                         "PreferDualStack",
@@ -8250,14 +9222,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -8274,14 +9250,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -8295,7 +9275,7 @@
                   "description": "Template for ZooKeeper nodes `Service`.",
                   "properties": {
                     "ipFamilies": {
-                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                       "items": {
                         "enum": [
                           "IPv4",
@@ -8306,7 +9286,7 @@
                       "type": "array"
                     },
                     "ipFamilyPolicy": {
-                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                      "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                       "enum": [
                         "SingleStack",
                         "PreferDualStack",
@@ -8318,14 +9298,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -8342,14 +9326,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -8519,12 +9507,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -8550,8 +9552,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -8606,12 +9610,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -8637,8 +9655,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -8694,12 +9714,26 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
                                       },
                                       "namespaceSelector": {
                                         "properties": {
@@ -8725,8 +9759,10 @@
                                             "type": "array"
                                           },
                                           "matchLabels": {
-                                            "type": "object",
-                                            "x-kubernetes-preserve-unknown-fields": true
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
                                           }
                                         },
                                         "type": "object",
@@ -8781,12 +9817,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -8812,8 +9862,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -8882,21 +9934,25 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "priorityClassName": {
-                      "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                      "description": "The name of the priority class used to assign priority to the pods. ",
                       "type": "string"
                     },
                     "schedulerName": {
@@ -9057,8 +10113,10 @@
                                 "type": "array"
                               },
                               "matchLabels": {
-                                "type": "object",
-                                "x-kubernetes-preserve-unknown-fields": true
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
                               }
                             },
                             "type": "object",
@@ -9110,14 +10168,18 @@
                       "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -9134,14 +10196,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -9158,14 +10224,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -9182,14 +10252,18 @@
                       "description": "Metadata applied to the resource.",
                       "properties": {
                         "annotations": {
-                          "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations added to the Kubernetes resource.",
+                          "type": "object"
                         },
                         "labels": {
-                          "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                          "type": "object",
-                          "x-kubernetes-preserve-unknown-fields": true
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels added to the Kubernetes resource.",
+                          "type": "object"
                         }
                       },
                       "type": "object",
@@ -9340,8 +10414,7 @@
         }
       },
       "required": [
-        "kafka",
-        "zookeeper"
+        "kafka"
       ],
       "type": "object",
       "additionalProperties": false
@@ -9383,6 +10456,40 @@
           },
           "type": "array"
         },
+        "kafkaMetadataState": {
+          "description": "Defines where cluster metadata are stored. Possible values are: ZooKeeper if the metadata are stored in ZooKeeper; KRaftMigration if the controllers are connected to ZooKeeper, brokers are being rolled with Zookeeper migration enabled and connection information to controllers, and the metadata migration process is running; KRaftDualWriting if the metadata migration process finished and the cluster is in dual-write mode; KRaftPostMigration if the brokers are fully KRaft-based but controllers being rolled to disconnect from ZooKeeper; PreKRaft if brokers and controller are fully KRaft-based, metadata are stored in KRaft, but ZooKeeper must be deleted; KRaft if the metadata are stored in KRaft.",
+          "enum": [
+            "ZooKeeper",
+            "KRaftMigration",
+            "KRaftDualWriting",
+            "KRaftPostMigration",
+            "PreKRaft",
+            "KRaft"
+          ],
+          "type": "string"
+        },
+        "kafkaMetadataVersion": {
+          "description": "The KRaft metadata.version currently used by the Kafka cluster.",
+          "type": "string"
+        },
+        "kafkaNodePools": {
+          "description": "List of the KafkaNodePools used by this Kafka cluster.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "The name of the KafkaNodePool used by this Kafka resource.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kafkaVersion": {
+          "description": "The version of Kafka currently deployed in the cluster.",
+          "type": "string"
+        },
         "listeners": {
           "description": "Addresses of the internal and external listeners.",
           "items": {
@@ -9421,7 +10528,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener.",
+                "description": "The name of the listener.",
                 "type": "string"
               }
             },
@@ -9433,6 +10540,10 @@
         "observedGeneration": {
           "description": "The generation of the CRD that was last reconciled by the operator.",
           "type": "integer"
+        },
+        "operatorLastSuccessfulVersion": {
+          "description": "The version of the Strimzi Cluster Operator which performed the last successful reconciliation.",
+          "type": "string"
         }
       },
       "type": "object",

--- a/kafka.strimzi.io/kafkabridge_v1beta2.json
+++ b/kafka.strimzi.io/kafkabridge_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the Kafka Bridge.",
       "properties": {
@@ -62,9 +73,9 @@
                 }
               },
               "required": [
-                "certificate",
                 "key",
-                "secretName"
+                "secretName",
+                "certificate"
               ],
               "type": "object",
               "additionalProperties": false
@@ -104,6 +115,18 @@
               "description": "Enable or disable OAuth metrics. Default value is `false`.",
               "type": "boolean"
             },
+            "httpRetries": {
+              "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+              "type": "integer"
+            },
+            "httpRetryPauseMs": {
+              "description": "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.",
+              "type": "integer"
+            },
+            "includeAcceptHeader": {
+              "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+              "type": "boolean"
+            },
             "maxTokenExpirySeconds": {
               "description": "Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.",
               "type": "integer"
@@ -121,8 +144,8 @@
                 }
               },
               "required": [
-                "password",
-                "secretName"
+                "secretName",
+                "password"
               ],
               "type": "object",
               "additionalProperties": false
@@ -168,8 +191,8 @@
                   }
                 },
                 "required": [
-                  "certificate",
-                  "secretName"
+                  "secretName",
+                  "certificate"
                 ],
                 "type": "object",
                 "additionalProperties": false
@@ -264,16 +287,18 @@
           "additionalProperties": false
         },
         "image": {
-          "description": "The docker image for the pods.",
+          "description": "The container image used for Kafka Bridge pods. If no image name is explicitly specified, the image name corresponds to the image specified in the Cluster Operator configuration. If an image name is not defined in the Cluster Operator configuration, a default value is used.",
           "type": "string"
         },
         "jvmOptions": {
           "description": "**Currently not supported** JVM Options for pods.",
           "properties": {
             "-XX": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A map of -XX options to the JVM.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "-Xms": {
               "description": "-Xms option to to the JVM.",
@@ -347,9 +372,11 @@
           "description": "Logging configuration for Kafka Bridge.",
           "properties": {
             "loggers": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A Map from logger name to logger level.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "type": {
               "description": "Logging type, must be either 'inline' or 'external'.",
@@ -405,7 +432,7 @@
           "description": "Configuration of the node label which will be used as the client.rack consumer configuration.",
           "properties": {
             "topologyKey": {
-              "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0.",
+              "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.",
               "example": "topology.kubernetes.io/zone",
               "type": "string"
             }
@@ -449,20 +476,54 @@
           "additionalProperties": false
         },
         "replicas": {
-          "description": "The number of pods in the `Deployment`.",
+          "description": "The number of pods in the `Deployment`.  Defaults to `1`.",
           "minimum": 0,
           "type": "integer"
         },
         "resources": {
           "description": "CPU and memory resources to reserve.",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "limits": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             },
             "requests": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             }
           },
           "type": "object",
@@ -475,7 +536,7 @@
               "description": "Template for Kafka Bridge API `Service`.",
               "properties": {
                 "ipFamilies": {
-                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                   "items": {
                     "enum": [
                       "IPv4",
@@ -486,7 +547,7 @@
                   "type": "array"
                 },
                 "ipFamilyPolicy": {
-                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                   "enum": [
                     "SingleStack",
                     "PreferDualStack",
@@ -498,14 +559,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -641,14 +706,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -673,14 +742,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -969,12 +1042,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1000,8 +1087,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1056,12 +1145,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1087,8 +1190,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1144,12 +1249,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1175,8 +1294,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1231,12 +1352,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1262,8 +1397,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1332,21 +1469,25 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "priorityClassName": {
-                  "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                  "description": "The name of the priority class used to assign priority to the pods. ",
                   "type": "string"
                 },
                 "schedulerName": {
@@ -1507,8 +1648,10 @@
                             "type": "array"
                           },
                           "matchLabels": {
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -1560,14 +1703,18 @@
                   "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1584,14 +1731,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1622,8 +1773,8 @@
                   }
                 },
                 "required": [
-                  "certificate",
-                  "secretName"
+                  "secretName",
+                  "certificate"
                 ],
                 "type": "object",
                 "additionalProperties": false
@@ -1638,7 +1789,7 @@
           "description": "The configuration of tracing in Kafka Bridge.",
           "properties": {
             "type": {
-              "description": "Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.",
+              "description": "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored.",
               "enum": [
                 "jaeger",
                 "opentelemetry"

--- a/kafka.strimzi.io/kafkaconnect_v1beta2.json
+++ b/kafka.strimzi.io/kafkaconnect_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the Kafka Connect cluster.",
       "properties": {
@@ -50,9 +61,9 @@
                 }
               },
               "required": [
-                "certificate",
                 "key",
-                "secretName"
+                "secretName",
+                "certificate"
               ],
               "type": "object",
               "additionalProperties": false
@@ -92,6 +103,18 @@
               "description": "Enable or disable OAuth metrics. Default value is `false`.",
               "type": "boolean"
             },
+            "httpRetries": {
+              "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+              "type": "integer"
+            },
+            "httpRetryPauseMs": {
+              "description": "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.",
+              "type": "integer"
+            },
+            "includeAcceptHeader": {
+              "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+              "type": "boolean"
+            },
             "maxTokenExpirySeconds": {
               "description": "Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.",
               "type": "integer"
@@ -109,8 +132,8 @@
                 }
               },
               "required": [
-                "password",
-                "secretName"
+                "secretName",
+                "password"
               ],
               "type": "object",
               "additionalProperties": false
@@ -156,8 +179,8 @@
                   }
                 },
                 "required": [
-                  "certificate",
-                  "secretName"
+                  "secretName",
+                  "certificate"
                 ],
                 "type": "object",
                 "additionalProperties": false
@@ -310,13 +333,47 @@
             "resources": {
               "description": "CPU and memory resources to reserve for the build.",
               "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "limits": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 },
                 "requests": {
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -489,7 +546,7 @@
           "additionalProperties": false
         },
         "image": {
-          "description": "The docker image for the pods.",
+          "description": "The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration.",
           "type": "string"
         },
         "jmxOptions": {
@@ -520,9 +577,11 @@
           "description": "JVM Options for pods.",
           "properties": {
             "-XX": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A map of -XX options to the JVM.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "-Xms": {
               "description": "-Xms option to to the JVM.",
@@ -596,9 +655,11 @@
           "description": "Logging configuration for Kafka Connect.",
           "properties": {
             "loggers": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A Map from logger name to logger level.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "type": {
               "description": "Logging type, must be either 'inline' or 'external'.",
@@ -649,7 +710,7 @@
               "type": "string"
             },
             "valueFrom": {
-              "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.",
+              "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. ",
               "properties": {
                 "configMapKeyRef": {
                   "description": "Reference to the key in the ConfigMap containing the configuration.",
@@ -683,7 +744,7 @@
           "description": "Configuration of the node label which will be used as the `client.rack` consumer configuration.",
           "properties": {
             "topologyKey": {
-              "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0.",
+              "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.",
               "example": "topology.kubernetes.io/zone",
               "type": "string"
             }
@@ -727,32 +788,66 @@
           "additionalProperties": false
         },
         "replicas": {
-          "description": "The number of pods in the Kafka Connect group.",
+          "description": "The number of pods in the Kafka Connect group. Defaults to `3`.",
           "type": "integer"
         },
         "resources": {
           "description": "The maximum limits for CPU and memory resources and the requested initial resources.",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "limits": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             },
             "requests": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "template": {
-          "description": "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.",
+          "description": "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.",
           "properties": {
             "apiService": {
               "description": "Template for Kafka Connect API `Service`.",
               "properties": {
                 "ipFamilies": {
-                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                   "items": {
                     "enum": [
                       "IPv4",
@@ -763,7 +858,7 @@
                   "type": "array"
                 },
                 "ipFamilyPolicy": {
-                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                   "enum": [
                     "SingleStack",
                     "PreferDualStack",
@@ -775,14 +870,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -799,14 +898,18 @@
                   "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1099,12 +1202,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1130,8 +1247,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1186,12 +1305,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1217,8 +1350,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1274,12 +1409,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1305,8 +1454,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1361,12 +1512,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1392,8 +1557,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1462,21 +1629,25 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "priorityClassName": {
-                  "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                  "description": "The name of the priority class used to assign priority to the pods. ",
                   "type": "string"
                 },
                 "schedulerName": {
@@ -1637,8 +1808,10 @@
                             "type": "array"
                           },
                           "matchLabels": {
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -1685,14 +1858,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1709,14 +1886,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1860,14 +2041,66 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "headlessService": {
+              "description": "Template for Kafka Connect headless `Service`.",
+              "properties": {
+                "ipFamilies": {
+                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
+                  "items": {
+                    "enum": [
+                      "IPv4",
+                      "IPv6"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
+                  "enum": [
+                    "SingleStack",
+                    "PreferDualStack",
+                    "RequireDualStack"
+                  ],
+                  "type": "string"
+                },
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2003,14 +2236,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2180,12 +2417,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -2211,8 +2462,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -2267,12 +2520,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2298,8 +2565,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -2355,12 +2624,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -2386,8 +2669,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -2442,12 +2727,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2473,8 +2772,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -2543,21 +2844,25 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "priorityClassName": {
-                  "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                  "description": "The name of the priority class used to assign priority to the pods. ",
                   "type": "string"
                 },
                 "schedulerName": {
@@ -2718,8 +3023,10 @@
                             "type": "array"
                           },
                           "matchLabels": {
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -2771,14 +3078,46 @@
                   "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podSet": {
+              "description": "Template for Kafka Connect `StrimziPodSet` resource.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2795,14 +3134,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2833,8 +3176,8 @@
                   }
                 },
                 "required": [
-                  "certificate",
-                  "secretName"
+                  "secretName",
+                  "certificate"
                 ],
                 "type": "object",
                 "additionalProperties": false
@@ -2849,7 +3192,7 @@
           "description": "The configuration of tracing in Kafka Connect.",
           "properties": {
             "type": {
-              "description": "Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.",
+              "description": "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored.",
               "enum": [
                 "jaeger",
                 "opentelemetry"
@@ -2864,7 +3207,7 @@
           "additionalProperties": false
         },
         "version": {
-          "description": "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.",
+          "description": "The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.",
           "type": "string"
         }
       },

--- a/kafka.strimzi.io/kafkaconnector_v1beta2.json
+++ b/kafka.strimzi.io/kafkaconnector_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the Kafka Connector.",
       "properties": {
@@ -11,7 +22,7 @@
               "type": "boolean"
             },
             "maxRestarts": {
-              "description": "The maximum number of restart attempts when a connector or task fails.",
+              "description": "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts.",
               "type": "integer"
             }
           },
@@ -30,6 +41,15 @@
         "pause": {
           "description": "Whether the connector should be paused. Defaults to false.",
           "type": "boolean"
+        },
+        "state": {
+          "description": "The state the connector should be in. Defaults to running.",
+          "enum": [
+            "paused",
+            "stopped",
+            "running"
+          ],
+          "type": "string"
         },
         "tasksMax": {
           "description": "The maximum number of tasks for the Kafka Connector.",

--- a/kafka.strimzi.io/kafkamirrormaker2_v1beta2.json
+++ b/kafka.strimzi.io/kafkamirrormaker2_v1beta2.json
@@ -1,7 +1,18 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
-      "description": "The specification of the Kafka MirrorMaker 2.0 cluster.",
+      "description": "The specification of the Kafka MirrorMaker 2 cluster.",
       "properties": {
         "clientRackInitImage": {
           "description": "The image of the init container used for initializing the `client.rack`.",
@@ -63,9 +74,9 @@
                       }
                     },
                     "required": [
-                      "certificate",
                       "key",
-                      "secretName"
+                      "secretName",
+                      "certificate"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -105,6 +116,18 @@
                     "description": "Enable or disable OAuth metrics. Default value is `false`.",
                     "type": "boolean"
                   },
+                  "httpRetries": {
+                    "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+                    "type": "integer"
+                  },
+                  "httpRetryPauseMs": {
+                    "description": "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.",
+                    "type": "integer"
+                  },
+                  "includeAcceptHeader": {
+                    "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+                    "type": "boolean"
+                  },
                   "maxTokenExpirySeconds": {
                     "description": "Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.",
                     "type": "integer"
@@ -122,8 +145,8 @@
                       }
                     },
                     "required": [
-                      "password",
-                      "secretName"
+                      "secretName",
+                      "password"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -169,8 +192,8 @@
                         }
                       },
                       "required": [
-                        "certificate",
-                        "secretName"
+                        "secretName",
+                        "certificate"
                       ],
                       "type": "object",
                       "additionalProperties": false
@@ -208,12 +231,12 @@
                 "type": "string"
               },
               "config": {
-                "description": "The MirrorMaker 2.0 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).",
+                "description": "The MirrorMaker 2 cluster config. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).",
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "tls": {
-                "description": "TLS configuration for connecting MirrorMaker 2.0 connectors to a cluster.",
+                "description": "TLS configuration for connecting MirrorMaker 2 connectors to a cluster.",
                 "properties": {
                   "trustedCertificates": {
                     "description": "Trusted certificates for TLS connection.",
@@ -229,8 +252,8 @@
                         }
                       },
                       "required": [
-                        "certificate",
-                        "secretName"
+                        "secretName",
+                        "certificate"
                       ],
                       "type": "object",
                       "additionalProperties": false
@@ -252,7 +275,7 @@
           "type": "array"
         },
         "connectCluster": {
-          "description": "The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.",
+          "description": "The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as specified in the `spec.clusters` configuration. The target Kafka cluster is used by the underlying Kafka Connect framework for its internal topics.",
           "type": "string"
         },
         "externalConfiguration": {
@@ -405,7 +428,7 @@
           "additionalProperties": false
         },
         "image": {
-          "description": "The docker image for the pods.",
+          "description": "The container image used for Kafka Connect pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration.",
           "type": "string"
         },
         "jmxOptions": {
@@ -436,9 +459,11 @@
           "description": "JVM Options for pods.",
           "properties": {
             "-XX": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A map of -XX options to the JVM.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "-Xms": {
               "description": "-Xms option to to the JVM.",
@@ -512,9 +537,11 @@
           "description": "Logging configuration for Kafka Connect.",
           "properties": {
             "loggers": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A Map from logger name to logger level.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "type": {
               "description": "Logging type, must be either 'inline' or 'external'.",
@@ -565,7 +592,7 @@
               "type": "string"
             },
             "valueFrom": {
-              "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.",
+              "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. ",
               "properties": {
                 "configMapKeyRef": {
                   "description": "Reference to the key in the ConfigMap containing the configuration.",
@@ -596,11 +623,11 @@
           "additionalProperties": false
         },
         "mirrors": {
-          "description": "Configuration of the MirrorMaker 2.0 connectors.",
+          "description": "Configuration of the MirrorMaker 2 connectors.",
           "items": {
             "properties": {
               "checkpointConnector": {
-                "description": "The specification of the Kafka MirrorMaker 2.0 checkpoint connector.",
+                "description": "The specification of the Kafka MirrorMaker 2 checkpoint connector.",
                 "properties": {
                   "autoRestart": {
                     "description": "Automatic restart of connector and tasks configuration.",
@@ -608,6 +635,10 @@
                       "enabled": {
                         "description": "Whether automatic restart for failed connectors and tasks should be enabled or disabled.",
                         "type": "boolean"
+                      },
+                      "maxRestarts": {
+                        "description": "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts.",
+                        "type": "integer"
                       }
                     },
                     "type": "object",
@@ -621,6 +652,15 @@
                   "pause": {
                     "description": "Whether the connector should be paused. Defaults to false.",
                     "type": "boolean"
+                  },
+                  "state": {
+                    "description": "The state the connector should be in. Defaults to running.",
+                    "enum": [
+                      "paused",
+                      "stopped",
+                      "running"
+                    ],
+                    "type": "string"
                   },
                   "tasksMax": {
                     "description": "The maximum number of tasks for the Kafka Connector.",
@@ -644,7 +684,7 @@
                 "type": "string"
               },
               "heartbeatConnector": {
-                "description": "The specification of the Kafka MirrorMaker 2.0 heartbeat connector.",
+                "description": "The specification of the Kafka MirrorMaker 2 heartbeat connector.",
                 "properties": {
                   "autoRestart": {
                     "description": "Automatic restart of connector and tasks configuration.",
@@ -652,6 +692,10 @@
                       "enabled": {
                         "description": "Whether automatic restart for failed connectors and tasks should be enabled or disabled.",
                         "type": "boolean"
+                      },
+                      "maxRestarts": {
+                        "description": "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts.",
+                        "type": "integer"
                       }
                     },
                     "type": "object",
@@ -665,6 +709,15 @@
                   "pause": {
                     "description": "Whether the connector should be paused. Defaults to false.",
                     "type": "boolean"
+                  },
+                  "state": {
+                    "description": "The state the connector should be in. Defaults to running.",
+                    "enum": [
+                      "paused",
+                      "stopped",
+                      "running"
+                    ],
+                    "type": "string"
                   },
                   "tasksMax": {
                     "description": "The maximum number of tasks for the Kafka Connector.",
@@ -676,11 +729,11 @@
                 "additionalProperties": false
               },
               "sourceCluster": {
-                "description": "The alias of the source cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.",
+                "description": "The alias of the source cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.",
                 "type": "string"
               },
               "sourceConnector": {
-                "description": "The specification of the Kafka MirrorMaker 2.0 source connector.",
+                "description": "The specification of the Kafka MirrorMaker 2 source connector.",
                 "properties": {
                   "autoRestart": {
                     "description": "Automatic restart of connector and tasks configuration.",
@@ -688,6 +741,10 @@
                       "enabled": {
                         "description": "Whether automatic restart for failed connectors and tasks should be enabled or disabled.",
                         "type": "boolean"
+                      },
+                      "maxRestarts": {
+                        "description": "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts.",
+                        "type": "integer"
                       }
                     },
                     "type": "object",
@@ -702,6 +759,15 @@
                     "description": "Whether the connector should be paused. Defaults to false.",
                     "type": "boolean"
                   },
+                  "state": {
+                    "description": "The state the connector should be in. Defaults to running.",
+                    "enum": [
+                      "paused",
+                      "stopped",
+                      "running"
+                    ],
+                    "type": "string"
+                  },
                   "tasksMax": {
                     "description": "The maximum number of tasks for the Kafka Connector.",
                     "minimum": 1,
@@ -712,7 +778,7 @@
                 "additionalProperties": false
               },
               "targetCluster": {
-                "description": "The alias of the target cluster used by the Kafka MirrorMaker 2.0 connectors. The alias must match a cluster in the list at `spec.clusters`.",
+                "description": "The alias of the target cluster used by the Kafka MirrorMaker 2 connectors. The alias must match a cluster in the list at `spec.clusters`.",
                 "type": "string"
               },
               "topicsBlacklistPattern": {
@@ -741,7 +807,7 @@
           "description": "Configuration of the node label which will be used as the `client.rack` consumer configuration.",
           "properties": {
             "topologyKey": {
-              "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.0.",
+              "description": "A key that matches labels assigned to the Kubernetes cluster nodes. The value of the label is used to set a broker's `broker.rack` config, and the `client.rack` config for Kafka Connect or MirrorMaker 2.",
               "example": "topology.kubernetes.io/zone",
               "type": "string"
             }
@@ -785,32 +851,66 @@
           "additionalProperties": false
         },
         "replicas": {
-          "description": "The number of pods in the Kafka Connect group.",
+          "description": "The number of pods in the Kafka Connect group. Defaults to `3`.",
           "type": "integer"
         },
         "resources": {
           "description": "The maximum limits for CPU and memory resources and the requested initial resources.",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "limits": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             },
             "requests": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "template": {
-          "description": "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Deployment`, `Pods` and `Service` are generated.",
+          "description": "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated.",
           "properties": {
             "apiService": {
               "description": "Template for Kafka Connect API `Service`.",
               "properties": {
                 "ipFamilies": {
-                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting. Available on Kubernetes 1.20 and newer.",
+                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
                   "items": {
                     "enum": [
                       "IPv4",
@@ -821,7 +921,7 @@
                   "type": "array"
                 },
                 "ipFamilyPolicy": {
-                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type. Available on Kubernetes 1.20 and newer.",
+                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
                   "enum": [
                     "SingleStack",
                     "PreferDualStack",
@@ -833,14 +933,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -857,14 +961,18 @@
                   "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1157,12 +1265,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1188,8 +1310,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1244,12 +1368,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1275,8 +1413,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1332,12 +1472,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1363,8 +1517,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1419,12 +1575,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1450,8 +1620,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1520,21 +1692,25 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "priorityClassName": {
-                  "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                  "description": "The name of the priority class used to assign priority to the pods. ",
                   "type": "string"
                 },
                 "schedulerName": {
@@ -1695,8 +1871,10 @@
                             "type": "array"
                           },
                           "matchLabels": {
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -1743,14 +1921,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1767,14 +1949,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1918,14 +2104,66 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "headlessService": {
+              "description": "Template for Kafka Connect headless `Service`.",
+              "properties": {
+                "ipFamilies": {
+                  "description": "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting.",
+                  "items": {
+                    "enum": [
+                      "IPv4",
+                      "IPv6"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ipFamilyPolicy": {
+                  "description": "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type.",
+                  "enum": [
+                    "SingleStack",
+                    "PreferDualStack",
+                    "RequireDualStack"
+                  ],
+                  "type": "string"
+                },
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2061,14 +2299,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2238,12 +2480,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -2269,8 +2525,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -2325,12 +2583,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2356,8 +2628,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -2413,12 +2687,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -2444,8 +2732,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -2500,12 +2790,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2531,8 +2835,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -2601,21 +2907,25 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "priorityClassName": {
-                  "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                  "description": "The name of the priority class used to assign priority to the pods. ",
                   "type": "string"
                 },
                 "schedulerName": {
@@ -2776,8 +3086,10 @@
                             "type": "array"
                           },
                           "matchLabels": {
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -2829,14 +3141,46 @@
                   "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podSet": {
+              "description": "Template for Kafka Connect `StrimziPodSet` resource.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2853,14 +3197,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -2878,7 +3226,7 @@
           "description": "The configuration of tracing in Kafka Connect.",
           "properties": {
             "type": {
-              "description": "Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.",
+              "description": "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored.",
               "enum": [
                 "jaeger",
                 "opentelemetry"
@@ -2893,7 +3241,7 @@
           "additionalProperties": false
         },
         "version": {
-          "description": "The Kafka Connect version. Defaults to {DefaultKafkaVersion}. Consult the user documentation to understand the process required to upgrade or downgrade the version.",
+          "description": "The Kafka Connect version. Defaults to the latest version. Consult the user documentation to understand the process required to upgrade or downgrade the version.",
           "type": "string"
         }
       },
@@ -2904,10 +3252,10 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "The status of the Kafka MirrorMaker 2.0 cluster.",
+      "description": "The status of the Kafka MirrorMaker 2 cluster.",
       "properties": {
         "autoRestartStatuses": {
-          "description": "List of MirrorMaker 2.0 connector auto restart statuses.",
+          "description": "List of MirrorMaker 2 connector auto restart statuses.",
           "items": {
             "properties": {
               "connectorName": {
@@ -2981,7 +3329,7 @@
           "type": "array"
         },
         "connectors": {
-          "description": "List of MirrorMaker 2.0 connector statuses, as reported by the Kafka Connect REST API.",
+          "description": "List of MirrorMaker 2 connector statuses, as reported by the Kafka Connect REST API.",
           "items": {
             "type": "object",
             "x-kubernetes-preserve-unknown-fields": true

--- a/kafka.strimzi.io/kafkamirrormaker_v1beta2.json
+++ b/kafka.strimzi.io/kafkamirrormaker_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of Kafka MirrorMaker.",
       "oneOf": [
@@ -71,9 +82,9 @@
                     }
                   },
                   "required": [
-                    "certificate",
                     "key",
-                    "secretName"
+                    "secretName",
+                    "certificate"
                   ],
                   "type": "object",
                   "additionalProperties": false
@@ -113,6 +124,18 @@
                   "description": "Enable or disable OAuth metrics. Default value is `false`.",
                   "type": "boolean"
                 },
+                "httpRetries": {
+                  "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+                  "type": "integer"
+                },
+                "httpRetryPauseMs": {
+                  "description": "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.",
+                  "type": "integer"
+                },
+                "includeAcceptHeader": {
+                  "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+                  "type": "boolean"
+                },
                 "maxTokenExpirySeconds": {
                   "description": "Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.",
                   "type": "integer"
@@ -130,8 +153,8 @@
                     }
                   },
                   "required": [
-                    "password",
-                    "secretName"
+                    "secretName",
+                    "password"
                   ],
                   "type": "object",
                   "additionalProperties": false
@@ -177,8 +200,8 @@
                       }
                     },
                     "required": [
-                      "certificate",
-                      "secretName"
+                      "secretName",
+                      "certificate"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -250,8 +273,8 @@
                       }
                     },
                     "required": [
-                      "certificate",
-                      "secretName"
+                      "secretName",
+                      "certificate"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -271,7 +294,7 @@
           "additionalProperties": false
         },
         "image": {
-          "description": "The docker image for the pods.",
+          "description": "The container image used for Kafka MirrorMaker pods. If no image name is explicitly specified, it is determined based on the `spec.version` configuration. The image names are specifically mapped to corresponding versions in the Cluster Operator configuration.",
           "type": "string"
         },
         "include": {
@@ -282,9 +305,11 @@
           "description": "JVM Options for pods.",
           "properties": {
             "-XX": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A map of -XX options to the JVM.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "-Xms": {
               "description": "-Xms option to to the JVM.",
@@ -358,9 +383,11 @@
           "description": "Logging configuration for MirrorMaker.",
           "properties": {
             "loggers": {
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "A Map from logger name to logger level.",
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "type": "object"
             },
             "type": {
               "description": "Logging type, must be either 'inline' or 'external'.",
@@ -411,7 +438,7 @@
               "type": "string"
             },
             "valueFrom": {
-              "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. For details of the structure of this configuration, see the {JMXExporter}.",
+              "description": "ConfigMap entry where the Prometheus JMX Exporter configuration is stored. ",
               "properties": {
                 "configMapKeyRef": {
                   "description": "Reference to the key in the ConfigMap containing the configuration.",
@@ -495,9 +522,9 @@
                     }
                   },
                   "required": [
-                    "certificate",
                     "key",
-                    "secretName"
+                    "secretName",
+                    "certificate"
                   ],
                   "type": "object",
                   "additionalProperties": false
@@ -537,6 +564,18 @@
                   "description": "Enable or disable OAuth metrics. Default value is `false`.",
                   "type": "boolean"
                 },
+                "httpRetries": {
+                  "description": "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries.",
+                  "type": "integer"
+                },
+                "httpRetryPauseMs": {
+                  "description": "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request.",
+                  "type": "integer"
+                },
+                "includeAcceptHeader": {
+                  "description": "Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.",
+                  "type": "boolean"
+                },
                 "maxTokenExpirySeconds": {
                   "description": "Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.",
                   "type": "integer"
@@ -554,8 +593,8 @@
                     }
                   },
                   "required": [
-                    "password",
-                    "secretName"
+                    "secretName",
+                    "password"
                   ],
                   "type": "object",
                   "additionalProperties": false
@@ -601,8 +640,8 @@
                       }
                     },
                     "required": [
-                      "certificate",
-                      "secretName"
+                      "secretName",
+                      "certificate"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -661,8 +700,8 @@
                       }
                     },
                     "required": [
-                      "certificate",
-                      "secretName"
+                      "secretName",
+                      "certificate"
                     ],
                     "type": "object",
                     "additionalProperties": false
@@ -720,13 +759,47 @@
         "resources": {
           "description": "CPU and memory resources to reserve.",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "limits": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             },
             "requests": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
             }
           },
           "type": "object",
@@ -750,14 +823,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1046,12 +1123,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1077,8 +1168,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1133,12 +1226,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1164,8 +1271,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1221,12 +1330,26 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -1252,8 +1375,10 @@
                                         "type": "array"
                                       },
                                       "matchLabels": {
-                                        "type": "object",
-                                        "x-kubernetes-preserve-unknown-fields": true
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
                                       }
                                     },
                                     "type": "object",
@@ -1308,12 +1433,26 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -1339,8 +1478,10 @@
                                     "type": "array"
                                   },
                                   "matchLabels": {
-                                    "type": "object",
-                                    "x-kubernetes-preserve-unknown-fields": true
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
                                   }
                                 },
                                 "type": "object",
@@ -1409,21 +1550,25 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "priorityClassName": {
-                  "description": "The name of the priority class used to assign priority to the pods. For more information about priority classes, see {K8sPriorityClass}.",
+                  "description": "The name of the priority class used to assign priority to the pods. ",
                   "type": "string"
                 },
                 "schedulerName": {
@@ -1584,8 +1729,10 @@
                             "type": "array"
                           },
                           "matchLabels": {
-                            "type": "object",
-                            "x-kubernetes-preserve-unknown-fields": true
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
                           }
                         },
                         "type": "object",
@@ -1637,14 +1784,18 @@
                   "description": "Metadata to apply to the `PodDisruptionBudgetTemplate` resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1661,14 +1812,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",
@@ -1686,7 +1841,7 @@
           "description": "The configuration of tracing in Kafka MirrorMaker.",
           "properties": {
             "type": {
-              "description": "Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.",
+              "description": "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored.",
               "enum": [
                 "jaeger",
                 "opentelemetry"
@@ -1701,7 +1856,7 @@
           "additionalProperties": false
         },
         "version": {
-          "description": "The Kafka MirrorMaker version. Defaults to {DefaultKafkaVersion}. Consult the documentation to understand the process required to upgrade or downgrade the version.",
+          "description": "The Kafka MirrorMaker version. Defaults to the latest version. Consult the documentation to understand the process required to upgrade or downgrade the version.",
           "type": "string"
         },
         "whitelist": {

--- a/kafka.strimzi.io/kafkanodepool_v1beta2.json
+++ b/kafka.strimzi.io/kafkanodepool_v1beta2.json
@@ -1,0 +1,1552 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "The specification of the KafkaNodePool.",
+      "properties": {
+        "jvmOptions": {
+          "description": "JVM Options for pods.",
+          "properties": {
+            "-XX": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "A map of -XX options to the JVM.",
+              "type": "object"
+            },
+            "-Xms": {
+              "description": "-Xms option to to the JVM.",
+              "pattern": "^[0-9]+[mMgG]?$",
+              "type": "string"
+            },
+            "-Xmx": {
+              "description": "-Xmx option to to the JVM.",
+              "pattern": "^[0-9]+[mMgG]?$",
+              "type": "string"
+            },
+            "gcLoggingEnabled": {
+              "description": "Specifies whether the Garbage Collection logging is enabled. The default is false.",
+              "type": "boolean"
+            },
+            "javaSystemProperties": {
+              "description": "A map of additional system properties which will be passed using the `-D` option to the JVM.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "The system property name.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "The system property value.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "The number of pods in the pool.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "resources": {
+          "description": "CPU and memory resources to reserve.",
+          "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "roles": {
+          "description": "The roles that the nodes in this pool will have when KRaft mode is enabled. Supported values are 'broker' and 'controller'. This field is required. When KRaft mode is disabled, the only allowed value if `broker`.",
+          "items": {
+            "enum": [
+              "controller",
+              "broker"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "storage": {
+          "description": "Storage configuration (disk). Cannot be updated.",
+          "properties": {
+            "class": {
+              "description": "The storage class to use for dynamic volume allocation.",
+              "type": "string"
+            },
+            "deleteClaim": {
+              "description": "Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.",
+              "type": "boolean"
+            },
+            "id": {
+              "description": "Storage identification number. It is mandatory only for storage volumes defined in a storage of type 'jbod'.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kraftMetadata": {
+              "description": "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set.",
+              "enum": [
+                "shared"
+              ],
+              "type": "string"
+            },
+            "overrides": {
+              "description": "Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.",
+              "items": {
+                "properties": {
+                  "broker": {
+                    "description": "Id of the kafka broker (broker identifier).",
+                    "type": "integer"
+                  },
+                  "class": {
+                    "description": "The storage class to use for dynamic volume allocation for this broker.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "selector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.",
+              "type": "object"
+            },
+            "size": {
+              "description": "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`.",
+              "type": "string"
+            },
+            "sizeLimit": {
+              "description": "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).",
+              "pattern": "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
+              "type": "string"
+            },
+            "type": {
+              "description": "Storage type, must be either 'ephemeral', 'persistent-claim', or 'jbod'.",
+              "enum": [
+                "ephemeral",
+                "persistent-claim",
+                "jbod"
+              ],
+              "type": "string"
+            },
+            "volumes": {
+              "description": "List of volumes as Storage objects representing the JBOD disks array.",
+              "items": {
+                "properties": {
+                  "class": {
+                    "description": "The storage class to use for dynamic volume allocation.",
+                    "type": "string"
+                  },
+                  "deleteClaim": {
+                    "description": "Specifies if the persistent volume claim has to be deleted when the cluster is un-deployed.",
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "description": "Storage identification number. Mandatory for storage volumes defined with a `jbod` storage type configuration.",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "kraftMetadata": {
+                    "description": "Specifies whether this volume should be used for storing KRaft metadata. This property is optional. When set, the only currently supported value is `shared`. At most one volume can have this property set.",
+                    "enum": [
+                      "shared"
+                    ],
+                    "type": "string"
+                  },
+                  "overrides": {
+                    "description": "Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.",
+                    "items": {
+                      "properties": {
+                        "broker": {
+                          "description": "Id of the kafka broker (broker identifier).",
+                          "type": "integer"
+                        },
+                        "class": {
+                          "description": "The storage class to use for dynamic volume allocation for this broker.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "selector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Specifies a specific persistent volume to use. It contains key:value pairs representing labels for selecting such a volume.",
+                    "type": "object"
+                  },
+                  "size": {
+                    "description": "When `type=persistent-claim`, defines the size of the persistent volume claim, such as 100Gi. Mandatory when `type=persistent-claim`.",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "description": "When type=ephemeral, defines the total amount of local storage required for this EmptyDir volume (for example 1Gi).",
+                    "pattern": "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Storage type, must be either 'ephemeral' or 'persistent-claim'.",
+                    "enum": [
+                      "ephemeral",
+                      "persistent-claim"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "description": "Template for pool resources. The template allows users to specify how the resources belonging to this pool are generated.",
+          "properties": {
+            "initContainer": {
+              "description": "Template for the Kafka init container.",
+              "properties": {
+                "env": {
+                  "description": "Environment variables which should be applied to the container.",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "description": "The environment variable key.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The environment variable value.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "securityContext": {
+                  "description": "Security context for the container.",
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "kafkaContainer": {
+              "description": "Template for the Kafka broker container.",
+              "properties": {
+                "env": {
+                  "description": "Environment variables which should be applied to the container.",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "description": "The environment variable key.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The environment variable value.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "securityContext": {
+                  "description": "Security context for the container.",
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "perPodIngress": {
+              "description": "Template for Kafka per-pod `Ingress` used for access from outside of Kubernetes.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "perPodRoute": {
+              "description": "Template for Kafka per-pod `Routes` used for access from outside of OpenShift.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "perPodService": {
+              "description": "Template for Kafka per-pod `Services` used for access from outside of Kubernetes.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "persistentVolumeClaim": {
+              "description": "Template for all Kafka `PersistentVolumeClaims`.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "pod": {
+              "description": "Template for Kafka `Pods`.",
+              "properties": {
+                "affinity": {
+                  "description": "The pod's affinity rules.",
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "enableServiceLinks": {
+                  "description": "Indicates whether information about services should be injected into Pod's environment variables.",
+                  "type": "boolean"
+                },
+                "hostAliases": {
+                  "description": "The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the Pod's hosts file if specified.",
+                  "items": {
+                    "properties": {
+                      "hostnames": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "imagePullSecrets": {
+                  "description": "List of references to secrets in the same namespace to use for pulling any of the images used by this Pod. When the `STRIMZI_IMAGE_PULL_SECRETS` environment variable in Cluster Operator and the `imagePullSecrets` option are specified, only the `imagePullSecrets` variable is used and the `STRIMZI_IMAGE_PULL_SECRETS` variable is ignored.",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "priorityClassName": {
+                  "description": "The name of the priority class used to assign priority to the pods. ",
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "description": "The name of the scheduler used to dispatch this `Pod`. If not specified, the default scheduler will be used.",
+                  "type": "string"
+                },
+                "securityContext": {
+                  "description": "Configures pod-level security attributes and common container settings.",
+                  "properties": {
+                    "fsGroup": {
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "description": "The grace period is the duration in seconds after the processes running in the pod are sent a termination signal, and the time when the processes are forcibly halted with a kill signal. Set this value to longer than the expected cleanup time for your process. Value must be a non-negative integer. A zero value indicates delete immediately. You might need to increase the grace period for very large Kafka clusters, so that the Kafka brokers have enough time to transfer their work to another broker before they are terminated. Defaults to 30 seconds.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "tmpDirSizeLimit": {
+                  "description": "Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.",
+                  "pattern": "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$",
+                  "type": "string"
+                },
+                "tolerations": {
+                  "description": "The pod's tolerations.",
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "topologySpreadConstraints": {
+                  "description": "The pod's topology spread constraints.",
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "maxSkew": {
+                        "type": "integer"
+                      },
+                      "minDomains": {
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podSet": {
+              "description": "Template for Kafka `StrimziPodSet` resource.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata applied to the resource.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "replicas",
+        "storage",
+        "roles"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "The status of the KafkaNodePool.",
+      "properties": {
+        "clusterId": {
+          "description": "Kafka cluster ID.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "List of status conditions.",
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition of a type changed from one status to another. The required format is 'yyyy-MM-ddTHH:mm:ssZ', in the UTC time zone.",
+                "type": "string"
+              },
+              "message": {
+                "description": "Human-readable message indicating details about the condition's last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition (a single word in CamelCase).",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of the condition, either True, False or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The unique identifier of a condition, used to distinguish between other conditions in the resource.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "labelSelector": {
+          "description": "Label selector for pods providing this resource.",
+          "type": "string"
+        },
+        "nodeIds": {
+          "description": "Node IDs used by Kafka nodes in this pool.",
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation of the CRD that was last reconciled by the operator.",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "The current number of pods being used to provide this resource.",
+          "type": "integer"
+        },
+        "roles": {
+          "description": "The roles currently assigned to this pool.",
+          "items": {
+            "enum": [
+              "controller",
+              "broker"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/kafka.strimzi.io/kafkarebalance_v1beta2.json
+++ b/kafka.strimzi.io/kafkarebalance_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the Kafka rebalance.",
       "properties": {

--- a/kafka.strimzi.io/kafkatopic_v1alpha1.json
+++ b/kafka.strimzi.io/kafkatopic_v1alpha1.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the topic.",
       "properties": {
@@ -63,6 +74,37 @@
         "observedGeneration": {
           "description": "The generation of the CRD that was last reconciled by the operator.",
           "type": "integer"
+        },
+        "replicasChange": {
+          "description": "Replication factor change status.",
+          "properties": {
+            "message": {
+              "description": "Message for the user related to the replicas change request. This may contain transient error messages that would disappear on periodic reconciliations.",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "The session identifier for replicas change requests pertaining to this KafkaTopic resource. This is used by the Topic Operator to track the status of `ongoing` replicas change operations.",
+              "type": "string"
+            },
+            "state": {
+              "description": "Current state of the replicas change operation. This can be `pending`, when the change has been requested, or `ongoing`, when the change has been successfully submitted to Cruise Control.",
+              "enum": [
+                "pending",
+                "ongoing"
+              ],
+              "type": "string"
+            },
+            "targetReplicas": {
+              "description": "The target replicas value requested by the user. This may be different from .spec.replicas when a change is ongoing.",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "topicId": {
+          "description": "The topic's id. For a KafkaTopic with the ready condition, this will change only if the topic gets deleted and recreated with the same name.",
+          "type": "string"
         },
         "topicName": {
           "description": "Topic name.",

--- a/kafka.strimzi.io/kafkatopic_v1beta1.json
+++ b/kafka.strimzi.io/kafkatopic_v1beta1.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the topic.",
       "properties": {
@@ -63,6 +74,37 @@
         "observedGeneration": {
           "description": "The generation of the CRD that was last reconciled by the operator.",
           "type": "integer"
+        },
+        "replicasChange": {
+          "description": "Replication factor change status.",
+          "properties": {
+            "message": {
+              "description": "Message for the user related to the replicas change request. This may contain transient error messages that would disappear on periodic reconciliations.",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "The session identifier for replicas change requests pertaining to this KafkaTopic resource. This is used by the Topic Operator to track the status of `ongoing` replicas change operations.",
+              "type": "string"
+            },
+            "state": {
+              "description": "Current state of the replicas change operation. This can be `pending`, when the change has been requested, or `ongoing`, when the change has been successfully submitted to Cruise Control.",
+              "enum": [
+                "pending",
+                "ongoing"
+              ],
+              "type": "string"
+            },
+            "targetReplicas": {
+              "description": "The target replicas value requested by the user. This may be different from .spec.replicas when a change is ongoing.",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "topicId": {
+          "description": "The topic's id. For a KafkaTopic with the ready condition, this will change only if the topic gets deleted and recreated with the same name.",
+          "type": "string"
         },
         "topicName": {
           "description": "Topic name.",

--- a/kafka.strimzi.io/kafkatopic_v1beta2.json
+++ b/kafka.strimzi.io/kafkatopic_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the topic.",
       "properties": {
@@ -63,6 +74,37 @@
         "observedGeneration": {
           "description": "The generation of the CRD that was last reconciled by the operator.",
           "type": "integer"
+        },
+        "replicasChange": {
+          "description": "Replication factor change status.",
+          "properties": {
+            "message": {
+              "description": "Message for the user related to the replicas change request. This may contain transient error messages that would disappear on periodic reconciliations.",
+              "type": "string"
+            },
+            "sessionId": {
+              "description": "The session identifier for replicas change requests pertaining to this KafkaTopic resource. This is used by the Topic Operator to track the status of `ongoing` replicas change operations.",
+              "type": "string"
+            },
+            "state": {
+              "description": "Current state of the replicas change operation. This can be `pending`, when the change has been requested, or `ongoing`, when the change has been successfully submitted to Cruise Control.",
+              "enum": [
+                "pending",
+                "ongoing"
+              ],
+              "type": "string"
+            },
+            "targetReplicas": {
+              "description": "The target replicas value requested by the user. This may be different from .spec.replicas when a change is ongoing.",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "topicId": {
+          "description": "The topic's id. For a KafkaTopic with the ready condition, this will change only if the topic gets deleted and recreated with the same name.",
+          "type": "string"
         },
         "topicName": {
           "description": "Topic name.",

--- a/kafka.strimzi.io/kafkauser_v1alpha1.json
+++ b/kafka.strimzi.io/kafkauser_v1alpha1.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the user.",
       "properties": {
@@ -63,7 +74,7 @@
               "items": {
                 "properties": {
                   "host": {
-                    "description": "The host from which the action described in the ACL rule is allowed or denied.",
+                    "description": "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*`, allowing or denying the action from any host.",
                     "type": "string"
                   },
                   "operation": {
@@ -153,7 +164,7 @@
               "type": "array"
             },
             "type": {
-              "description": "Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.",
+              "description": "Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.",
               "enum": [
                 "simple"
               ],
@@ -204,14 +215,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",

--- a/kafka.strimzi.io/kafkauser_v1beta1.json
+++ b/kafka.strimzi.io/kafkauser_v1beta1.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the user.",
       "properties": {
@@ -63,7 +74,7 @@
               "items": {
                 "properties": {
                   "host": {
-                    "description": "The host from which the action described in the ACL rule is allowed or denied.",
+                    "description": "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*`, allowing or denying the action from any host.",
                     "type": "string"
                   },
                   "operation": {
@@ -153,7 +164,7 @@
               "type": "array"
             },
             "type": {
-              "description": "Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.",
+              "description": "Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.",
               "enum": [
                 "simple"
               ],
@@ -204,14 +215,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",

--- a/kafka.strimzi.io/kafkauser_v1beta2.json
+++ b/kafka.strimzi.io/kafkauser_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the user.",
       "properties": {
@@ -63,7 +74,7 @@
               "items": {
                 "properties": {
                   "host": {
-                    "description": "The host from which the action described in the ACL rule is allowed or denied.",
+                    "description": "The host from which the action described in the ACL rule is allowed or denied. If not set, it defaults to `*`, allowing or denying the action from any host.",
                     "type": "string"
                   },
                   "operation": {
@@ -153,7 +164,7 @@
               "type": "array"
             },
             "type": {
-              "description": "Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.",
+              "description": "Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.",
               "enum": [
                 "simple"
               ],
@@ -204,14 +215,18 @@
                   "description": "Metadata applied to the resource.",
                   "properties": {
                     "annotations": {
-                      "description": "Annotations added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations added to the Kubernetes resource.",
+                      "type": "object"
                     },
                     "labels": {
-                      "description": "Labels added to the resource template. Can be applied to different resources such as `StatefulSets`, `Deployments`, `Pods`, and `Services`.",
-                      "type": "object",
-                      "x-kubernetes-preserve-unknown-fields": true
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels added to the Kubernetes resource.",
+                      "type": "object"
                     }
                   },
                   "type": "object",

--- a/kafka.strimzi.io/strimzipodset_v1beta2.json
+++ b/kafka.strimzi.io/strimzipodset_v1beta2.json
@@ -1,5 +1,16 @@
 {
   "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
     "spec": {
       "description": "The specification of the StrimziPodSet.",
       "properties": {
@@ -36,8 +47,10 @@
               "type": "array"
             },
             "matchLabels": {
-              "type": "object",
-              "x-kubernetes-preserve-unknown-fields": true
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
             }
           },
           "type": "object",
@@ -85,7 +98,7 @@
           "type": "array"
         },
         "currentPods": {
-          "description": "Number of pods managed by the StrimziPodSet controller that have the current revision.",
+          "description": "Number of pods managed by this `StrimziPodSet` resource that have the current revision.",
           "type": "integer"
         },
         "observedGeneration": {
@@ -93,11 +106,11 @@
           "type": "integer"
         },
         "pods": {
-          "description": "Number of pods managed by the StrimziPodSet controller.",
+          "description": "Number of pods managed by this `StrimziPodSet` resource.",
           "type": "integer"
         },
         "readyPods": {
-          "description": "Number of pods managed by the StrimziPodSet controller that are ready.",
+          "description": "Number of pods managed by this `StrimziPodSet` resource that are ready.",
           "type": "integer"
         }
       },


### PR DESCRIPTION
`KafkaNodePool` CRD was introduced as GA from Strimzi 0.41 and this changed the requirement fields of `Kafka` CRDs.
I also updated other CRDs related to Strimzi. Just in case, these updates are created by running CRD Extractor toward my cluster.