### PR TITLE
Add GCP Cloud SQL Operator CRDs (v1.4.5)

### DIFF
--- a/cloudsql.cloud.google.com/authproxyworkload_v1.json
+++ b/cloudsql.cloud.google.com/authproxyworkload_v1.json
@@ -1,0 +1,1732 @@
+{
+  "description": "AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied\nto a matching set of workloads, and shows the status of those proxy containers.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AuthProxyWorkloadSpec describes where and how to configure the proxy.",
+      "properties": {
+        "authProxyContainer": {
+          "description": "AuthProxyContainer describes the resources and config for the Auth Proxy container.",
+          "properties": {
+            "adminServer": {
+              "description": "AdminServer specifies the config for the proxy's admin service which is\navailable to other containers in the same pod.",
+              "properties": {
+                "enableAPIs": {
+                  "description": "EnableAPIs specifies the list of admin APIs to enable. At least one\nAPI must be enabled. Possible values:\n- \"Debug\" will enable pprof debugging by setting the `--debug` cli flag.\n- \"QuitQuitQuit\" will enable pprof debugging by setting the `--quitquitquit`\n  cli flag.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "port": {
+                  "description": "Port the port for the proxy's localhost-only admin server.\nThis sets the proxy container's CLI argument `--admin-port`",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "authentication": {
+              "description": "Authentication specifies the config for how the proxy authenticates itself\nto the Google Cloud API.",
+              "properties": {
+                "impersonationChain": {
+                  "description": "ImpersonationChain is a list of one or more service\naccounts. The first entry in the chain is the impersonation target. Any\nadditional service accounts after the target are delegates. The\nroles/iam.serviceAccountTokenCreator must be configured for each account\nthat will be impersonated. This sets the --impersonate-service-account\nflag on the proxy.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "container": {
+              "description": "Container is debugging parameter that when specified will override the\nproxy container with a completely custom Container spec.",
+              "properties": {
+                "args": {
+                  "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "command": {
+                  "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "env": {
+                  "description": "List of environment variables to set in the container.\nCannot be updated.",
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "resource"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "envFrom": {
+                  "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                  "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                    "properties": {
+                      "configMapRef": {
+                        "description": "The ConfigMap to select from",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "The Secret to select from",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "image": {
+                  "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string"
+                },
+                "lifecycle": {
+                  "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
+                  "properties": {
+                    "postStart": {
+                      "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec specifies the action to take.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "HTTPGet specifies the http request to perform.",
+                          "properties": {
+                            "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                              "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                "properties": {
+                                  "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The header field value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "description": "Path to access on the HTTP server.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Sleep represents the duration that the container should sleep before being terminated.",
+                          "properties": {
+                            "seconds": {
+                              "description": "Seconds is the number of seconds to sleep.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "seconds"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor the backward compatibility. There are no validation of this field and\nlifecycle hooks will fail in runtime when tcp handler is specified.",
+                          "properties": {
+                            "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec specifies the action to take.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "HTTPGet specifies the http request to perform.",
+                          "properties": {
+                            "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                              "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                "properties": {
+                                  "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The header field value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "description": "Path to access on the HTTP server.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Sleep represents the duration that the container should sleep before being terminated.",
+                          "properties": {
+                            "seconds": {
+                              "description": "Seconds is the number of seconds to sleep.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "seconds"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor the backward compatibility. There are no validation of this field and\nlifecycle hooks will fail in runtime when tcp handler is specified.",
+                          "properties": {
+                            "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "livenessProbe": {
+                  "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies the action to take.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "properties": {
+                        "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "name": {
+                  "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                  "type": "string"
+                },
+                "ports": {
+                  "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                  "items": {
+                    "description": "ContainerPort represents a network port in a single container.",
+                    "properties": {
+                      "containerPort": {
+                        "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "hostIP": {
+                        "description": "What host IP to bind the external port to.",
+                        "type": "string"
+                      },
+                      "hostPort": {
+                        "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "readinessProbe": {
+                  "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies the action to take.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "properties": {
+                        "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "resizePolicy": {
+                  "description": "Resources resize policy for the container.",
+                  "items": {
+                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                    "properties": {
+                      "resourceName": {
+                        "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "resources": {
+                  "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                  "type": "string"
+                },
+                "securityContext": {
+                  "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "add": {
+                          "description": "Added capabilities",
+                          "items": {
+                            "description": "Capability represent POSIX capabilities type",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "description": "Removed capabilities",
+                          "items": {
+                            "description": "Capability represent POSIX capabilities type",
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privileged": {
+                      "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
+                          "type": "string"
+                        },
+                        "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
+                          "type": "string"
+                        },
+                        "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "startupProbe": {
+                  "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies the action to take.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "properties": {
+                        "port": {
+                          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies the http request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "stdin": {
+                  "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
+                  "type": "boolean"
+                },
+                "stdinOnce": {
+                  "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                  "type": "boolean"
+                },
+                "terminationMessagePath": {
+                  "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                  "type": "string"
+                },
+                "terminationMessagePolicy": {
+                  "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                  "type": "string"
+                },
+                "tty": {
+                  "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                  "type": "boolean"
+                },
+                "volumeDevices": {
+                  "description": "volumeDevices is the list of block devices to be used by the container.",
+                  "items": {
+                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                    "properties": {
+                      "devicePath": {
+                        "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "name must match the name of a persistentVolumeClaim in the pod",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumeMounts": {
+                  "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                  "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "properties": {
+                      "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "This must match the Name of a Volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "workingDir": {
+                  "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "image": {
+              "description": "Image is the URL to the proxy image. Optional, by default the operator\nwill use the latest Cloud SQL Auth Proxy version as of the release of the\noperator.\n\n\nThe operator ensures that all workloads configured with the default proxy\nimage are upgraded automatically to use to the latest released proxy image.\n\n\nWhen the customer upgrades the operator, the operator upgrades all\nworkloads using the default proxy image to the latest proxy image. The\nchange to the proxy container image is applied in accordance with\nthe RolloutStrategy.",
+              "type": "string"
+            },
+            "maxConnections": {
+              "description": "MaxConnections limits the number of connections. Default value is no limit.\nThis sets the proxy container's CLI argument `--max-connections`",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxSigtermDelay": {
+              "description": "MaxSigtermDelay is the maximum number of seconds to wait for connections to\nclose after receiving a TERM signal. This sets the proxy container's\nCLI argument `--max-sigterm-delay` and\nconfigures `terminationGracePeriodSeconds` on the workload's PodSpec.",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "quiet": {
+              "description": "Quiet configures the proxy's --quiet flag to limit the amount of\nlogging generated by the proxy container.",
+              "type": "boolean"
+            },
+            "resources": {
+              "description": "Resources specifies the resources required for the proxy pod.",
+              "properties": {
+                "claims": {
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                  "items": {
+                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                    "properties": {
+                      "name": {
+                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rolloutStrategy": {
+              "default": "Workload",
+              "description": "RolloutStrategy indicates the strategy to use when rolling out changes to\nthe workloads affected by the results. When this is set to\n`Workload`, changes to this resource will be automatically applied\nto a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in\naccordance with the Strategy set on that workload. When this is set to\n`None`, the operator will take no action to roll out changes to affected\nworkloads. `Workload` will be used by default if no value is set.\nSee: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy",
+              "enum": [
+                "Workload",
+                "None"
+              ],
+              "type": "string"
+            },
+            "sqlAdminAPIEndpoint": {
+              "description": "SQLAdminAPIEndpoint is a debugging parameter that when specified will\nchange the Google Cloud api endpoint used by the proxy.",
+              "type": "string"
+            },
+            "telemetry": {
+              "description": "Telemetry specifies how the proxy should expose telemetry.\nOptional, by default",
+              "properties": {
+                "disableMetrics": {
+                  "description": "DisableMetrics disables Cloud Monitoring testintegration (used with telemetryProject)\nThis sets the proxy container's CLI argument `--disable-metrics`",
+                  "type": "boolean"
+                },
+                "disableTraces": {
+                  "description": "DisableTraces disables Cloud Trace testintegration (used with telemetryProject)\nThis sets the proxy container's CLI argument `--disable-traces`",
+                  "type": "boolean"
+                },
+                "httpPort": {
+                  "description": "HTTPPort the port for Prometheus and health check server.\nThis sets the proxy container's CLI argument `--http-port`",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prometheus": {
+                  "description": "Prometheus Enables Prometheus HTTP endpoint /metrics on localhost\nThis sets the proxy container's CLI argument `--prometheus`",
+                  "type": "boolean"
+                },
+                "prometheusNamespace": {
+                  "description": "PrometheusNamespace is used the provided Prometheus namespace for metrics\nThis sets the proxy container's CLI argument `--prometheus-namespace`",
+                  "type": "string"
+                },
+                "quotaProject": {
+                  "description": "QuotaProject Specifies the project to use for Cloud SQL Admin API quota tracking.\nThe IAM principal must have the \"serviceusage.services.use\" permission\nfor the given project. See https://cloud.google.com/service-usage/docs/overview and\nhttps://cloud.google.com/storage/docs/requester-pays\nThis sets the proxy container's CLI argument `--quota-project`",
+                  "type": "string"
+                },
+                "telemetryPrefix": {
+                  "description": "TelemetryPrefix is the prefix for Cloud Monitoring metrics.\nThis sets the proxy container's CLI argument `--telemetry-prefix`",
+                  "type": "string"
+                },
+                "telemetryProject": {
+                  "description": "TelemetryProject enables Cloud Monitoring and Cloud Trace with the provided project ID.\nThis sets the proxy container's CLI argument `--telemetry-project`",
+                  "type": "string"
+                },
+                "telemetrySampleRate": {
+                  "description": "TelemetrySampleRate is the Cloud Trace sample rate. A smaller number means more traces.\nThis sets the proxy container's CLI argument `--telemetry-sample-rate`",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "instances": {
+          "description": "Instances describes the Cloud SQL instances to configure on the proxy container.",
+          "items": {
+            "description": "InstanceSpec describes the configuration for how the proxy should expose\na Cloud SQL database instance to a workload.\n\n\nIn the minimum recommended configuration, the operator will choose\na non-conflicting TCP port and set environment\nvariables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port\nand hostname. The application can read these values to connect to the database\nthrough the proxy. For example:\n\n\n\t`{\n\t\t\t   \"connectionString\":\"my-project:us-central1:my-db-server\",\n\t\t\t   \"portEnvName\":\"MY_DB_SERVER_PORT\"\n\t\t\t   \"hostEnvName\":\"MY_DB_SERVER_HOST\"\n\t}`\n\n\nIf you want to assign a specific port number for a database, set the `port`\nfield. For example:\n\n\n\t`{ \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 }`",
+            "properties": {
+              "autoIAMAuthN": {
+                "description": "AutoIAMAuthN (optional) Enables IAM Authentication for this instance.\nDefault value is false.",
+                "type": "boolean"
+              },
+              "connectionString": {
+                "description": "ConnectionString is the connection string for the Cloud SQL Instance\nin the format `project_id:region:instance_name`",
+                "pattern": "^([^:]+(:[^:]+)?):([^:]+):([^:]+)$",
+                "type": "string"
+              },
+              "hostEnvName": {
+                "description": "HostEnvName The name of the environment variable containing this instances tcp hostname\nOptional, when set this environment variable will be added to all containers in the workload.",
+                "type": "string"
+              },
+              "port": {
+                "description": "Port (optional) sets the tcp port for this instance. If not set, a value will\nbe automatically assigned by the operator and set as an environment variable\non all containers in the workload named according to PortEnvName. The operator will choose\na port so that it does not conflict with other ports on the workload.",
+                "format": "int32",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "portEnvName": {
+                "description": "PortEnvName is name of the environment variable containing this instance's tcp port.\nOptional, when set this environment variable will be added to all containers in the workload.",
+                "type": "string"
+              },
+              "privateIP": {
+                "description": "PrivateIP (optional) Enable connection to the Cloud SQL instance's private ip for this instance.\nDefault value is false.",
+                "type": "boolean"
+              },
+              "psc": {
+                "description": "PSC (optional) Enable connection to the Cloud SQL instance's private\nservice connect endpoint. May not be used with PrivateIP.\nDefault value is false.",
+                "type": "boolean"
+              },
+              "unixSocketPath": {
+                "description": "UnixSocketPath is the path to the unix socket where the proxy will listen\nfor connnections. This will be mounted to all containers in the pod.",
+                "type": "string"
+              },
+              "unixSocketPathEnvName": {
+                "description": "UnixSocketPathEnvName is the environment variable containing the value of\nUnixSocketPath.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "workloadSelector": {
+          "description": "Workload selects the workload where the proxy container will be added.",
+          "properties": {
+            "kind": {
+              "description": "Kind specifies what kind of workload\nSupported kinds: Deployment, StatefulSet, Pod, ReplicaSet,DaemonSet, Job, CronJob\nExample: \"Deployment\" \"Deployment.v1\" or \"Deployment.v1.apps\".",
+              "pattern": "\\w+(\\.\\w+)*",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name specifies the name of the resource to select.",
+              "type": "string"
+            },
+            "selector": {
+              "description": "Selector (optional) selects resources using labels. See \"Label selectors\" in the kubernetes docs\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "instances",
+        "workloadSelector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AuthProxyWorkloadStatus presents the observed state of AuthProxyWorkload using\nstandard Kubernetes Conditions.",
+      "properties": {
+        "WorkloadStatus": {
+          "description": "WorkloadStatus presents the observed status of individual workloads that match\nthis AuthProxyWorkload resource.",
+          "items": {
+            "description": "WorkloadStatus presents the status for how this AuthProxyWorkload resource\nwas applied to a specific workload.",
+            "properties": {
+              "conditions": {
+                "description": "Conditions show the status of the AuthProxyWorkload resource on this\nmatching workload.\n\n\nThe \"UpToDate\" condition indicates that the proxy was successfully\napplied to all matching workloads. See ConditionUpToDate.",
+                "items": {
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+                  "properties": {
+                    "lastTransitionTime": {
+                      "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                      "maxLength": 32768,
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "status of the condition, one of True, False, Unknown.",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                      "maxLength": 316,
+                      "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "kind": {
+                "description": "Kind Version Namespace Name identify the specific workload.",
+                "enum": [
+                  "Pod",
+                  "Deployment",
+                  "StatefulSet",
+                  "ReplicaSet",
+                  "DaemonSet",
+                  "Job",
+                  "CronJob"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "conditions"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions show the overall status of the AuthProxyWorkload resource on all\nmatching workloads.\n\n\nThe \"UpToDate\" condition indicates that the proxy was successfully\napplied to all matching workloads. See ConditionUpToDate.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Generated using:

```bash
export FILENAME_FORMAT="{fullgroup}__{kind}_{version}"
curl -s https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py | \
  python3 /dev/stdin https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy-operator/v1.4.5/cloud-sql-proxy-operator.yaml | \
  grep 'JSON schema written to' | \
  awk '{ print $(NF) }' | \
  xargs -I {} sh -c 'mkdir -p $(dirname $(echo {} | sed "s|__|/|")) && mv {} $(echo {} | sed "s|__|/|")'
```

Source repo: https://github.com/GoogleCloudPlatform/cloud-sql-proxy-operator