### PR TITLE
chore(externaldns): add dnsendpoint schema v1alpha1

### DIFF
--- a/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+++ b/externaldns.k8s.io/dnsendpoint_v1alpha1.json
@@ -1,0 +1,93 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DNSEndpointSpec defines the desired state of DNSEndpoint",
+      "properties": {
+        "endpoints": {
+          "items": {
+            "description": "Endpoint is a high-level way of a connection between a service and an IP",
+            "properties": {
+              "dnsName": {
+                "description": "The hostname of the DNS record",
+                "type": "string"
+              },
+              "labels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Labels stores labels defined for the Endpoint",
+                "type": "object"
+              },
+              "providerSpecific": {
+                "description": "ProviderSpecific stores provider specific config",
+                "items": {
+                  "description": "ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "recordTTL": {
+                "description": "TTL for the record",
+                "format": "int64",
+                "type": "integer"
+              },
+              "recordType": {
+                "description": "RecordType type of record, e.g. CNAME, A, AAAA, SRV, TXT etc",
+                "type": "string"
+              },
+              "setIdentifier": {
+                "description": "Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')",
+                "type": "string"
+              },
+              "targets": {
+                "description": "The targets the DNS record points to",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DNSEndpointStatus defines the observed state of DNSEndpoint",
+      "properties": {
+        "observedGeneration": {
+          "description": "The generation observed by the external-dns controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Generated schemas using [openapi2jsonschema.py](https://github.com/yannh/kubeconform/blob/master/scripts/openapi2jsonschema.py) python script.

DNS endpoint was already present but for `externaldns.nginx.org` not [`externaldns.k8s.io`](https://github.com/kubernetes-sigs/external-dns)

```
✖ stdin: DNSEndpoint failed validation: design-token-proxy-dns could not find schema for DNSEndpoint
```

[Source](https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/charts/external-dns/crds/dnsendpoint.yaml) on master.

Hope this helps ! ✌️