### PR TITLE
Update cluster api AWS CRD to 2.6.1

### DIFF
--- a/bootstrap.cluster.x-k8s.io/eksconfig_v1beta1.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfig_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "EKSConfig is the schema for the Amazon EKS Machine Bootstrap Configuration API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -24,11 +24,11 @@
           "type": "string"
         },
         "dnsClusterIP": {
-          "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+          "description": " DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
           "type": "string"
         },
         "dockerConfigJson": {
-          "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+          "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI.\nThis is expected to be a json string.",
           "type": "string"
         },
         "kubeletExtraArgs": {
@@ -42,7 +42,7 @@
           "description": "PauseContainer allows customization of the pause container to use.",
           "properties": {
             "accountNumber": {
-              "description": "AccountNumber is the AWS account number to pull the pause container from.",
+              "description": " AccountNumber is the AWS account number to pull the pause container from.",
               "type": "string"
             },
             "version": {
@@ -58,7 +58,7 @@
           "additionalProperties": false
         },
         "serviceIPV6Cidr": {
-          "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+          "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then\nthe ip family will be set to ipv6.",
           "type": "string"
         },
         "useMaxPods": {
@@ -78,20 +78,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -99,7 +99,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },

--- a/bootstrap.cluster.x-k8s.io/eksconfig_v1beta2.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfig_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "EKSConfig is the schema for the Amazon EKS Machine Bootstrap Configuration API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -55,7 +55,7 @@
                     "type": "string"
                   },
                   "overwrite": {
-                    "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                    "description": "Overwrite defines whether or not to overwrite any existing filesystem.\nIf true, any pre-existing file system will be destroyed. Use with Caution.",
                     "type": "boolean"
                   },
                   "partition": {
@@ -83,15 +83,15 @@
                     "type": "string"
                   },
                   "layout": {
-                    "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                    "description": "Layout specifies the device layout.\nIf it is true, a single partition will be created for the entire device.\nWhen layout is false, it means don't partition or ignore existing partitioning.",
                     "type": "boolean"
                   },
                   "overwrite": {
-                    "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                    "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.\nUse with caution. Default is 'false'.",
                     "type": "boolean"
                   },
                   "tableType": {
-                    "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                    "description": "TableType specifies the tupe of partition table. The following are supported:\n'mbr': default and setups a MS-DOS partition table\n'gpt': setups a GPT partition table",
                     "type": "string"
                   }
                 },
@@ -109,11 +109,11 @@
           "additionalProperties": false
         },
         "dnsClusterIP": {
-          "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+          "description": " DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
           "type": "string"
         },
         "dockerConfigJson": {
-          "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+          "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI.\nThis is expected to be a json string.",
           "type": "string"
         },
         "files": {
@@ -228,7 +228,7 @@
           "description": "PauseContainer allows customization of the pause container to use.",
           "properties": {
             "accountNumber": {
-              "description": "AccountNumber is the AWS account number to pull the pause container from.",
+              "description": " AccountNumber is the AWS account number to pull the pause container from.",
               "type": "string"
             },
             "version": {
@@ -258,7 +258,7 @@
           "type": "array"
         },
         "serviceIPV6Cidr": {
-          "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+          "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then\nthe ip family will be set to ipv6.",
           "type": "string"
         },
         "useMaxPods": {
@@ -368,20 +368,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -389,7 +389,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },

--- a/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta1.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "EKSConfigTemplate is the Amazon EKS Bootstrap Configuration Template API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -30,11 +30,11 @@
                   "type": "string"
                 },
                 "dnsClusterIP": {
-                  "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+                  "description": " DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
                   "type": "string"
                 },
                 "dockerConfigJson": {
-                  "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+                  "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI.\nThis is expected to be a json string.",
                   "type": "string"
                 },
                 "kubeletExtraArgs": {
@@ -48,7 +48,7 @@
                   "description": "PauseContainer allows customization of the pause container to use.",
                   "properties": {
                     "accountNumber": {
-                      "description": "AccountNumber is the AWS account number to pull the pause container from.",
+                      "description": " AccountNumber is the AWS account number to pull the pause container from.",
                       "type": "string"
                     },
                     "version": {
@@ -64,7 +64,7 @@
                   "additionalProperties": false
                 },
                 "serviceIPV6Cidr": {
-                  "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+                  "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then\nthe ip family will be set to ipv6.",
                   "type": "string"
                 },
                 "useMaxPods": {

--- a/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta2.json
+++ b/bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "EKSConfigTemplate is the Amazon EKS Bootstrap Configuration Template API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -61,7 +61,7 @@
                             "type": "string"
                           },
                           "overwrite": {
-                            "description": "Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.",
+                            "description": "Overwrite defines whether or not to overwrite any existing filesystem.\nIf true, any pre-existing file system will be destroyed. Use with Caution.",
                             "type": "boolean"
                           },
                           "partition": {
@@ -89,15 +89,15 @@
                             "type": "string"
                           },
                           "layout": {
-                            "description": "Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.",
+                            "description": "Layout specifies the device layout.\nIf it is true, a single partition will be created for the entire device.\nWhen layout is false, it means don't partition or ignore existing partitioning.",
                             "type": "boolean"
                           },
                           "overwrite": {
-                            "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.",
+                            "description": "Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.\nUse with caution. Default is 'false'.",
                             "type": "boolean"
                           },
                           "tableType": {
-                            "description": "TableType specifies the tupe of partition table. The following are supported: 'mbr': default and setups a MS-DOS partition table 'gpt': setups a GPT partition table",
+                            "description": "TableType specifies the tupe of partition table. The following are supported:\n'mbr': default and setups a MS-DOS partition table\n'gpt': setups a GPT partition table",
                             "type": "string"
                           }
                         },
@@ -115,11 +115,11 @@
                   "additionalProperties": false
                 },
                 "dnsClusterIP": {
-                  "description": "DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
+                  "description": " DNSClusterIP overrides the IP address to use for DNS queries within the cluster.",
                   "type": "string"
                 },
                 "dockerConfigJson": {
-                  "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI. This is expected to be a json string.",
+                  "description": "DockerConfigJson is used for the contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI.\nThis is expected to be a json string.",
                   "type": "string"
                 },
                 "files": {
@@ -234,7 +234,7 @@
                   "description": "PauseContainer allows customization of the pause container to use.",
                   "properties": {
                     "accountNumber": {
-                      "description": "AccountNumber is the AWS account number to pull the pause container from.",
+                      "description": " AccountNumber is the AWS account number to pull the pause container from.",
                       "type": "string"
                     },
                     "version": {
@@ -264,7 +264,7 @@
                   "type": "array"
                 },
                 "serviceIPV6Cidr": {
-                  "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then the ip family will be set to ipv6.",
+                  "description": "ServiceIPV6Cidr is the ipv6 cidr range of the cluster. If this is specified then\nthe ip family will be set to ipv6.",
                   "type": "string"
                 },
                 "useMaxPods": {

--- a/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta1.json
+++ b/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSManagedControlPlane is the schema for the Amazon EKS Managed Control Plane API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "addons": {
@@ -27,9 +27,13 @@
           "items": {
             "description": "Addon represents a EKS addon.",
             "properties": {
+              "configuration": {
+                "description": "Configuration of the EKS addon",
+                "type": "string"
+              },
               "conflictResolution": {
                 "default": "none",
-                "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+                "description": "ConflictResolution is used to declare what should happen if there\nare parameter conflicts. Defaults to none",
                 "enum": [
                   "overwrite",
                   "none"
@@ -61,33 +65,33 @@
         },
         "associateOIDCProvider": {
           "default": false,
-          "description": "AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts",
+          "description": "AssociateOIDCProvider can be enabled to automatically create an identity\nprovider for the controller for use with IAM roles for service accounts",
           "type": "boolean"
         },
         "bastion": {
           "description": "Bastion contains options to configure the bastion host.",
           "properties": {
             "allowedCIDRBlocks": {
-              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.\nThey are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "ami": {
-              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified,\nthe AMI will default to one picked out in public space.",
               "type": "string"
             },
             "disableIngressRules": {
-              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.\nRequires AllowedCIDRBlocks to be empty.",
               "type": "boolean"
             },
             "enabled": {
-              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "description": "Enabled allows this provider to create a bastion host instance\nwith a public ip to access the VPC private network.",
               "type": "boolean"
             },
             "instanceType": {
-              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified,\nCluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro\nwill be the default.",
               "type": "string"
             }
           },
@@ -116,11 +120,11 @@
         },
         "disableVPCCNI": {
           "default": false,
-          "description": "DisableVPCCNI indicates that the Amazon VPC CNI should be disabled. With EKS clusters the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon.",
+          "description": "DisableVPCCNI indicates that the Amazon VPC CNI should be disabled. With EKS clusters the\nAmazon VPC CNI is automatically installed into the cluster. For clusters where you want\nto use an alternate CNI this option provides a way to specify that the Amazon VPC CNI\nshould be deleted. You cannot set this to true if you are using the\nAmazon VPC CNI addon.",
           "type": "boolean"
         },
         "eksClusterName": {
-          "description": "EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.",
+          "description": "EKSClusterName allows you to specify the name of the EKS cluster in\nAWS. If you don't specify a name then a default name will be created\nbased on the namespace and name of the managed control plane.",
           "type": "string"
         },
         "encryptionConfig": {
@@ -164,7 +168,7 @@
           "additionalProperties": false
         },
         "iamAuthenticatorConfig": {
-          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.",
+          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings\nfor use when generating the aws-iam-authenticator configuration. If this is nil the\ndefault configuration is still generated for the cluster.",
           "properties": {
             "mapRoles": {
               "description": "RoleMappings is a list of role mappings",
@@ -235,7 +239,7 @@
           "additionalProperties": false
         },
         "identityRef": {
-          "description": "IdentityRef is a reference to a identity to be used when reconciling the managed control plane.",
+          "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
           "properties": {
             "kind": {
               "description": "Kind of the identity.",
@@ -260,15 +264,15 @@
           "additionalProperties": false
         },
         "imageLookupBaseOS": {
-          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look\nup machine images when a machine does not specify an AMI. When set, this\nwill be used for all cluster machines unless a machine specifies a\ndifferent ImageLookupBaseOS.",
           "type": "string"
         },
         "imageLookupFormat": {
-          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when\na machine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.\nSupports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base\nOS and kubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
           "type": "string"
         },
         "imageLookupOrg": {
-          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a\nmachine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.",
           "type": "string"
         },
         "kubeProxy": {
@@ -276,7 +280,7 @@
           "properties": {
             "disable": {
               "default": false,
-              "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster. For clusters where you want to use kube-proxy functionality that is provided with an alternate CNI, this option provides a way to specify that the kube-proxy daemonset should be deleted. You cannot set this to true if you are using the Amazon kube-proxy addon.",
+              "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters\nkube-proxy is automatically installed into the cluster. For clusters where you want\nto use kube-proxy functionality that is provided with an alternate CNI, this option\nprovides a way to specify that the kube-proxy daemonset should be deleted. You cannot\nset this to true if you are using the Amazon kube-proxy addon.",
               "type": "boolean"
             }
           },
@@ -284,7 +288,7 @@
           "additionalProperties": false
         },
         "logging": {
-          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch",
+          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for\neach of the enabled logs will be sent to CloudWatch",
           "properties": {
             "apiServer": {
               "default": false,
@@ -325,11 +329,96 @@
         "network": {
           "description": "NetworkSpec encapsulates all things related to AWS network.",
           "properties": {
+            "additionalControlPlaneIngressRules": {
+              "description": "AdditionalControlPlaneIngressRules is an optional set of ingress rules to add to the control plane",
+              "items": {
+                "description": "IngressRule defines an AWS ingress rule for security groups.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description provides extended information about the ingress rule.",
+                    "type": "string"
+                  },
+                  "fromPort": {
+                    "description": "FromPort is the start of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "ipv6CidrBlocks": {
+                    "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "natGatewaysIPsSource": {
+                    "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                    "type": "boolean"
+                  },
+                  "protocol": {
+                    "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                    "enum": [
+                      "-1",
+                      "4",
+                      "tcp",
+                      "udp",
+                      "icmp",
+                      "58",
+                      "50"
+                    ],
+                    "type": "string"
+                  },
+                  "sourceSecurityGroupIds": {
+                    "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sourceSecurityGroupRoles": {
+                    "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                    "items": {
+                      "description": "SecurityGroupRole defines the unique role of a security group.",
+                      "enum": [
+                        "bastion",
+                        "node",
+                        "controlplane",
+                        "apiserver-lb",
+                        "lb",
+                        "node-eks-additional"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "toPort": {
+                    "description": "ToPort is the end of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "description",
+                  "fromPort",
+                  "protocol",
+                  "toPort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "cni": {
               "description": "CNI configuration",
               "properties": {
                 "cniIngressRules": {
-                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups.\nThe source for the rule will be set to control plane and worker security group IDs.",
                   "items": {
                     "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
                     "properties": {
@@ -368,7 +457,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances\nThis is optional - if not provided new security groups will be created for the cluster",
               "type": "object"
             },
             "subnets": {
@@ -385,15 +474,15 @@
                     "type": "string"
                   },
                   "id": {
-                    "description": "ID defines a unique identifier to reference this resource.",
+                    "description": "ID defines a unique identifier to reference this resource.\nIf you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`.\n\n\nWhen the VPC is managed by CAPA, and you'd like the provider to create a subnet for you,\nthe id can be set to any placeholder value that does not start with `subnet-`;\nupon creation, the subnet AWS identifier will be populated in the `ResourceID` field and\nthe `id` field is going to be used as the subnet name. If you specify a tag\ncalled `Name`, it takes precedence.",
                     "type": "string"
                   },
                   "ipv6CidrBlock": {
-                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.\nA subnet can have an IPv4 and an IPv6 address.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "string"
                   },
                   "isIpv6": {
-                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "boolean"
                   },
                   "isPublic": {
@@ -401,7 +490,15 @@
                     "type": "boolean"
                   },
                   "natGatewayId": {
-                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet.\nIgnored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "parentZoneName": {
+                    "description": "ParentZoneName is the zone name where the current subnet's zone is tied when\nthe zone is a Local Zone.\n\n\nThe subnets in Local Zone or Wavelength Zone locations consume the ParentZoneName\nto select the correct private route table to egress traffic to the internet.",
+                    "type": "string"
+                  },
+                  "resourceID": {
+                    "description": "ResourceID is the subnet identifier from AWS, READ ONLY.\nThis field is populated when the provider manages the subnet.",
                     "type": "string"
                   },
                   "routeTableId": {
@@ -414,6 +511,15 @@
                     },
                     "description": "Tags is a collection of tags describing the resource.",
                     "type": "object"
+                  },
+                  "zoneType": {
+                    "description": "ZoneType defines the type of the zone where the subnet is created.\n\n\nThe valid values are availability-zone, local-zone, and wavelength-zone.\n\n\nSubnet with zone type availability-zone (regular) is always selected to create cluster\nresources, like Load Balancers, NAT Gateways, Contol Plane nodes, etc.\n\n\nSubnet with zone type local-zone or wavelength-zone is not eligible to automatically create\nregular cluster resources.\n\n\nThe public subnet in availability-zone or local-zone is associated with regular public\nroute table with default route entry to a Internet Gateway.\n\n\nThe public subnet in wavelength-zone is associated with a carrier public\nroute table with default route entry to a Carrier Gateway.\n\n\nThe private subnet in the availability-zone is associated with a private route table with\nthe default route entry to a NAT Gateway created in that zone.\n\n\nThe private subnet in the local-zone or wavelength-zone is associated with a private route table with\nthe default route entry re-using the NAT Gateway in the Region (preferred from the\nparent zone, the zone type availability-zone in the region, or first table available).",
+                    "enum": [
+                      "availability-zone",
+                      "local-zone",
+                      "wavelength-zone"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -433,7 +539,7 @@
               "properties": {
                 "availabilityZoneSelection": {
                   "default": "Ordered",
-                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs\nin a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:\nOrdered - selects based on alphabetical order\nRandom - selects AZs randomly in a region\nDefaults to Ordered",
                   "enum": [
                     "Ordered",
                     "Random"
@@ -442,13 +548,53 @@
                 },
                 "availabilityZoneUsageLimit": {
                   "default": 3,
-                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that\nshould be used in a region when automatically creating subnets. If a region has more\nthan this number of AZs then this number of AZs will be picked randomly when creating\ndefault subnets. Defaults to 3",
                   "minimum": 1,
                   "type": "integer"
                 },
+                "carrierGatewayId": {
+                  "description": "CarrierGatewayID is the id of the internet gateway associated with the VPC,\nfor carrier network (Wavelength Zones).",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Carrier Gateway ID must start with 'cagw-'",
+                      "rule": "self.startsWith('cagw-')"
+                    }
+                  ]
+                },
                 "cidrBlock": {
-                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.\nDefaults to 10.0.0.0/16.\nMutually exclusive with IPAMPool.",
                   "type": "string"
+                },
+                "elasticIpPool": {
+                  "description": "ElasticIPPool contains specific configuration to allocate Public IPv4 address (Elastic IP) from user-defined pool\nbrought to AWS for core infrastructure resources, like NAT Gateways and Public Network Load Balancers for\nthe API Server.",
+                  "properties": {
+                    "publicIpv4Pool": {
+                      "description": "PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources\ncreated in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom\nPublic IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool\nresource ID starts with 'ipv4pool-ec2'.",
+                      "maxLength": 30,
+                      "type": "string"
+                    },
+                    "publicIpv4PoolFallbackOrder": {
+                      "description": "PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,\nno more IPv4 address available in the pool.\n\n\nWhen set to 'amazon-pool', the controller check if the pool has available IPv4 address, when pool has reached the\nIPv4 limit, the address will be claimed from Amazon-pool (default).\n\n\nWhen set to 'none', the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.",
+                      "enum": [
+                        "amazon-pool",
+                        "none"
+                      ],
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "allowed values are 'none' and 'amazon-pool'",
+                          "rule": "self in ['none','amazon-pool']"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "emptyRoutesDefaultVPCSecurityGroup": {
+                  "description": "EmptyRoutesDefaultVPCSecurityGroup specifies whether the default VPC security group ingress\nand egress rules should be removed.\n\n\nBy default, when creating a VPC, AWS creates a security group called `default` with ingress and egress\nrules that allow traffic from anywhere. The group could be used as a potential surface attack and\nit's generally suggested that the group rules are removed or modified appropriately.\n\n\nNOTE: This only applies when the VPC is managed by the Cluster API AWS controller.",
+                  "type": "boolean"
                 },
                 "id": {
                   "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
@@ -458,24 +604,81 @@
                   "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
                   "type": "string"
                 },
+                "ipamPool": {
+                  "description": "IPAMPool defines the IPAMv4 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                      "type": "string"
+                    },
+                    "netmaskLength": {
+                      "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "ipv6": {
-                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.\nThis field cannot be set on AWSCluster object.",
                   "properties": {
                     "cidrBlock": {
-                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.\nMutually exclusive with IPAMPool.",
                       "type": "string"
                     },
                     "egressOnlyInternetGatewayId": {
                       "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
                       "type": "string"
                     },
+                    "ipamPool": {
+                      "description": "IPAMPool defines the IPAMv6 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                      "properties": {
+                        "id": {
+                          "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                          "type": "string"
+                        },
+                        "netmaskLength": {
+                          "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "poolId": {
-                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.\nMust be specified if CidrBlock is set.\nMutually exclusive with IPAMPool.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "privateDnsHostnameTypeOnLaunch": {
+                  "description": "PrivateDNSHostnameTypeOnLaunch is the type of hostname to assign to instances in the subnet at launch.\nFor IPv4-only and dual-stack (IPv4 and IPv6) subnets, an instance DNS name can be based on the instance IPv4 address (ip-name)\nor the instance ID (resource-name). For IPv6 only subnets, an instance DNS name must be based on the instance ID (resource-name).",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                },
+                "subnetSchema": {
+                  "default": "PreferPrivate",
+                  "description": "SubnetSchema specifies how CidrBlock should be divided on subnets in the VPC depending on the number of AZs.\nPreferPrivate - one private subnet for each AZ plus one other subnet that will be further sub-divided for the public subnets.\nPreferPublic - have the reverse logic of PreferPrivate, one public subnet for each AZ plus one other subnet\nthat will be further sub-divided for the private subnets.\nDefaults to PreferPrivate",
+                  "enum": [
+                    "PreferPrivate",
+                    "PreferPublic"
+                  ],
+                  "type": "string"
                 },
                 "tags": {
                   "additionalProperties": {
@@ -493,10 +696,10 @@
           "additionalProperties": false
         },
         "oidcIdentityProviderConfig": {
-          "description": "IdentityProviderconfig is used to specify the oidc provider config to be attached with this eks cluster",
+          "description": "IdentityProviderconfig is used to specify the oidc provider config\nto be attached with this eks cluster",
           "properties": {
             "clientId": {
-              "description": "This is also known as audience. The ID for the client application that makes authentication requests to the OpenID identity provider.",
+              "description": "This is also known as audience. The ID for the client application that makes\nauthentication requests to the OpenID identity provider.",
               "type": "string"
             },
             "groupsClaim": {
@@ -504,22 +707,22 @@
               "type": "string"
             },
             "groupsPrefix": {
-              "description": "The prefix that is prepended to group claims to prevent clashes with existing names (such as system: groups). For example, the valueoidc: will create group names like oidc:engineering and oidc:infra.",
+              "description": "The prefix that is prepended to group claims to prevent clashes with existing\nnames (such as system: groups). For example, the valueoidc: will create group\nnames like oidc:engineering and oidc:infra.",
               "type": "string"
             },
             "identityProviderConfigName": {
-              "description": "The name of the OIDC provider configuration. \n IdentityProviderConfigName is a required field",
+              "description": "The name of the OIDC provider configuration.\n\n\nIdentityProviderConfigName is a required field",
               "type": "string"
             },
             "issuerUrl": {
-              "description": "The URL of the OpenID identity provider that allows the API server to discover public signing keys for verifying tokens. The URL must begin with https:// and should correspond to the iss claim in the provider's OIDC ID tokens. Per the OIDC standard, path components are allowed but query parameters are not. Typically the URL consists of only a hostname, like https://server.example.org or https://example.com. This URL should point to the level below .well-known/openid-configuration and must be publicly accessible over the internet.",
+              "description": "The URL of the OpenID identity provider that allows the API server to discover\npublic signing keys for verifying tokens. The URL must begin with https://\nand should correspond to the iss claim in the provider's OIDC ID tokens.\nPer the OIDC standard, path components are allowed but query parameters are\nnot. Typically the URL consists of only a hostname, like https://server.example.org\nor https://example.com. This URL should point to the level below .well-known/openid-configuration\nand must be publicly accessible over the internet.",
               "type": "string"
             },
             "requiredClaims": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "The key value pairs that describe required claims in the identity token. If set, each claim is verified to be present in the token with a matching value. For the maximum number of claims that you can require, see Amazon EKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) in the Amazon EKS User Guide.",
+              "description": "The key value pairs that describe required claims in the identity token.\nIf set, each claim is verified to be present in the token with a matching\nvalue. For the maximum number of claims that you can require, see Amazon\nEKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html)\nin the Amazon EKS User Guide.",
               "type": "object"
             },
             "tags": {
@@ -530,11 +733,11 @@
               "type": "object"
             },
             "usernameClaim": {
-              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub, which is expected to be a unique identifier of the end user. You can choose other claims, such as email or name, depending on the OpenID identity provider. Claims other than email are prefixed with the issuer URL to prevent naming clashes with other plug-ins.",
+              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub,\nwhich is expected to be a unique identifier of the end user. You can choose\nother claims, such as email or name, depending on the OpenID identity provider.\nClaims other than email are prefixed with the issuer URL to prevent naming\nclashes with other plug-ins.",
               "type": "string"
             },
             "usernamePrefix": {
-              "description": "The prefix that is prepended to username claims to prevent clashes with existing names. If you do not provide this field, and username is a value other than email, the prefix defaults to issuerurl#. You can use the value - to disable all prefixing.",
+              "description": "The prefix that is prepended to username claims to prevent clashes with existing\nnames. If you do not provide this field, and username is a value other than\nemail, the prefix defaults to issuerurl#. You can use the value - to disable\nall prefixing.",
               "type": "string"
             }
           },
@@ -546,19 +749,19 @@
           "type": "string"
         },
         "roleAdditionalPolicies": {
-          "description": "RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to\nthe control plane role. You must enable the EKSAllowAddRoles\nfeature flag to incorporate these into the created role.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "roleName": {
-          "description": "RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "description": "RoleName specifies the name of IAM role that gives EKS\npermission to make API calls. If the role is pre-existing\nwe will treat it as unmanaged and not delete it on\ndeletion. If the EKSEnableIAM feature flag is true\nand no name is supplied then a role is created.",
           "minLength": 2,
           "type": "string"
         },
         "secondaryCidrBlock": {
-          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
+          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs.\nMust be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
           "type": "string"
         },
         "sshKeyName": {
@@ -567,7 +770,7 @@
         },
         "tokenMethod": {
           "default": "iam-authenticator",
-          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator",
+          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS\niam-authenticator - obtains a client token using iam-authentictor\naws-cli - obtains a client token using the AWS CLI\nDefaults to iam-authenticator",
           "enum": [
             "iam-authenticator",
             "aws-cli"
@@ -575,7 +778,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.",
+          "description": "Version defines the desired Kubernetes version. If no version number\nis supplied then the latest version of Kubernetes that EKS supports\nwill be used.",
           "minLength": 2,
           "pattern": "^v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.?(\\.0|[1-9][0-9]*)?$",
           "type": "string"
@@ -593,7 +796,7 @@
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   },
                   "valueFrom": {
@@ -607,7 +810,7 @@
                             "type": "string"
                           },
                           "name": {
-                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
@@ -619,10 +822,11 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "fieldRef": {
-                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                         "properties": {
                           "apiVersion": {
                             "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
@@ -637,10 +841,11 @@
                           "fieldPath"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "resourceFieldRef": {
-                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                         "properties": {
                           "containerName": {
                             "description": "Container name: required for volumes, optional for env vars",
@@ -668,6 +873,7 @@
                           "resource"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "secretKeyRef": {
@@ -678,7 +884,7 @@
                             "type": "string"
                           },
                           "name": {
-                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
@@ -690,6 +896,7 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -801,7 +1008,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
                     "type": "string"
                   }
                 },
@@ -816,6 +1023,10 @@
             },
             "availabilityZone": {
               "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "capacityReservationId": {
+              "description": "CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.",
               "type": "string"
             },
             "ebsOptimized": {
@@ -842,7 +1053,7 @@
               "properties": {
                 "httpEndpoint": {
                   "default": "enabled",
-                  "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -851,15 +1062,15 @@
                 },
                 "httpPutResponseHopLimit": {
                   "default": 1,
-                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
                   "format": "int64",
                   "maximum": 64,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "httpTokens": {
-                  "default": "required",
-                  "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                  "default": "optional",
+                  "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
                   "enum": [
                     "optional",
                     "required"
@@ -868,7 +1079,7 @@
                 },
                 "instanceMetadataTags": {
                   "default": "disabled",
-                  "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -904,7 +1115,7 @@
                     "type": "boolean"
                   },
                   "encryptionKey": {
-                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                     "type": "string"
                   },
                   "iops": {
@@ -913,7 +1124,7 @@
                     "type": "integer"
                   },
                   "size": {
-                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                     "format": "int64",
                     "minimum": 8,
                     "type": "integer"
@@ -936,9 +1147,47 @@
               },
               "type": "array"
             },
+            "placementGroupName": {
+              "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance.",
+              "type": "string"
+            },
+            "placementGroupPartition": {
+              "description": "PlacementGroupPartition is the partition number within the placement group in which to launch the instance.\nThis value is only valid if the placement group, referred in `PlacementGroupName`, was created with\nstrategy set to partition.",
+              "format": "int64",
+              "maximum": 7,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "privateDnsName": {
+              "description": "PrivateDNSName is the options for the instance hostname.",
+              "properties": {
+                "enableResourceNameDnsAAAARecord": {
+                  "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+                  "type": "boolean"
+                },
+                "enableResourceNameDnsARecord": {
+                  "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+                  "type": "boolean"
+                },
+                "hostnameType": {
+                  "description": "The type of hostname to assign to an instance.",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "privateIp": {
               "description": "The private IPv4 address assigned to the instance.",
               "type": "string"
+            },
+            "publicIPOnLaunch": {
+              "description": "PublicIPOnLaunch is the option to associate a public IP on instance launch",
+              "type": "boolean"
             },
             "publicIp": {
               "description": "The public IPv4 address assigned to the instance, if applicable.",
@@ -956,7 +1205,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -965,7 +1214,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -1028,7 +1277,7 @@
               "type": "string"
             },
             "userData": {
-              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap.\nThis field must not be base64 encoded and should only be used when running a new instance.",
               "type": "string"
             },
             "volumeIDs": {
@@ -1051,20 +1300,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -1072,7 +1321,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -1088,12 +1337,12 @@
         },
         "externalManagedControlPlane": {
           "default": true,
-          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.",
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane\nis managed by an external service such as AKS, EKS, GKE, etc.",
           "type": "boolean"
         },
         "failureDomains": {
           "additionalProperties": {
-            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains.\nIt allows controllers to understand how many failure domains a cluster can optionally span across.",
             "properties": {
               "attributes": {
                 "additionalProperties": {
@@ -1114,11 +1363,11 @@
           "type": "object"
         },
         "failureMessage": {
-          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the\nstate, and will be set to a descriptive error message.",
           "type": "string"
         },
         "identityProviderStatus": {
-          "description": "IdentityProviderStatus holds the status for associated identity provider",
+          "description": "IdentityProviderStatus holds the status for\nassociated identity provider",
           "properties": {
             "arn": {
               "description": "ARN holds the ARN of associated identity provider",
@@ -1133,7 +1382,7 @@
           "additionalProperties": false
         },
         "initialized": {
-          "description": "Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.",
+          "description": "Initialized denotes whether or not the control plane has the\nuploaded kubernetes config-map.",
           "type": "boolean"
         },
         "networkStatus": {
@@ -1143,7 +1392,7 @@
               "description": "APIServerELB is the Kubernetes api server load balancer.",
               "properties": {
                 "arn": {
-                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly to define and get it.",
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly\nto define and get it.",
                   "type": "string"
                 },
                 "attributes": {
@@ -1154,7 +1403,7 @@
                       "type": "boolean"
                     },
                     "idleTimeout": {
-                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
                       "format": "int64",
                       "type": "integer"
                     }
@@ -1194,10 +1443,11 @@
                         "type": "string"
                       },
                       "targetGroup": {
-                        "description": "TargetGroupSpec specifies target group settings for a given listener. This is created first, and the ARN is then passed to the listener.",
+                        "description": "TargetGroupSpec specifies target group settings for a given listener.\nThis is created first, and the ARN is then passed to the listener.",
                         "properties": {
                           "name": {
                             "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "maxLength": 32,
                             "type": "string"
                           },
                           "port": {
@@ -1210,7 +1460,10 @@
                             "enum": [
                               "tcp",
                               "tls",
-                              "upd"
+                              "udp",
+                              "TCP",
+                              "TLS",
+                              "UDP"
                             ],
                             "type": "string"
                           },
@@ -1235,6 +1488,10 @@
                                 "type": "integer"
                               },
                               "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
                                 "format": "int64",
                                 "type": "integer"
                               }
@@ -1274,7 +1531,7 @@
                       "type": "integer"
                     },
                     "interval": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -1282,7 +1539,7 @@
                       "type": "string"
                     },
                     "timeout": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -1345,7 +1602,260 @@
                   "type": "string"
                 },
                 "name": {
-                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "natGatewaysIPs": {
+              "description": "NatGatewaysIPs contains the public IPs of the NAT Gateways",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secondaryAPIServerELB": {
+              "description": "SecondaryAPIServerELB is the secondary Kubernetes api server load balancer.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly\nto define and get it.",
+                  "type": "string"
+                },
+                "attributes": {
+                  "description": "ClassicElbAttributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "elbAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ELBAttributes defines extra attributes associated with v2 load balancers.",
+                  "type": "object"
+                },
+                "elbListeners": {
+                  "description": "ELBListeners is an array of listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "Listener defines an AWS network load balancer listener.",
+                    "properties": {
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "targetGroup": {
+                        "description": "TargetGroupSpec specifies target group settings for a given listener.\nThis is created first, and the ARN is then passed to the listener.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "maxLength": 32,
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port is the exposed port",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "ELBProtocol defines listener protocols for a load balancer.",
+                            "enum": [
+                              "tcp",
+                              "tls",
+                              "udp",
+                              "TCP",
+                              "TLS",
+                              "UDP"
+                            ],
+                            "type": "string"
+                          },
+                          "targetGroupHealthCheck": {
+                            "description": "HealthCheck is the elb health check associated with the load balancer.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vpcId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "port",
+                          "protocol",
+                          "vpcId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "port",
+                      "protocol",
+                      "targetGroup"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "ClassicELBListeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "loadBalancerType": {
+                  "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                  "enum": [
+                    "classic",
+                    "elb",
+                    "alb",
+                    "nlb"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
                   "type": "string"
                 },
                 "scheme": {
@@ -1398,9 +1908,11 @@
                           "type": "array"
                         },
                         "description": {
+                          "description": "Description provides extended information about the ingress rule.",
                           "type": "string"
                         },
                         "fromPort": {
+                          "description": "FromPort is the start of port range.",
                           "format": "int64",
                           "type": "integer"
                         },
@@ -1411,8 +1923,21 @@
                           },
                           "type": "array"
                         },
+                        "natGatewaysIPsSource": {
+                          "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                          "type": "boolean"
+                        },
                         "protocol": {
-                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                          "enum": [
+                            "-1",
+                            "4",
+                            "tcp",
+                            "udp",
+                            "icmp",
+                            "58",
+                            "50"
+                          ],
                           "type": "string"
                         },
                         "sourceSecurityGroupIds": {
@@ -1422,7 +1947,24 @@
                           },
                           "type": "array"
                         },
+                        "sourceSecurityGroupRoles": {
+                          "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                          "items": {
+                            "description": "SecurityGroupRole defines the unique role of a security group.",
+                            "enum": [
+                              "bastion",
+                              "node",
+                              "controlplane",
+                              "apiserver-lb",
+                              "lb",
+                              "node-eks-additional"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "toPort": {
+                          "description": "ToPort is the end of port range.",
                           "format": "int64",
                           "type": "integer"
                         }
@@ -1481,7 +2023,7 @@
         },
         "ready": {
           "default": false,
-          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.",
+          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to\nreceive requests and that the VPC infra is ready.",
           "type": "boolean"
         }
       },

--- a/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta2.json
+++ b/controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSManagedControlPlane is the schema for the Amazon EKS Managed Control Plane API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "addons": {
@@ -27,9 +27,13 @@
           "items": {
             "description": "Addon represents a EKS addon.",
             "properties": {
+              "configuration": {
+                "description": "Configuration of the EKS addon",
+                "type": "string"
+              },
               "conflictResolution": {
                 "default": "overwrite",
-                "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+                "description": "ConflictResolution is used to declare what should happen if there\nare parameter conflicts. Defaults to none",
                 "enum": [
                   "overwrite",
                   "none"
@@ -61,33 +65,33 @@
         },
         "associateOIDCProvider": {
           "default": false,
-          "description": "AssociateOIDCProvider can be enabled to automatically create an identity provider for the controller for use with IAM roles for service accounts",
+          "description": "AssociateOIDCProvider can be enabled to automatically create an identity\nprovider for the controller for use with IAM roles for service accounts",
           "type": "boolean"
         },
         "bastion": {
           "description": "Bastion contains options to configure the bastion host.",
           "properties": {
             "allowedCIDRBlocks": {
-              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.\nThey are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "ami": {
-              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified,\nthe AMI will default to one picked out in public space.",
               "type": "string"
             },
             "disableIngressRules": {
-              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.\nRequires AllowedCIDRBlocks to be empty.",
               "type": "boolean"
             },
             "enabled": {
-              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "description": "Enabled allows this provider to create a bastion host instance\nwith a public ip to access the VPC private network.",
               "type": "boolean"
             },
             "instanceType": {
-              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified,\nCluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro\nwill be the default.",
               "type": "string"
             }
           },
@@ -115,7 +119,7 @@
           "additionalProperties": false
         },
         "eksClusterName": {
-          "description": "EKSClusterName allows you to specify the name of the EKS cluster in AWS. If you don't specify a name then a default name will be created based on the namespace and name of the managed control plane.",
+          "description": "EKSClusterName allows you to specify the name of the EKS cluster in\nAWS. If you don't specify a name then a default name will be created\nbased on the namespace and name of the managed control plane.",
           "type": "string"
         },
         "encryptionConfig": {
@@ -159,7 +163,7 @@
           "additionalProperties": false
         },
         "iamAuthenticatorConfig": {
-          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings for use when generating the aws-iam-authenticator configuration. If this is nil the default configuration is still generated for the cluster.",
+          "description": "IAMAuthenticatorConfig allows the specification of any additional user or role mappings\nfor use when generating the aws-iam-authenticator configuration. If this is nil the\ndefault configuration is still generated for the cluster.",
           "properties": {
             "mapRoles": {
               "description": "RoleMappings is a list of role mappings",
@@ -230,7 +234,7 @@
           "additionalProperties": false
         },
         "identityRef": {
-          "description": "IdentityRef is a reference to a identity to be used when reconciling the managed control plane.",
+          "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
           "properties": {
             "kind": {
               "description": "Kind of the identity.",
@@ -255,15 +259,15 @@
           "additionalProperties": false
         },
         "imageLookupBaseOS": {
-          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look\nup machine images when a machine does not specify an AMI. When set, this\nwill be used for all cluster machines unless a machine specifies a\ndifferent ImageLookupBaseOS.",
           "type": "string"
         },
         "imageLookupFormat": {
-          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when\na machine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.\nSupports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base\nOS and kubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
           "type": "string"
         },
         "imageLookupOrg": {
-          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a\nmachine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.",
           "type": "string"
         },
         "kubeProxy": {
@@ -271,7 +275,7 @@
           "properties": {
             "disable": {
               "default": false,
-              "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster. For clusters where you want to use kube-proxy functionality that is provided with an alternate CNI, this option provides a way to specify that the kube-proxy daemonset should be deleted. You cannot set this to true if you are using the Amazon kube-proxy addon.",
+              "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters\nkube-proxy is automatically installed into the cluster. For clusters where you want\nto use kube-proxy functionality that is provided with an alternate CNI, this option\nprovides a way to specify that the kube-proxy daemonset should be deleted. You cannot\nset this to true if you are using the Amazon kube-proxy addon.",
               "type": "boolean"
             }
           },
@@ -279,7 +283,7 @@
           "additionalProperties": false
         },
         "logging": {
-          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for each of the enabled logs will be sent to CloudWatch",
+          "description": "Logging specifies which EKS Cluster logs should be enabled. Entries for\neach of the enabled logs will be sent to CloudWatch",
           "properties": {
             "apiServer": {
               "default": false,
@@ -320,11 +324,96 @@
         "network": {
           "description": "NetworkSpec encapsulates all things related to AWS network.",
           "properties": {
+            "additionalControlPlaneIngressRules": {
+              "description": "AdditionalControlPlaneIngressRules is an optional set of ingress rules to add to the control plane",
+              "items": {
+                "description": "IngressRule defines an AWS ingress rule for security groups.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description provides extended information about the ingress rule.",
+                    "type": "string"
+                  },
+                  "fromPort": {
+                    "description": "FromPort is the start of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "ipv6CidrBlocks": {
+                    "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "natGatewaysIPsSource": {
+                    "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                    "type": "boolean"
+                  },
+                  "protocol": {
+                    "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                    "enum": [
+                      "-1",
+                      "4",
+                      "tcp",
+                      "udp",
+                      "icmp",
+                      "58",
+                      "50"
+                    ],
+                    "type": "string"
+                  },
+                  "sourceSecurityGroupIds": {
+                    "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sourceSecurityGroupRoles": {
+                    "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                    "items": {
+                      "description": "SecurityGroupRole defines the unique role of a security group.",
+                      "enum": [
+                        "bastion",
+                        "node",
+                        "controlplane",
+                        "apiserver-lb",
+                        "lb",
+                        "node-eks-additional"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "toPort": {
+                    "description": "ToPort is the end of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "description",
+                  "fromPort",
+                  "protocol",
+                  "toPort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "cni": {
               "description": "CNI configuration",
               "properties": {
                 "cniIngressRules": {
-                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups.\nThe source for the rule will be set to control plane and worker security group IDs.",
                   "items": {
                     "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
                     "properties": {
@@ -363,7 +452,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances\nThis is optional - if not provided new security groups will be created for the cluster",
               "type": "object"
             },
             "subnets": {
@@ -380,15 +469,15 @@
                     "type": "string"
                   },
                   "id": {
-                    "description": "ID defines a unique identifier to reference this resource.",
+                    "description": "ID defines a unique identifier to reference this resource.\nIf you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`.\n\n\nWhen the VPC is managed by CAPA, and you'd like the provider to create a subnet for you,\nthe id can be set to any placeholder value that does not start with `subnet-`;\nupon creation, the subnet AWS identifier will be populated in the `ResourceID` field and\nthe `id` field is going to be used as the subnet name. If you specify a tag\ncalled `Name`, it takes precedence.",
                     "type": "string"
                   },
                   "ipv6CidrBlock": {
-                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.\nA subnet can have an IPv4 and an IPv6 address.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "string"
                   },
                   "isIpv6": {
-                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "boolean"
                   },
                   "isPublic": {
@@ -396,7 +485,15 @@
                     "type": "boolean"
                   },
                   "natGatewayId": {
-                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet.\nIgnored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "parentZoneName": {
+                    "description": "ParentZoneName is the zone name where the current subnet's zone is tied when\nthe zone is a Local Zone.\n\n\nThe subnets in Local Zone or Wavelength Zone locations consume the ParentZoneName\nto select the correct private route table to egress traffic to the internet.",
+                    "type": "string"
+                  },
+                  "resourceID": {
+                    "description": "ResourceID is the subnet identifier from AWS, READ ONLY.\nThis field is populated when the provider manages the subnet.",
                     "type": "string"
                   },
                   "routeTableId": {
@@ -409,6 +506,15 @@
                     },
                     "description": "Tags is a collection of tags describing the resource.",
                     "type": "object"
+                  },
+                  "zoneType": {
+                    "description": "ZoneType defines the type of the zone where the subnet is created.\n\n\nThe valid values are availability-zone, local-zone, and wavelength-zone.\n\n\nSubnet with zone type availability-zone (regular) is always selected to create cluster\nresources, like Load Balancers, NAT Gateways, Contol Plane nodes, etc.\n\n\nSubnet with zone type local-zone or wavelength-zone is not eligible to automatically create\nregular cluster resources.\n\n\nThe public subnet in availability-zone or local-zone is associated with regular public\nroute table with default route entry to a Internet Gateway.\n\n\nThe public subnet in wavelength-zone is associated with a carrier public\nroute table with default route entry to a Carrier Gateway.\n\n\nThe private subnet in the availability-zone is associated with a private route table with\nthe default route entry to a NAT Gateway created in that zone.\n\n\nThe private subnet in the local-zone or wavelength-zone is associated with a private route table with\nthe default route entry re-using the NAT Gateway in the Region (preferred from the\nparent zone, the zone type availability-zone in the region, or first table available).",
+                    "enum": [
+                      "availability-zone",
+                      "local-zone",
+                      "wavelength-zone"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -428,7 +534,7 @@
               "properties": {
                 "availabilityZoneSelection": {
                   "default": "Ordered",
-                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs\nin a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:\nOrdered - selects based on alphabetical order\nRandom - selects AZs randomly in a region\nDefaults to Ordered",
                   "enum": [
                     "Ordered",
                     "Random"
@@ -437,13 +543,53 @@
                 },
                 "availabilityZoneUsageLimit": {
                   "default": 3,
-                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that\nshould be used in a region when automatically creating subnets. If a region has more\nthan this number of AZs then this number of AZs will be picked randomly when creating\ndefault subnets. Defaults to 3",
                   "minimum": 1,
                   "type": "integer"
                 },
+                "carrierGatewayId": {
+                  "description": "CarrierGatewayID is the id of the internet gateway associated with the VPC,\nfor carrier network (Wavelength Zones).",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Carrier Gateway ID must start with 'cagw-'",
+                      "rule": "self.startsWith('cagw-')"
+                    }
+                  ]
+                },
                 "cidrBlock": {
-                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.\nDefaults to 10.0.0.0/16.\nMutually exclusive with IPAMPool.",
                   "type": "string"
+                },
+                "elasticIpPool": {
+                  "description": "ElasticIPPool contains specific configuration to allocate Public IPv4 address (Elastic IP) from user-defined pool\nbrought to AWS for core infrastructure resources, like NAT Gateways and Public Network Load Balancers for\nthe API Server.",
+                  "properties": {
+                    "publicIpv4Pool": {
+                      "description": "PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources\ncreated in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom\nPublic IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool\nresource ID starts with 'ipv4pool-ec2'.",
+                      "maxLength": 30,
+                      "type": "string"
+                    },
+                    "publicIpv4PoolFallbackOrder": {
+                      "description": "PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,\nno more IPv4 address available in the pool.\n\n\nWhen set to 'amazon-pool', the controller check if the pool has available IPv4 address, when pool has reached the\nIPv4 limit, the address will be claimed from Amazon-pool (default).\n\n\nWhen set to 'none', the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.",
+                      "enum": [
+                        "amazon-pool",
+                        "none"
+                      ],
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "allowed values are 'none' and 'amazon-pool'",
+                          "rule": "self in ['none','amazon-pool']"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "emptyRoutesDefaultVPCSecurityGroup": {
+                  "description": "EmptyRoutesDefaultVPCSecurityGroup specifies whether the default VPC security group ingress\nand egress rules should be removed.\n\n\nBy default, when creating a VPC, AWS creates a security group called `default` with ingress and egress\nrules that allow traffic from anywhere. The group could be used as a potential surface attack and\nit's generally suggested that the group rules are removed or modified appropriately.\n\n\nNOTE: This only applies when the VPC is managed by the Cluster API AWS controller.",
+                  "type": "boolean"
                 },
                 "id": {
                   "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
@@ -453,24 +599,81 @@
                   "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
                   "type": "string"
                 },
+                "ipamPool": {
+                  "description": "IPAMPool defines the IPAMv4 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                      "type": "string"
+                    },
+                    "netmaskLength": {
+                      "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "ipv6": {
-                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.\nThis field cannot be set on AWSCluster object.",
                   "properties": {
                     "cidrBlock": {
-                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.\nMutually exclusive with IPAMPool.",
                       "type": "string"
                     },
                     "egressOnlyInternetGatewayId": {
                       "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
                       "type": "string"
                     },
+                    "ipamPool": {
+                      "description": "IPAMPool defines the IPAMv6 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                      "properties": {
+                        "id": {
+                          "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                          "type": "string"
+                        },
+                        "netmaskLength": {
+                          "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "poolId": {
-                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.\nMust be specified if CidrBlock is set.\nMutually exclusive with IPAMPool.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "privateDnsHostnameTypeOnLaunch": {
+                  "description": "PrivateDNSHostnameTypeOnLaunch is the type of hostname to assign to instances in the subnet at launch.\nFor IPv4-only and dual-stack (IPv4 and IPv6) subnets, an instance DNS name can be based on the instance IPv4 address (ip-name)\nor the instance ID (resource-name). For IPv6 only subnets, an instance DNS name must be based on the instance ID (resource-name).",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                },
+                "subnetSchema": {
+                  "default": "PreferPrivate",
+                  "description": "SubnetSchema specifies how CidrBlock should be divided on subnets in the VPC depending on the number of AZs.\nPreferPrivate - one private subnet for each AZ plus one other subnet that will be further sub-divided for the public subnets.\nPreferPublic - have the reverse logic of PreferPrivate, one public subnet for each AZ plus one other subnet\nthat will be further sub-divided for the private subnets.\nDefaults to PreferPrivate",
+                  "enum": [
+                    "PreferPrivate",
+                    "PreferPublic"
+                  ],
+                  "type": "string"
                 },
                 "tags": {
                   "additionalProperties": {
@@ -488,10 +691,10 @@
           "additionalProperties": false
         },
         "oidcIdentityProviderConfig": {
-          "description": "IdentityProviderconfig is used to specify the oidc provider config to be attached with this eks cluster",
+          "description": "IdentityProviderconfig is used to specify the oidc provider config\nto be attached with this eks cluster",
           "properties": {
             "clientId": {
-              "description": "This is also known as audience. The ID for the client application that makes authentication requests to the OpenID identity provider.",
+              "description": "This is also known as audience. The ID for the client application that makes\nauthentication requests to the OpenID identity provider.",
               "type": "string"
             },
             "groupsClaim": {
@@ -499,22 +702,22 @@
               "type": "string"
             },
             "groupsPrefix": {
-              "description": "The prefix that is prepended to group claims to prevent clashes with existing names (such as system: groups). For example, the valueoidc: will create group names like oidc:engineering and oidc:infra.",
+              "description": "The prefix that is prepended to group claims to prevent clashes with existing\nnames (such as system: groups). For example, the valueoidc: will create group\nnames like oidc:engineering and oidc:infra.",
               "type": "string"
             },
             "identityProviderConfigName": {
-              "description": "The name of the OIDC provider configuration. \n IdentityProviderConfigName is a required field",
+              "description": "The name of the OIDC provider configuration.\n\n\nIdentityProviderConfigName is a required field",
               "type": "string"
             },
             "issuerUrl": {
-              "description": "The URL of the OpenID identity provider that allows the API server to discover public signing keys for verifying tokens. The URL must begin with https:// and should correspond to the iss claim in the provider's OIDC ID tokens. Per the OIDC standard, path components are allowed but query parameters are not. Typically the URL consists of only a hostname, like https://server.example.org or https://example.com. This URL should point to the level below .well-known/openid-configuration and must be publicly accessible over the internet.",
+              "description": "The URL of the OpenID identity provider that allows the API server to discover\npublic signing keys for verifying tokens. The URL must begin with https://\nand should correspond to the iss claim in the provider's OIDC ID tokens.\nPer the OIDC standard, path components are allowed but query parameters are\nnot. Typically the URL consists of only a hostname, like https://server.example.org\nor https://example.com. This URL should point to the level below .well-known/openid-configuration\nand must be publicly accessible over the internet.",
               "type": "string"
             },
             "requiredClaims": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "The key value pairs that describe required claims in the identity token. If set, each claim is verified to be present in the token with a matching value. For the maximum number of claims that you can require, see Amazon EKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) in the Amazon EKS User Guide.",
+              "description": "The key value pairs that describe required claims in the identity token.\nIf set, each claim is verified to be present in the token with a matching\nvalue. For the maximum number of claims that you can require, see Amazon\nEKS service quotas (https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html)\nin the Amazon EKS User Guide.",
               "type": "object"
             },
             "tags": {
@@ -525,35 +728,44 @@
               "type": "object"
             },
             "usernameClaim": {
-              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub, which is expected to be a unique identifier of the end user. You can choose other claims, such as email or name, depending on the OpenID identity provider. Claims other than email are prefixed with the issuer URL to prevent naming clashes with other plug-ins.",
+              "description": "The JSON Web Token (JWT) claim to use as the username. The default is sub,\nwhich is expected to be a unique identifier of the end user. You can choose\nother claims, such as email or name, depending on the OpenID identity provider.\nClaims other than email are prefixed with the issuer URL to prevent naming\nclashes with other plug-ins.",
               "type": "string"
             },
             "usernamePrefix": {
-              "description": "The prefix that is prepended to username claims to prevent clashes with existing names. If you do not provide this field, and username is a value other than email, the prefix defaults to issuerurl#. You can use the value - to disable all prefixing.",
+              "description": "The prefix that is prepended to username claims to prevent clashes with existing\nnames. If you do not provide this field, and username is a value other than\nemail, the prefix defaults to issuerurl#. You can use the value - to disable\nall prefixing.",
               "type": "string"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
+        "partition": {
+          "description": "Partition is the AWS security partition being used. Defaults to \"aws\"",
+          "type": "string"
+        },
         "region": {
           "description": "The AWS Region the cluster lives in.",
           "type": "string"
         },
+        "restrictPrivateSubnets": {
+          "default": false,
+          "description": "RestrictPrivateSubnets indicates that the EKS control plane should only use private subnets.",
+          "type": "boolean"
+        },
         "roleAdditionalPolicies": {
-          "description": "RoleAdditionalPolicies allows you to attach additional polices to the control plane role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to\nthe control plane role. You must enable the EKSAllowAddRoles\nfeature flag to incorporate these into the created role.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "roleName": {
-          "description": "RoleName specifies the name of IAM role that gives EKS permission to make API calls. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "description": "RoleName specifies the name of IAM role that gives EKS\npermission to make API calls. If the role is pre-existing\nwe will treat it as unmanaged and not delete it on\ndeletion. If the EKSEnableIAM feature flag is true\nand no name is supplied then a role is created.",
           "minLength": 2,
           "type": "string"
         },
         "secondaryCidrBlock": {
-          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs. Must be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
+          "description": "SecondaryCidrBlock is the additional CIDR range to use for pod IPs.\nMust be within the 100.64.0.0/10 or 198.19.0.0/16 range.",
           "type": "string"
         },
         "sshKeyName": {
@@ -562,7 +774,7 @@
         },
         "tokenMethod": {
           "default": "iam-authenticator",
-          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS iam-authenticator - obtains a client token using iam-authentictor aws-cli - obtains a client token using the AWS CLI Defaults to iam-authenticator",
+          "description": "TokenMethod is used to specify the method for obtaining a client token for communicating with EKS\niam-authenticator - obtains a client token using iam-authentictor\naws-cli - obtains a client token using the AWS CLI\nDefaults to iam-authenticator",
           "enum": [
             "iam-authenticator",
             "aws-cli"
@@ -570,7 +782,7 @@
           "type": "string"
         },
         "version": {
-          "description": "Version defines the desired Kubernetes version. If no version number is supplied then the latest version of Kubernetes that EKS supports will be used.",
+          "description": "Version defines the desired Kubernetes version. If no version number\nis supplied then the latest version of Kubernetes that EKS supports\nwill be used.",
           "minLength": 2,
           "pattern": "^v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.?(\\.0|[1-9][0-9]*)?$",
           "type": "string"
@@ -580,7 +792,7 @@
           "properties": {
             "disable": {
               "default": false,
-              "description": "Disable indicates that the Amazon VPC CNI should be disabled. With EKS clusters the Amazon VPC CNI is automatically installed into the cluster. For clusters where you want to use an alternate CNI this option provides a way to specify that the Amazon VPC CNI should be deleted. You cannot set this to true if you are using the Amazon VPC CNI addon.",
+              "description": "Disable indicates that the Amazon VPC CNI should be disabled. With EKS clusters the\nAmazon VPC CNI is automatically installed into the cluster. For clusters where you want\nto use an alternate CNI this option provides a way to specify that the Amazon VPC CNI\nshould be deleted. You cannot set this to true if you are using the\nAmazon VPC CNI addon.",
               "type": "boolean"
             },
             "env": {
@@ -593,7 +805,7 @@
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   },
                   "valueFrom": {
@@ -607,7 +819,7 @@
                             "type": "string"
                           },
                           "name": {
-                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
@@ -619,10 +831,11 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "fieldRef": {
-                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                         "properties": {
                           "apiVersion": {
                             "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
@@ -637,10 +850,11 @@
                           "fieldPath"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "resourceFieldRef": {
-                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                         "properties": {
                           "containerName": {
                             "description": "Container name: required for volumes, optional for env vars",
@@ -668,6 +882,7 @@
                           "resource"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "secretKeyRef": {
@@ -678,7 +893,7 @@
                             "type": "string"
                           },
                           "name": {
-                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                             "type": "string"
                           },
                           "optional": {
@@ -690,6 +905,7 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -801,7 +1017,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
                     "type": "string"
                   }
                 },
@@ -816,6 +1032,10 @@
             },
             "availabilityZone": {
               "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "capacityReservationId": {
+              "description": "CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.",
               "type": "string"
             },
             "ebsOptimized": {
@@ -842,7 +1062,7 @@
               "properties": {
                 "httpEndpoint": {
                   "default": "enabled",
-                  "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -851,15 +1071,15 @@
                 },
                 "httpPutResponseHopLimit": {
                   "default": 1,
-                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
                   "format": "int64",
                   "maximum": 64,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "httpTokens": {
-                  "default": "required",
-                  "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                  "default": "optional",
+                  "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
                   "enum": [
                     "optional",
                     "required"
@@ -868,7 +1088,7 @@
                 },
                 "instanceMetadataTags": {
                   "default": "disabled",
-                  "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -904,7 +1124,7 @@
                     "type": "boolean"
                   },
                   "encryptionKey": {
-                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                     "type": "string"
                   },
                   "iops": {
@@ -913,7 +1133,7 @@
                     "type": "integer"
                   },
                   "size": {
-                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                     "format": "int64",
                     "minimum": 8,
                     "type": "integer"
@@ -936,9 +1156,47 @@
               },
               "type": "array"
             },
+            "placementGroupName": {
+              "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance.",
+              "type": "string"
+            },
+            "placementGroupPartition": {
+              "description": "PlacementGroupPartition is the partition number within the placement group in which to launch the instance.\nThis value is only valid if the placement group, referred in `PlacementGroupName`, was created with\nstrategy set to partition.",
+              "format": "int64",
+              "maximum": 7,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "privateDnsName": {
+              "description": "PrivateDNSName is the options for the instance hostname.",
+              "properties": {
+                "enableResourceNameDnsAAAARecord": {
+                  "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+                  "type": "boolean"
+                },
+                "enableResourceNameDnsARecord": {
+                  "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+                  "type": "boolean"
+                },
+                "hostnameType": {
+                  "description": "The type of hostname to assign to an instance.",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "privateIp": {
               "description": "The private IPv4 address assigned to the instance.",
               "type": "string"
+            },
+            "publicIPOnLaunch": {
+              "description": "PublicIPOnLaunch is the option to associate a public IP on instance launch",
+              "type": "boolean"
             },
             "publicIp": {
               "description": "The public IPv4 address assigned to the instance, if applicable.",
@@ -956,7 +1214,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -965,7 +1223,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -1028,7 +1286,7 @@
               "type": "string"
             },
             "userData": {
-              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap.\nThis field must not be base64 encoded and should only be used when running a new instance.",
               "type": "string"
             },
             "volumeIDs": {
@@ -1051,20 +1309,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -1072,7 +1330,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -1088,12 +1346,12 @@
         },
         "externalManagedControlPlane": {
           "default": true,
-          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane is managed by an external service such as AKS, EKS, GKE, etc.",
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane\nis managed by an external service such as AKS, EKS, GKE, etc.",
           "type": "boolean"
         },
         "failureDomains": {
           "additionalProperties": {
-            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains.\nIt allows controllers to understand how many failure domains a cluster can optionally span across.",
             "properties": {
               "attributes": {
                 "additionalProperties": {
@@ -1114,11 +1372,11 @@
           "type": "object"
         },
         "failureMessage": {
-          "description": "ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.",
+          "description": "ErrorMessage indicates that there is a terminal problem reconciling the\nstate, and will be set to a descriptive error message.",
           "type": "string"
         },
         "identityProviderStatus": {
-          "description": "IdentityProviderStatus holds the status for associated identity provider",
+          "description": "IdentityProviderStatus holds the status for\nassociated identity provider",
           "properties": {
             "arn": {
               "description": "ARN holds the ARN of associated identity provider",
@@ -1133,7 +1391,7 @@
           "additionalProperties": false
         },
         "initialized": {
-          "description": "Initialized denotes whether or not the control plane has the uploaded kubernetes config-map.",
+          "description": "Initialized denotes whether or not the control plane has the\nuploaded kubernetes config-map.",
           "type": "boolean"
         },
         "networkStatus": {
@@ -1143,7 +1401,7 @@
               "description": "APIServerELB is the Kubernetes api server load balancer.",
               "properties": {
                 "arn": {
-                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly to define and get it.",
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly\nto define and get it.",
                   "type": "string"
                 },
                 "attributes": {
@@ -1154,7 +1412,7 @@
                       "type": "boolean"
                     },
                     "idleTimeout": {
-                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
                       "format": "int64",
                       "type": "integer"
                     }
@@ -1194,10 +1452,11 @@
                         "type": "string"
                       },
                       "targetGroup": {
-                        "description": "TargetGroupSpec specifies target group settings for a given listener. This is created first, and the ARN is then passed to the listener.",
+                        "description": "TargetGroupSpec specifies target group settings for a given listener.\nThis is created first, and the ARN is then passed to the listener.",
                         "properties": {
                           "name": {
                             "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "maxLength": 32,
                             "type": "string"
                           },
                           "port": {
@@ -1210,7 +1469,10 @@
                             "enum": [
                               "tcp",
                               "tls",
-                              "upd"
+                              "udp",
+                              "TCP",
+                              "TLS",
+                              "UDP"
                             ],
                             "type": "string"
                           },
@@ -1235,6 +1497,10 @@
                                 "type": "integer"
                               },
                               "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
                                 "format": "int64",
                                 "type": "integer"
                               }
@@ -1274,7 +1540,7 @@
                       "type": "integer"
                     },
                     "interval": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -1282,7 +1548,7 @@
                       "type": "string"
                     },
                     "timeout": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -1345,7 +1611,260 @@
                   "type": "string"
                 },
                 "name": {
-                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "natGatewaysIPs": {
+              "description": "NatGatewaysIPs contains the public IPs of the NAT Gateways",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secondaryAPIServerELB": {
+              "description": "SecondaryAPIServerELB is the secondary Kubernetes api server load balancer.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly\nto define and get it.",
+                  "type": "string"
+                },
+                "attributes": {
+                  "description": "ClassicElbAttributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "elbAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ELBAttributes defines extra attributes associated with v2 load balancers.",
+                  "type": "object"
+                },
+                "elbListeners": {
+                  "description": "ELBListeners is an array of listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "Listener defines an AWS network load balancer listener.",
+                    "properties": {
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "targetGroup": {
+                        "description": "TargetGroupSpec specifies target group settings for a given listener.\nThis is created first, and the ARN is then passed to the listener.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "maxLength": 32,
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port is the exposed port",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "ELBProtocol defines listener protocols for a load balancer.",
+                            "enum": [
+                              "tcp",
+                              "tls",
+                              "udp",
+                              "TCP",
+                              "TLS",
+                              "UDP"
+                            ],
+                            "type": "string"
+                          },
+                          "targetGroupHealthCheck": {
+                            "description": "HealthCheck is the elb health check associated with the load balancer.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vpcId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "port",
+                          "protocol",
+                          "vpcId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "port",
+                      "protocol",
+                      "targetGroup"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "ClassicELBListeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "loadBalancerType": {
+                  "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                  "enum": [
+                    "classic",
+                    "elb",
+                    "alb",
+                    "nlb"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
                   "type": "string"
                 },
                 "scheme": {
@@ -1398,9 +1917,11 @@
                           "type": "array"
                         },
                         "description": {
+                          "description": "Description provides extended information about the ingress rule.",
                           "type": "string"
                         },
                         "fromPort": {
+                          "description": "FromPort is the start of port range.",
                           "format": "int64",
                           "type": "integer"
                         },
@@ -1411,8 +1932,21 @@
                           },
                           "type": "array"
                         },
+                        "natGatewaysIPsSource": {
+                          "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                          "type": "boolean"
+                        },
                         "protocol": {
-                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                          "enum": [
+                            "-1",
+                            "4",
+                            "tcp",
+                            "udp",
+                            "icmp",
+                            "58",
+                            "50"
+                          ],
                           "type": "string"
                         },
                         "sourceSecurityGroupIds": {
@@ -1422,7 +1956,24 @@
                           },
                           "type": "array"
                         },
+                        "sourceSecurityGroupRoles": {
+                          "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                          "items": {
+                            "description": "SecurityGroupRole defines the unique role of a security group.",
+                            "enum": [
+                              "bastion",
+                              "node",
+                              "controlplane",
+                              "apiserver-lb",
+                              "lb",
+                              "node-eks-additional"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "toPort": {
+                          "description": "ToPort is the end of port range.",
                           "format": "int64",
                           "type": "integer"
                         }
@@ -1481,7 +2032,7 @@
         },
         "ready": {
           "default": false,
-          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to receive requests and that the VPC infra is ready.",
+          "description": "Ready denotes that the AWSManagedControlPlane API Server is ready to\nreceive requests and that the VPC infra is ready.",
           "type": "boolean"
         }
       },

--- a/controlplane.cluster.x-k8s.io/rosacontrolplane_v1beta2.json
+++ b/controlplane.cluster.x-k8s.io/rosacontrolplane_v1beta2.json
@@ -1,0 +1,644 @@
+{
+  "description": "ROSAControlPlane is the Schema for the ROSAControlPlanes API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "RosaControlPlaneSpec defines the desired state of ROSAControlPlane.",
+      "properties": {
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags are user-defined tags to be added on the AWS resources associated with the control plane.",
+          "type": "object"
+        },
+        "auditLogRoleARN": {
+          "description": "AuditLogRoleARN defines the role that is used to forward audit logs to AWS CloudWatch.\nIf not set, audit log forwarding is disabled.",
+          "type": "string"
+        },
+        "availabilityZones": {
+          "description": "AvailabilityZones describe AWS AvailabilityZones of the worker nodes.\nshould match the AvailabilityZones of the provided Subnets.\na machinepool will be created for each availabilityZone.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "billingAccount": {
+          "description": "BillingAccount is an optional AWS account to use for billing the subscription fees for ROSA clusters.\nThe cost of running each ROSA cluster will be billed to the infrastructure account in which the cluster\nis running.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "billingAccount is immutable",
+              "rule": "self == oldSelf"
+            },
+            {
+              "message": "billingAccount must be a valid AWS account ID",
+              "rule": "self.matches('^[0-9]{12}$')"
+            }
+          ]
+        },
+        "controlPlaneEndpoint": {
+          "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
+          "properties": {
+            "host": {
+              "description": "The hostname on which the API server is serving.",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "credentialsSecretRef": {
+          "description": "CredentialsSecretRef references a secret with necessary credentials to connect to the OCM API.\nThe secret should contain the following data keys:\n- ocmToken: eyJhbGciOiJIUzI1NiIsI....\n- ocmApiUrl: Optional, defaults to 'https://api.openshift.com'",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "defaultMachinePoolSpec": {
+          "description": "DefaultMachinePoolSpec defines the configuration for the default machinepool(s) provisioned as part of the cluster creation.\nOne MachinePool will be created with this configuration per AvailabilityZone. Those default machinepools are required for openshift cluster operators\nto work properly.\nAs these machinepool not created using ROSAMachinePool CR, they will not be visible/managed by ROSA CAPI provider.\n`rosa list machinepools -c <rosaClusterName>` can be used to view those machinepools.\n\n\nThis field will be removed in the future once the current limitation is resolved.",
+          "properties": {
+            "autoscaling": {
+              "description": "Autoscaling specifies auto scaling behaviour for the default MachinePool. Autoscaling min/max value\nmust be equal or multiple of the availability zones count.",
+              "properties": {
+                "maxReplicas": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "minReplicas": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instanceType": {
+              "description": "The instance type to use, for example `r5.xlarge`. Instance type ref; https://aws.amazon.com/ec2/instance-types/",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "domainPrefix": {
+          "description": "DomainPrefix is an optional prefix added to the cluster's domain name. It will be used\nwhen generating a sub-domain for the cluster on openshiftapps domain. It must be valid DNS-1035 label\nconsisting of lower case alphanumeric characters or '-', start with an alphabetic character\nend with an alphanumeric character and have a max length of 15 characters.",
+          "maxLength": 15,
+          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "domainPrefix is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "enableExternalAuthProviders": {
+          "default": false,
+          "description": "EnableExternalAuthProviders enables external authentication configuration for the cluster.",
+          "type": "boolean",
+          "x-kubernetes-validations": [
+            {
+              "message": "enableExternalAuthProviders is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "endpointAccess": {
+          "default": "Public",
+          "description": "EndpointAccess specifies the publishing scope of cluster endpoints. The\ndefault is Public.",
+          "enum": [
+            "Public",
+            "Private"
+          ],
+          "type": "string"
+        },
+        "etcdEncryptionKMSARN": {
+          "description": "EtcdEncryptionKMSARN is the ARN of the KMS key used to encrypt etcd. The key itself needs to be\ncreated out-of-band by the user and tagged with `red-hat:true`.",
+          "type": "string"
+        },
+        "externalAuthProviders": {
+          "description": "ExternalAuthProviders are external OIDC identity providers that can issue tokens for this cluster.\nCan only be set if \"enableExternalAuthProviders\" is set to \"True\".\n\n\nAt most one provider can be configured.",
+          "items": {
+            "description": "ExternalAuthProvider is an external OIDC identity provider that can issue tokens for this cluster",
+            "properties": {
+              "claimMappings": {
+                "description": "ClaimMappings describes rules on how to transform information from an\nID token into a cluster identity",
+                "properties": {
+                  "groups": {
+                    "description": "Groups is a name of the claim that should be used to construct\ngroups for the cluster identity.\nThe referenced claim must use array of strings values.",
+                    "properties": {
+                      "claim": {
+                        "description": "Claim is a JWT token claim to be used in the mapping",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "description": "Prefix is a string to prefix the value from the token in the result of the\nclaim mapping.\n\n\nBy default, no prefixing occurs.\n\n\nExample: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains\nan array of strings \"a\", \"b\" and  \"c\", the mapping will result in an\narray of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "claim"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "username": {
+                    "description": "Username is a name of the claim that should be used to construct\nusernames for the cluster identity.\n\n\nDefault value: \"sub\"",
+                    "properties": {
+                      "claim": {
+                        "description": "Claim is a JWT token claim to be used in the mapping",
+                        "type": "string"
+                      },
+                      "prefix": {
+                        "description": "Prefix is prepended to claim to prevent clashes with existing names.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "prefixPolicy": {
+                        "description": "PrefixPolicy specifies how a prefix should apply.\n\n\nBy default, claims other than `email` will be prefixed with the issuer URL to\nprevent naming clashes with other plugins.\n\n\nSet to \"NoPrefix\" to disable prefixing.\n\n\nExample:\n    (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\".\n        If the JWT claim `username` contains value `userA`, the resulting\n        mapped value will be \"myoidc:userA\".\n    (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the\n        JWT `email` claim contains value \"userA@myoidc.tld\", the resulting\n        mapped value will be \"myoidc:userA@myoidc.tld\".\n    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n        the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n        and `claim` is set to:\n        (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n        (b) \"email\": the mapped value will be \"userA@myoidc.tld\"",
+                        "enum": [
+                          "",
+                          "NoPrefix",
+                          "Prefix"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "claim"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise",
+                        "rule": "self.prefixPolicy == 'Prefix' ? has(self.prefix) : !has(self.prefix)"
+                      }
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "claimValidationRules": {
+                "description": "ClaimValidationRules are rules that are applied to validate token claims to authenticate users.",
+                "items": {
+                  "description": "TokenClaimValidationRule validates token claims to authenticate users.",
+                  "properties": {
+                    "requiredClaim": {
+                      "description": "RequiredClaim allows configuring a required claim name and its expected value",
+                      "properties": {
+                        "claim": {
+                          "description": "Claim is a name of a required claim. Only claims with string values are\nsupported.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "requiredValue": {
+                          "description": "RequiredValue is the required value for the claim.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "claim",
+                        "requiredValue"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "default": "RequiredClaim",
+                      "description": "Type sets the type of the validation rule",
+                      "enum": [
+                        "RequiredClaim"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "requiredClaim",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "issuer": {
+                "description": "Issuer describes attributes of the OIDC token issuer",
+                "properties": {
+                  "audiences": {
+                    "description": "Audiences is an array of audiences that the token was issued for.\nValid tokens must include at least one of these values in their\n\"aud\" claim.\nMust be set to exactly one value.",
+                    "items": {
+                      "description": "TokenAudience is the audience that the token was issued for.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "maxItems": 10,
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
+                  "issuerCertificateAuthority": {
+                    "description": "CertificateAuthority is a reference to a config map in the\nconfiguration namespace. The .data of the configMap must contain\nthe \"ca-bundle.crt\" key.\nIf unset, system trust is used instead.",
+                    "properties": {
+                      "name": {
+                        "description": "Name is the metadata.name of the referenced object.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "issuerURL": {
+                    "description": "URL is the serving URL of the token issuer.\nMust use the https:// scheme.",
+                    "pattern": "^https:\\/\\/[^\\s]",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "audiences",
+                  "issuerURL"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name of the OIDC provider",
+                "minLength": 1,
+                "type": "string"
+              },
+              "oidcClients": {
+                "description": "OIDCClients contains configuration for the platform's clients that\nneed to request tokens from the issuer",
+                "items": {
+                  "description": "OIDCClientConfig contains configuration for the platform's client that\nneed to request tokens from the issuer.",
+                  "properties": {
+                    "clientID": {
+                      "description": "ClientID is the identifier of the OIDC client from the OIDC provider",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "clientSecret": {
+                      "description": "ClientSecret refers to a secret that\ncontains the client secret in the `clientSecret` key of the `.data` field",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the metadata.name of the referenced object.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "componentName": {
+                      "description": "ComponentName is the name of the component that is supposed to consume this\nclient configuration",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "componentNamespace": {
+                      "description": "ComponentNamespace is the namespace of the component that is supposed to consume this\nclient configuration",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "extraScopes": {
+                      "description": "ExtraScopes is an optional set of scopes to request tokens with.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    }
+                  },
+                  "required": [
+                    "clientID",
+                    "clientSecret",
+                    "componentName",
+                    "componentNamespace"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxItems": 20,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "componentNamespace",
+                  "componentName"
+                ],
+                "x-kubernetes-list-type": "map"
+              }
+            },
+            "required": [
+              "issuer",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 1,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "identityRef": {
+          "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
+          "properties": {
+            "kind": {
+              "description": "Kind of the identity.",
+              "enum": [
+                "AWSClusterControllerIdentity",
+                "AWSClusterRoleIdentity",
+                "AWSClusterStaticIdentity"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the identity.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "installerRoleARN": {
+          "description": "InstallerRoleARN is an AWS IAM role that OpenShift Cluster Manager will assume to create the cluster..",
+          "type": "string"
+        },
+        "network": {
+          "description": "Network config for the ROSA HCP cluster.",
+          "properties": {
+            "hostPrefix": {
+              "default": 23,
+              "description": "Network host prefix which is defaulted to `23` if not specified.",
+              "type": "integer"
+            },
+            "machineCIDR": {
+              "description": "IP addresses block used by OpenShift while installing the cluster, for example \"10.0.0.0/16\".",
+              "format": "cidr",
+              "type": "string"
+            },
+            "networkType": {
+              "default": "OVNKubernetes",
+              "description": "The CNI network type default is OVNKubernetes.",
+              "enum": [
+                "OVNKubernetes",
+                "Other"
+              ],
+              "type": "string"
+            },
+            "podCIDR": {
+              "description": "IP address block from which to assign pod IP addresses, for example `10.128.0.0/14`.",
+              "format": "cidr",
+              "type": "string"
+            },
+            "serviceCIDR": {
+              "description": "IP address block from which to assign service IP addresses, for example `172.30.0.0/16`.",
+              "format": "cidr",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "oidcID": {
+          "description": "The ID of the internal OpenID Connect Provider.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "oidcID is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "provisionShardID": {
+          "description": "ProvisionShardID defines the shard where rosa control plane components will be hosted.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "provisionShardID is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "region": {
+          "description": "The AWS Region the cluster lives in.",
+          "type": "string"
+        },
+        "rolesRef": {
+          "description": "AWS IAM roles used to perform credential requests by the openshift operators.",
+          "properties": {
+            "controlPlaneOperatorARN": {
+              "description": "ControlPlaneOperatorARN  is an ARN value referencing a role appropriate for the Control Plane Operator.\n\n\nThe following is an example of a valid policy document:\n\n\n{\n\t\"Version\": \"2012-10-17\",\n\t\"Statement\": [\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"ec2:CreateVpcEndpoint\",\n\t\t\t\t\"ec2:DescribeVpcEndpoints\",\n\t\t\t\t\"ec2:ModifyVpcEndpoint\",\n\t\t\t\t\"ec2:DeleteVpcEndpoints\",\n\t\t\t\t\"ec2:CreateTags\",\n\t\t\t\t\"route53:ListHostedZones\",\n\t\t\t\t\"ec2:CreateSecurityGroup\",\n\t\t\t\t\"ec2:AuthorizeSecurityGroupIngress\",\n\t\t\t\t\"ec2:AuthorizeSecurityGroupEgress\",\n\t\t\t\t\"ec2:DeleteSecurityGroup\",\n\t\t\t\t\"ec2:RevokeSecurityGroupIngress\",\n\t\t\t\t\"ec2:RevokeSecurityGroupEgress\",\n\t\t\t\t\"ec2:DescribeSecurityGroups\",\n\t\t\t\t\"ec2:DescribeVpcs\",\n\t\t\t],\n\t\t\t\"Resource\": \"*\"\n\t\t},\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"route53:ChangeResourceRecordSets\",\n\t\t\t\t\"route53:ListResourceRecordSets\"\n\t\t\t],\n\t\t\t\"Resource\": \"arn:aws:route53:::%s\"\n\t\t}\n\t]\n}",
+              "type": "string"
+            },
+            "imageRegistryARN": {
+              "description": "ImageRegistryARN is an ARN value referencing a role appropriate for the Image Registry Operator.\n\n\nThe following is an example of a valid policy document:\n\n\n{\n\t\"Version\": \"2012-10-17\",\n\t\"Statement\": [\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"s3:CreateBucket\",\n\t\t\t\t\"s3:DeleteBucket\",\n\t\t\t\t\"s3:PutBucketTagging\",\n\t\t\t\t\"s3:GetBucketTagging\",\n\t\t\t\t\"s3:PutBucketPublicAccessBlock\",\n\t\t\t\t\"s3:GetBucketPublicAccessBlock\",\n\t\t\t\t\"s3:PutEncryptionConfiguration\",\n\t\t\t\t\"s3:GetEncryptionConfiguration\",\n\t\t\t\t\"s3:PutLifecycleConfiguration\",\n\t\t\t\t\"s3:GetLifecycleConfiguration\",\n\t\t\t\t\"s3:GetBucketLocation\",\n\t\t\t\t\"s3:ListBucket\",\n\t\t\t\t\"s3:GetObject\",\n\t\t\t\t\"s3:PutObject\",\n\t\t\t\t\"s3:DeleteObject\",\n\t\t\t\t\"s3:ListBucketMultipartUploads\",\n\t\t\t\t\"s3:AbortMultipartUpload\",\n\t\t\t\t\"s3:ListMultipartUploadParts\"\n\t\t\t],\n\t\t\t\"Resource\": \"*\"\n\t\t}\n\t]\n}",
+              "type": "string"
+            },
+            "ingressARN": {
+              "description": "The referenced role must have a trust relationship that allows it to be assumed via web identity.\nhttps://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html.\nExample:\n{\n\t\t\"Version\": \"2012-10-17\",\n\t\t\"Statement\": [\n\t\t\t{\n\t\t\t\t\"Effect\": \"Allow\",\n\t\t\t\t\"Principal\": {\n\t\t\t\t\t\"Federated\": \"{{ .ProviderARN }}\"\n\t\t\t\t},\n\t\t\t\t\t\"Action\": \"sts:AssumeRoleWithWebIdentity\",\n\t\t\t\t\"Condition\": {\n\t\t\t\t\t\"StringEquals\": {\n\t\t\t\t\t\t\"{{ .ProviderName }}:sub\": {{ .ServiceAccounts }}\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n\n\nIngressARN is an ARN value referencing a role appropriate for the Ingress Operator.\n\n\nThe following is an example of a valid policy document:\n\n\n{\n\t\"Version\": \"2012-10-17\",\n\t\"Statement\": [\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"elasticloadbalancing:DescribeLoadBalancers\",\n\t\t\t\t\"tag:GetResources\",\n\t\t\t\t\"route53:ListHostedZones\"\n\t\t\t],\n\t\t\t\"Resource\": \"*\"\n\t\t},\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"route53:ChangeResourceRecordSets\"\n\t\t\t],\n\t\t\t\"Resource\": [\n\t\t\t\t\"arn:aws:route53:::PUBLIC_ZONE_ID\",\n\t\t\t\t\"arn:aws:route53:::PRIVATE_ZONE_ID\"\n\t\t\t]\n\t\t}\n\t]\n}",
+              "type": "string"
+            },
+            "kmsProviderARN": {
+              "type": "string"
+            },
+            "kubeCloudControllerARN": {
+              "description": "KubeCloudControllerARN is an ARN value referencing a role appropriate for the KCM/KCC.\nSource: https://cloud-provider-aws.sigs.k8s.io/prerequisites/#iam-policies\n\n\nThe following is an example of a valid policy document:\n\n\n {\n \"Version\": \"2012-10-17\",\n \"Statement\": [\n   {\n     \"Action\": [\n       \"autoscaling:DescribeAutoScalingGroups\",\n       \"autoscaling:DescribeLaunchConfigurations\",\n       \"autoscaling:DescribeTags\",\n       \"ec2:DescribeAvailabilityZones\",\n       \"ec2:DescribeInstances\",\n       \"ec2:DescribeImages\",\n       \"ec2:DescribeRegions\",\n       \"ec2:DescribeRouteTables\",\n       \"ec2:DescribeSecurityGroups\",\n       \"ec2:DescribeSubnets\",\n       \"ec2:DescribeVolumes\",\n       \"ec2:CreateSecurityGroup\",\n       \"ec2:CreateTags\",\n       \"ec2:CreateVolume\",\n       \"ec2:ModifyInstanceAttribute\",\n       \"ec2:ModifyVolume\",\n       \"ec2:AttachVolume\",\n       \"ec2:AuthorizeSecurityGroupIngress\",\n       \"ec2:CreateRoute\",\n       \"ec2:DeleteRoute\",\n       \"ec2:DeleteSecurityGroup\",\n       \"ec2:DeleteVolume\",\n       \"ec2:DetachVolume\",\n       \"ec2:RevokeSecurityGroupIngress\",\n       \"ec2:DescribeVpcs\",\n       \"elasticloadbalancing:AddTags\",\n       \"elasticloadbalancing:AttachLoadBalancerToSubnets\",\n       \"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer\",\n       \"elasticloadbalancing:CreateLoadBalancer\",\n       \"elasticloadbalancing:CreateLoadBalancerPolicy\",\n       \"elasticloadbalancing:CreateLoadBalancerListeners\",\n       \"elasticloadbalancing:ConfigureHealthCheck\",\n       \"elasticloadbalancing:DeleteLoadBalancer\",\n       \"elasticloadbalancing:DeleteLoadBalancerListeners\",\n       \"elasticloadbalancing:DescribeLoadBalancers\",\n       \"elasticloadbalancing:DescribeLoadBalancerAttributes\",\n       \"elasticloadbalancing:DetachLoadBalancerFromSubnets\",\n       \"elasticloadbalancing:DeregisterInstancesFromLoadBalancer\",\n       \"elasticloadbalancing:ModifyLoadBalancerAttributes\",\n       \"elasticloadbalancing:RegisterInstancesWithLoadBalancer\",\n       \"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer\",\n       \"elasticloadbalancing:AddTags\",\n       \"elasticloadbalancing:CreateListener\",\n       \"elasticloadbalancing:CreateTargetGroup\",\n       \"elasticloadbalancing:DeleteListener\",\n       \"elasticloadbalancing:DeleteTargetGroup\",\n       \"elasticloadbalancing:DeregisterTargets\",\n       \"elasticloadbalancing:DescribeListeners\",\n       \"elasticloadbalancing:DescribeLoadBalancerPolicies\",\n       \"elasticloadbalancing:DescribeTargetGroups\",\n       \"elasticloadbalancing:DescribeTargetHealth\",\n       \"elasticloadbalancing:ModifyListener\",\n       \"elasticloadbalancing:ModifyTargetGroup\",\n       \"elasticloadbalancing:RegisterTargets\",\n       \"elasticloadbalancing:SetLoadBalancerPoliciesOfListener\",\n       \"iam:CreateServiceLinkedRole\",\n       \"kms:DescribeKey\"\n     ],\n     \"Resource\": [\n       \"*\"\n     ],\n     \"Effect\": \"Allow\"\n   }\n ]\n}",
+              "type": "string"
+            },
+            "networkARN": {
+              "description": "NetworkARN is an ARN value referencing a role appropriate for the Network Operator.\n\n\nThe following is an example of a valid policy document:\n\n\n{\n\t\"Version\": \"2012-10-17\",\n\t\"Statement\": [\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"ec2:DescribeInstances\",\n       \"ec2:DescribeInstanceStatus\",\n       \"ec2:DescribeInstanceTypes\",\n       \"ec2:UnassignPrivateIpAddresses\",\n       \"ec2:AssignPrivateIpAddresses\",\n       \"ec2:UnassignIpv6Addresses\",\n       \"ec2:AssignIpv6Addresses\",\n       \"ec2:DescribeSubnets\",\n       \"ec2:DescribeNetworkInterfaces\"\n\t\t\t],\n\t\t\t\"Resource\": \"*\"\n\t\t}\n\t]\n}",
+              "type": "string"
+            },
+            "nodePoolManagementARN": {
+              "description": "NodePoolManagementARN is an ARN value referencing a role appropriate for the CAPI Controller.\n\n\nThe following is an example of a valid policy document:\n\n\n{\n  \"Version\": \"2012-10-17\",\n \"Statement\": [\n   {\n     \"Action\": [\n       \"ec2:AssociateRouteTable\",\n       \"ec2:AttachInternetGateway\",\n       \"ec2:AuthorizeSecurityGroupIngress\",\n       \"ec2:CreateInternetGateway\",\n       \"ec2:CreateNatGateway\",\n       \"ec2:CreateRoute\",\n       \"ec2:CreateRouteTable\",\n       \"ec2:CreateSecurityGroup\",\n       \"ec2:CreateSubnet\",\n       \"ec2:CreateTags\",\n       \"ec2:DeleteInternetGateway\",\n       \"ec2:DeleteNatGateway\",\n       \"ec2:DeleteRouteTable\",\n       \"ec2:DeleteSecurityGroup\",\n       \"ec2:DeleteSubnet\",\n       \"ec2:DeleteTags\",\n       \"ec2:DescribeAccountAttributes\",\n       \"ec2:DescribeAddresses\",\n       \"ec2:DescribeAvailabilityZones\",\n       \"ec2:DescribeImages\",\n       \"ec2:DescribeInstances\",\n       \"ec2:DescribeInternetGateways\",\n       \"ec2:DescribeNatGateways\",\n       \"ec2:DescribeNetworkInterfaces\",\n       \"ec2:DescribeNetworkInterfaceAttribute\",\n       \"ec2:DescribeRouteTables\",\n       \"ec2:DescribeSecurityGroups\",\n       \"ec2:DescribeSubnets\",\n       \"ec2:DescribeVpcs\",\n       \"ec2:DescribeVpcAttribute\",\n       \"ec2:DescribeVolumes\",\n       \"ec2:DetachInternetGateway\",\n       \"ec2:DisassociateRouteTable\",\n       \"ec2:DisassociateAddress\",\n       \"ec2:ModifyInstanceAttribute\",\n       \"ec2:ModifyNetworkInterfaceAttribute\",\n       \"ec2:ModifySubnetAttribute\",\n       \"ec2:RevokeSecurityGroupIngress\",\n       \"ec2:RunInstances\",\n       \"ec2:TerminateInstances\",\n       \"tag:GetResources\",\n       \"ec2:CreateLaunchTemplate\",\n       \"ec2:CreateLaunchTemplateVersion\",\n       \"ec2:DescribeLaunchTemplates\",\n       \"ec2:DescribeLaunchTemplateVersions\",\n       \"ec2:DeleteLaunchTemplate\",\n       \"ec2:DeleteLaunchTemplateVersions\"\n     ],\n     \"Resource\": [\n       \"*\"\n     ],\n     \"Effect\": \"Allow\"\n   },\n   {\n     \"Condition\": {\n       \"StringLike\": {\n         \"iam:AWSServiceName\": \"elasticloadbalancing.amazonaws.com\"\n       }\n     },\n     \"Action\": [\n       \"iam:CreateServiceLinkedRole\"\n     ],\n     \"Resource\": [\n       \"arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing\"\n     ],\n     \"Effect\": \"Allow\"\n   },\n   {\n     \"Action\": [\n       \"iam:PassRole\"\n     ],\n     \"Resource\": [\n       \"arn:*:iam::*:role/*-worker-role\"\n     ],\n     \"Effect\": \"Allow\"\n   },\n\t  {\n\t  \t\"Effect\": \"Allow\",\n\t  \t\"Action\": [\n\t  \t\t\"kms:Decrypt\",\n\t  \t\t\"kms:ReEncrypt\",\n\t  \t\t\"kms:GenerateDataKeyWithoutPlainText\",\n\t  \t\t\"kms:DescribeKey\"\n\t  \t],\n\t  \t\"Resource\": \"*\"\n\t  },\n\t  {\n\t  \t\"Effect\": \"Allow\",\n\t  \t\"Action\": [\n\t  \t\t\"kms:CreateGrant\"\n\t  \t],\n\t  \t\"Resource\": \"*\",\n\t  \t\"Condition\": {\n\t  \t\t\"Bool\": {\n\t  \t\t\t\"kms:GrantIsForAWSResource\": true\n\t  \t\t}\n\t  \t}\n\t  }\n ]\n}",
+              "type": "string"
+            },
+            "storageARN": {
+              "description": "StorageARN is an ARN value referencing a role appropriate for the Storage Operator.\n\n\nThe following is an example of a valid policy document:\n\n\n{\n\t\"Version\": \"2012-10-17\",\n\t\"Statement\": [\n\t\t{\n\t\t\t\"Effect\": \"Allow\",\n\t\t\t\"Action\": [\n\t\t\t\t\"ec2:AttachVolume\",\n\t\t\t\t\"ec2:CreateSnapshot\",\n\t\t\t\t\"ec2:CreateTags\",\n\t\t\t\t\"ec2:CreateVolume\",\n\t\t\t\t\"ec2:DeleteSnapshot\",\n\t\t\t\t\"ec2:DeleteTags\",\n\t\t\t\t\"ec2:DeleteVolume\",\n\t\t\t\t\"ec2:DescribeInstances\",\n\t\t\t\t\"ec2:DescribeSnapshots\",\n\t\t\t\t\"ec2:DescribeTags\",\n\t\t\t\t\"ec2:DescribeVolumes\",\n\t\t\t\t\"ec2:DescribeVolumesModifications\",\n\t\t\t\t\"ec2:DetachVolume\",\n\t\t\t\t\"ec2:ModifyVolume\"\n\t\t\t],\n\t\t\t\"Resource\": \"*\"\n\t\t}\n\t]\n}",
+              "type": "string"
+            }
+          },
+          "required": [
+            "controlPlaneOperatorARN",
+            "imageRegistryARN",
+            "ingressARN",
+            "kmsProviderARN",
+            "kubeCloudControllerARN",
+            "networkARN",
+            "nodePoolManagementARN",
+            "storageARN"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rosaClusterName": {
+          "description": "Cluster name must be valid DNS-1035 label, so it must consist of lower case alphanumeric\ncharacters or '-', start with an alphabetic character, end with an alphanumeric character\nand have a max length of 54 characters.",
+          "maxLength": 54,
+          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "rosaClusterName is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "subnets": {
+          "description": "The Subnet IDs to use when installing the cluster.\nSubnetIDs should come in pairs; two per availability zone, one private and one public.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "supportRoleARN": {
+          "description": "SupportRoleARN is an AWS IAM role used by Red Hat SREs to enable\naccess to the cluster account in order to provide support.",
+          "type": "string"
+        },
+        "version": {
+          "description": "OpenShift semantic version, for example \"4.14.5\".",
+          "type": "string"
+        },
+        "workerRoleARN": {
+          "description": "WorkerRoleARN is an AWS IAM role that will be attached to worker instances.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "availabilityZones",
+        "installerRoleARN",
+        "oidcID",
+        "region",
+        "rolesRef",
+        "rosaClusterName",
+        "subnets",
+        "supportRoleARN",
+        "version",
+        "workerRoleARN"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "RosaControlPlaneStatus defines the observed state of ROSAControlPlane.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions specifies the conditions for the managed control plane",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "consoleURL": {
+          "description": "ConsoleURL is the url for the openshift console.",
+          "type": "string"
+        },
+        "externalManagedControlPlane": {
+          "default": true,
+          "description": "ExternalManagedControlPlane indicates to cluster-api that the control plane\nis managed by an external service such as AKS, EKS, GKE, etc.",
+          "type": "boolean"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the state and will be set to a descriptive error message.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the spec or the configuration of\nthe controller, and that manual intervention is required.",
+          "type": "string"
+        },
+        "id": {
+          "description": "ID is the cluster ID given by ROSA.",
+          "type": "string"
+        },
+        "initialized": {
+          "description": "Initialized denotes whether or not the control plane has the\nuploaded kubernetes config-map.",
+          "type": "boolean"
+        },
+        "oidcEndpointURL": {
+          "description": "OIDCEndpointURL is the endpoint url for the managed OIDC provider.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the ROSAControlPlane API Server is ready to receive requests.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSCluster is the schema for Amazon EC2 based Kubernetes Cluster API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,33 +19,33 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "bastion": {
           "description": "Bastion contains options to configure the bastion host.",
           "properties": {
             "allowedCIDRBlocks": {
-              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.\nThey are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "ami": {
-              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified,\nthe AMI will default to one picked out in public space.",
               "type": "string"
             },
             "disableIngressRules": {
-              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.\nRequires AllowedCIDRBlocks to be empty.",
               "type": "boolean"
             },
             "enabled": {
-              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "description": "Enabled allows this provider to create a bastion host instance\nwith a public ip to access the VPC private network.",
               "type": "boolean"
             },
             "instanceType": {
-              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified,\nCluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro\nwill be the default.",
               "type": "string"
             }
           },
@@ -76,22 +76,22 @@
           "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
           "properties": {
             "additionalSecurityGroups": {
-              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs\nThis is optional - if not provided new security groups will be created for the load balancer",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "crossZoneLoadBalancing": {
-              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing.\n\n\nWith cross-zone load balancing, each load balancer node for your Classic Load Balancer\ndistributes requests evenly across the registered instances in all enabled Availability Zones.\nIf cross-zone load balancing is disabled, each load balancer node distributes requests evenly across\nthe registered instances in its Availability Zone only.\n\n\nDefaults to false.",
               "type": "boolean"
             },
             "healthCheckProtocol": {
-              "description": "HealthCheckProtocol sets the protocol type for classic ELB health check target default value is ClassicELBProtocolSSL",
+              "description": "HealthCheckProtocol sets the protocol type for classic ELB health check target\ndefault value is ClassicELBProtocolSSL",
               "type": "string"
             },
             "name": {
-              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique\nwithin your set of load balancers for the region, must have a maximum of 32 characters, must\ncontain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once\nset, the value cannot be changed.",
               "maxLength": 32,
               "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
               "type": "string"
@@ -117,7 +117,7 @@
           "additionalProperties": false
         },
         "identityRef": {
-          "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+          "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
           "properties": {
             "kind": {
               "description": "Kind of the identity.",
@@ -142,15 +142,15 @@
           "additionalProperties": false
         },
         "imageLookupBaseOS": {
-          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look\nup machine images when a machine does not specify an AMI. When set, this\nwill be used for all cluster machines unless a machine specifies a\ndifferent ImageLookupBaseOS.",
           "type": "string"
         },
         "imageLookupFormat": {
-          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when\na machine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.\nSupports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base\nOS and kubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
           "type": "string"
         },
         "imageLookupOrg": {
-          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a\nmachine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.",
           "type": "string"
         },
         "network": {
@@ -160,7 +160,7 @@
               "description": "CNI configuration",
               "properties": {
                 "cniIngressRules": {
-                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups.\nThe source for the rule will be set to control plane and worker security group IDs.",
                   "items": {
                     "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
                     "properties": {
@@ -199,7 +199,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances\nThis is optional - if not provided new security groups will be created for the cluster",
               "type": "object"
             },
             "subnets": {
@@ -220,11 +220,11 @@
                     "type": "string"
                   },
                   "ipv6CidrBlock": {
-                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.\nA subnet can have an IPv4 and an IPv6 address.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "string"
                   },
                   "isIpv6": {
-                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "boolean"
                   },
                   "isPublic": {
@@ -232,7 +232,7 @@
                     "type": "boolean"
                   },
                   "natGatewayId": {
-                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet.\nIgnored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
                     "type": "string"
                   },
                   "routeTableId": {
@@ -257,7 +257,7 @@
               "properties": {
                 "availabilityZoneSelection": {
                   "default": "Ordered",
-                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs\nin a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:\nOrdered - selects based on alphabetical order\nRandom - selects AZs randomly in a region\nDefaults to Ordered",
                   "enum": [
                     "Ordered",
                     "Random"
@@ -266,12 +266,12 @@
                 },
                 "availabilityZoneUsageLimit": {
                   "default": 3,
-                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that\nshould be used in a region when automatically creating subnets. If a region has more\nthan this number of AZs then this number of AZs will be picked randomly when creating\ndefault subnets. Defaults to 3",
                   "minimum": 1,
                   "type": "integer"
                 },
                 "cidrBlock": {
-                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.\nDefaults to 10.0.0.0/16.",
                   "type": "string"
                 },
                 "id": {
@@ -283,7 +283,7 @@
                   "type": "string"
                 },
                 "ipv6": {
-                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.\nThis field cannot be set on AWSCluster object.",
                   "properties": {
                     "cidrBlock": {
                       "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
@@ -321,10 +321,10 @@
           "type": "string"
         },
         "s3Bucket": {
-          "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+          "description": "S3Bucket contains options to configure a supporting S3 bucket for this\ncluster - currently used for nodes requiring Ignition\n(https://coreos.github.io/ignition/) for bootstrapping (requires\nBootstrapFormatIgnition feature flag to be enabled).",
           "properties": {
             "controlPlaneIAMInstanceProfile": {
-              "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+              "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed\nto read control-plane node bootstrap data from S3 Bucket.",
               "type": "string"
             },
             "name": {
@@ -335,7 +335,7 @@
               "type": "string"
             },
             "nodesIAMInstanceProfiles": {
-              "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+              "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read\nworker nodes bootstrap data from S3 Bucket.",
               "items": {
                 "type": "string"
               },
@@ -374,7 +374,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
                     "type": "string"
                   }
                 },
@@ -435,7 +435,7 @@
                     "type": "boolean"
                   },
                   "encryptionKey": {
-                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                     "type": "string"
                   },
                   "iops": {
@@ -444,7 +444,7 @@
                     "type": "integer"
                   },
                   "size": {
-                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                     "format": "int64",
                     "minimum": 8,
                     "type": "integer"
@@ -487,7 +487,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -496,7 +496,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -559,7 +559,7 @@
               "type": "string"
             },
             "userData": {
-              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap.\nThis field must not be base64 encoded and should only be used when running a new instance.",
               "type": "string"
             },
             "volumeIDs": {
@@ -582,20 +582,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -603,7 +603,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -619,7 +619,7 @@
         },
         "failureDomains": {
           "additionalProperties": {
-            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains.\nIt allows controllers to understand how many failure domains a cluster can optionally span across.",
             "properties": {
               "attributes": {
                 "additionalProperties": {
@@ -653,7 +653,7 @@
                       "type": "boolean"
                     },
                     "idleTimeout": {
-                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
                       "format": "int64",
                       "type": "integer"
                     }
@@ -680,7 +680,7 @@
                       "type": "integer"
                     },
                     "interval": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -688,7 +688,7 @@
                       "type": "string"
                     },
                     "timeout": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -741,7 +741,7 @@
                   "type": "array"
                 },
                 "name": {
-                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
                   "type": "string"
                 },
                 "scheme": {

--- a/infrastructure.cluster.x-k8s.io/awscluster_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awscluster_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSCluster is the schema for Amazon EC2 based Kubernetes Cluster API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,33 +19,33 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "bastion": {
           "description": "Bastion contains options to configure the bastion host.",
           "properties": {
             "allowedCIDRBlocks": {
-              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+              "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.\nThey are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "ami": {
-              "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+              "description": "AMI will use the specified AMI to boot the bastion. If not specified,\nthe AMI will default to one picked out in public space.",
               "type": "string"
             },
             "disableIngressRules": {
-              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+              "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.\nRequires AllowedCIDRBlocks to be empty.",
               "type": "boolean"
             },
             "enabled": {
-              "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+              "description": "Enabled allows this provider to create a bastion host instance\nwith a public ip to access the VPC private network.",
               "type": "boolean"
             },
             "instanceType": {
-              "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+              "description": "InstanceType will use the specified instance type for the bastion. If not specified,\nCluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro\nwill be the default.",
               "type": "string"
             }
           },
@@ -75,24 +75,237 @@
         "controlPlaneLoadBalancer": {
           "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
           "properties": {
+            "additionalListeners": {
+              "description": "AdditionalListeners sets the additional listeners for the control plane load balancer.\nThis is only applicable to Network Load Balancer (NLB) types for the time being.",
+              "items": {
+                "description": "AdditionalListenerSpec defines the desired state of an\nadditional listener on an AWS load balancer.",
+                "properties": {
+                  "healthCheck": {
+                    "description": "HealthCheck sets the optional custom health check configuration to the API target group.",
+                    "properties": {
+                      "intervalSeconds": {
+                        "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                        "format": "int64",
+                        "maximum": 300,
+                        "minimum": 5,
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "The destination for health checks on the targets when using the protocol HTTP or HTTPS,\notherwise the path will be ignored.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "The port the load balancer uses when performing health checks for additional target groups. When\nnot specified this value will be set for the same of listener port.",
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocol to use to health check connect with the target. When not specified the Protocol\nwill be the same of the listener.",
+                        "enum": [
+                          "TCP",
+                          "HTTP",
+                          "HTTPS"
+                        ],
+                        "type": "string"
+                      },
+                      "thresholdCount": {
+                        "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                        "format": "int64",
+                        "maximum": 10,
+                        "minimum": 2,
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                        "format": "int64",
+                        "maximum": 120,
+                        "minimum": 2,
+                        "type": "integer"
+                      },
+                      "unhealthyThresholdCount": {
+                        "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                        "format": "int64",
+                        "maximum": 10,
+                        "minimum": 2,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "description": "Port sets the port for the additional listener.",
+                    "format": "int64",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "default": "TCP",
+                    "description": "Protocol sets the protocol for the additional listener.\nCurrently only TCP is supported.",
+                    "enum": [
+                      "TCP"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "port"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "port"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
             "additionalSecurityGroups": {
-              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs\nThis is optional - if not provided new security groups will be created for the load balancer",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "crossZoneLoadBalancing": {
-              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing.\n\n\nWith cross-zone load balancing, each load balancer node for your Classic Load Balancer\ndistributes requests evenly across the registered instances in all enabled Availability Zones.\nIf cross-zone load balancing is disabled, each load balancer node distributes requests evenly across\nthe registered instances in its Availability Zone only.\n\n\nDefaults to false.",
               "type": "boolean"
             },
             "disableHostsRewrite": {
-              "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts file of each instance. This is by default, false.",
+              "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts\nfile of each instance. This is by default, false.",
               "type": "boolean"
             },
+            "healthCheck": {
+              "description": "HealthCheck sets custom health check configuration to the API target group.",
+              "properties": {
+                "intervalSeconds": {
+                  "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                  "format": "int64",
+                  "maximum": 300,
+                  "minimum": 5,
+                  "type": "integer"
+                },
+                "thresholdCount": {
+                  "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                  "format": "int64",
+                  "maximum": 10,
+                  "minimum": 2,
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                  "format": "int64",
+                  "maximum": 120,
+                  "minimum": 2,
+                  "type": "integer"
+                },
+                "unhealthyThresholdCount": {
+                  "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                  "format": "int64",
+                  "maximum": 10,
+                  "minimum": 2,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "healthCheckProtocol": {
-              "description": "HealthCheckProtocol sets the protocol type for ELB health check target default value is ELBProtocolSSL",
+              "description": "HealthCheckProtocol sets the protocol type for ELB health check target\ndefault value is ELBProtocolSSL",
+              "enum": [
+                "TCP",
+                "SSL",
+                "HTTP",
+                "HTTPS",
+                "TLS",
+                "UDP"
+              ],
               "type": "string"
+            },
+            "ingressRules": {
+              "description": "IngressRules sets the ingress rules for the control plane load balancer.",
+              "items": {
+                "description": "IngressRule defines an AWS ingress rule for security groups.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description provides extended information about the ingress rule.",
+                    "type": "string"
+                  },
+                  "fromPort": {
+                    "description": "FromPort is the start of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "ipv6CidrBlocks": {
+                    "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "natGatewaysIPsSource": {
+                    "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                    "type": "boolean"
+                  },
+                  "protocol": {
+                    "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                    "enum": [
+                      "-1",
+                      "4",
+                      "tcp",
+                      "udp",
+                      "icmp",
+                      "58",
+                      "50"
+                    ],
+                    "type": "string"
+                  },
+                  "sourceSecurityGroupIds": {
+                    "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sourceSecurityGroupRoles": {
+                    "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                    "items": {
+                      "description": "SecurityGroupRole defines the unique role of a security group.",
+                      "enum": [
+                        "bastion",
+                        "node",
+                        "controlplane",
+                        "apiserver-lb",
+                        "lb",
+                        "node-eks-additional"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "toPort": {
+                    "description": "ToPort is the end of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "description",
+                  "fromPort",
+                  "protocol",
+                  "toPort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
             },
             "loadBalancerType": {
               "default": "classic",
@@ -101,18 +314,19 @@
                 "classic",
                 "elb",
                 "alb",
-                "nlb"
+                "nlb",
+                "disabled"
               ],
               "type": "string"
             },
             "name": {
-              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique\nwithin your set of load balancers for the region, must have a maximum of 32 characters, must\ncontain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once\nset, the value cannot be changed.",
               "maxLength": 32,
               "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
               "type": "string"
             },
             "preserveClientIP": {
-              "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not. If this is enabled 6443 will be opened to 0.0.0.0/0.",
+              "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not.\nIf this is enabled 6443 will be opened to 0.0.0.0/0.",
               "type": "boolean"
             },
             "scheme": {
@@ -136,7 +350,7 @@
           "additionalProperties": false
         },
         "identityRef": {
-          "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+          "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
           "properties": {
             "kind": {
               "description": "Kind of the identity.",
@@ -161,25 +375,110 @@
           "additionalProperties": false
         },
         "imageLookupBaseOS": {
-          "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+          "description": "ImageLookupBaseOS is the name of the base operating system used to look\nup machine images when a machine does not specify an AMI. When set, this\nwill be used for all cluster machines unless a machine specifies a\ndifferent ImageLookupBaseOS.",
           "type": "string"
         },
         "imageLookupFormat": {
-          "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "description": "ImageLookupFormat is the AMI naming format to look up machine images when\na machine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.\nSupports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base\nOS and kubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
           "type": "string"
         },
         "imageLookupOrg": {
-          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+          "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a\nmachine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.",
           "type": "string"
         },
         "network": {
           "description": "NetworkSpec encapsulates all things related to AWS network.",
           "properties": {
+            "additionalControlPlaneIngressRules": {
+              "description": "AdditionalControlPlaneIngressRules is an optional set of ingress rules to add to the control plane",
+              "items": {
+                "description": "IngressRule defines an AWS ingress rule for security groups.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description provides extended information about the ingress rule.",
+                    "type": "string"
+                  },
+                  "fromPort": {
+                    "description": "FromPort is the start of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "ipv6CidrBlocks": {
+                    "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "natGatewaysIPsSource": {
+                    "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                    "type": "boolean"
+                  },
+                  "protocol": {
+                    "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                    "enum": [
+                      "-1",
+                      "4",
+                      "tcp",
+                      "udp",
+                      "icmp",
+                      "58",
+                      "50"
+                    ],
+                    "type": "string"
+                  },
+                  "sourceSecurityGroupIds": {
+                    "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sourceSecurityGroupRoles": {
+                    "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                    "items": {
+                      "description": "SecurityGroupRole defines the unique role of a security group.",
+                      "enum": [
+                        "bastion",
+                        "node",
+                        "controlplane",
+                        "apiserver-lb",
+                        "lb",
+                        "node-eks-additional"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "toPort": {
+                    "description": "ToPort is the end of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "description",
+                  "fromPort",
+                  "protocol",
+                  "toPort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "cni": {
               "description": "CNI configuration",
               "properties": {
                 "cniIngressRules": {
-                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                  "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups.\nThe source for the rule will be set to control plane and worker security group IDs.",
                   "items": {
                     "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
                     "properties": {
@@ -218,7 +517,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+              "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances\nThis is optional - if not provided new security groups will be created for the cluster",
               "type": "object"
             },
             "subnets": {
@@ -235,15 +534,15 @@
                     "type": "string"
                   },
                   "id": {
-                    "description": "ID defines a unique identifier to reference this resource.",
+                    "description": "ID defines a unique identifier to reference this resource.\nIf you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`.\n\n\nWhen the VPC is managed by CAPA, and you'd like the provider to create a subnet for you,\nthe id can be set to any placeholder value that does not start with `subnet-`;\nupon creation, the subnet AWS identifier will be populated in the `ResourceID` field and\nthe `id` field is going to be used as the subnet name. If you specify a tag\ncalled `Name`, it takes precedence.",
                     "type": "string"
                   },
                   "ipv6CidrBlock": {
-                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.\nA subnet can have an IPv4 and an IPv6 address.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "string"
                   },
                   "isIpv6": {
-                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                    "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                     "type": "boolean"
                   },
                   "isPublic": {
@@ -251,7 +550,15 @@
                     "type": "boolean"
                   },
                   "natGatewayId": {
-                    "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "description": "NatGatewayID is the NAT gateway id associated with the subnet.\nIgnored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                    "type": "string"
+                  },
+                  "parentZoneName": {
+                    "description": "ParentZoneName is the zone name where the current subnet's zone is tied when\nthe zone is a Local Zone.\n\n\nThe subnets in Local Zone or Wavelength Zone locations consume the ParentZoneName\nto select the correct private route table to egress traffic to the internet.",
+                    "type": "string"
+                  },
+                  "resourceID": {
+                    "description": "ResourceID is the subnet identifier from AWS, READ ONLY.\nThis field is populated when the provider manages the subnet.",
                     "type": "string"
                   },
                   "routeTableId": {
@@ -264,6 +571,15 @@
                     },
                     "description": "Tags is a collection of tags describing the resource.",
                     "type": "object"
+                  },
+                  "zoneType": {
+                    "description": "ZoneType defines the type of the zone where the subnet is created.\n\n\nThe valid values are availability-zone, local-zone, and wavelength-zone.\n\n\nSubnet with zone type availability-zone (regular) is always selected to create cluster\nresources, like Load Balancers, NAT Gateways, Contol Plane nodes, etc.\n\n\nSubnet with zone type local-zone or wavelength-zone is not eligible to automatically create\nregular cluster resources.\n\n\nThe public subnet in availability-zone or local-zone is associated with regular public\nroute table with default route entry to a Internet Gateway.\n\n\nThe public subnet in wavelength-zone is associated with a carrier public\nroute table with default route entry to a Carrier Gateway.\n\n\nThe private subnet in the availability-zone is associated with a private route table with\nthe default route entry to a NAT Gateway created in that zone.\n\n\nThe private subnet in the local-zone or wavelength-zone is associated with a private route table with\nthe default route entry re-using the NAT Gateway in the Region (preferred from the\nparent zone, the zone type availability-zone in the region, or first table available).",
+                    "enum": [
+                      "availability-zone",
+                      "local-zone",
+                      "wavelength-zone"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -283,7 +599,7 @@
               "properties": {
                 "availabilityZoneSelection": {
                   "default": "Ordered",
-                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                  "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs\nin a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:\nOrdered - selects based on alphabetical order\nRandom - selects AZs randomly in a region\nDefaults to Ordered",
                   "enum": [
                     "Ordered",
                     "Random"
@@ -292,13 +608,53 @@
                 },
                 "availabilityZoneUsageLimit": {
                   "default": 3,
-                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                  "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that\nshould be used in a region when automatically creating subnets. If a region has more\nthan this number of AZs then this number of AZs will be picked randomly when creating\ndefault subnets. Defaults to 3",
                   "minimum": 1,
                   "type": "integer"
                 },
+                "carrierGatewayId": {
+                  "description": "CarrierGatewayID is the id of the internet gateway associated with the VPC,\nfor carrier network (Wavelength Zones).",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Carrier Gateway ID must start with 'cagw-'",
+                      "rule": "self.startsWith('cagw-')"
+                    }
+                  ]
+                },
                 "cidrBlock": {
-                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                  "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.\nDefaults to 10.0.0.0/16.\nMutually exclusive with IPAMPool.",
                   "type": "string"
+                },
+                "elasticIpPool": {
+                  "description": "ElasticIPPool contains specific configuration to allocate Public IPv4 address (Elastic IP) from user-defined pool\nbrought to AWS for core infrastructure resources, like NAT Gateways and Public Network Load Balancers for\nthe API Server.",
+                  "properties": {
+                    "publicIpv4Pool": {
+                      "description": "PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources\ncreated in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom\nPublic IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool\nresource ID starts with 'ipv4pool-ec2'.",
+                      "maxLength": 30,
+                      "type": "string"
+                    },
+                    "publicIpv4PoolFallbackOrder": {
+                      "description": "PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,\nno more IPv4 address available in the pool.\n\n\nWhen set to 'amazon-pool', the controller check if the pool has available IPv4 address, when pool has reached the\nIPv4 limit, the address will be claimed from Amazon-pool (default).\n\n\nWhen set to 'none', the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.",
+                      "enum": [
+                        "amazon-pool",
+                        "none"
+                      ],
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "allowed values are 'none' and 'amazon-pool'",
+                          "rule": "self in ['none','amazon-pool']"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "emptyRoutesDefaultVPCSecurityGroup": {
+                  "description": "EmptyRoutesDefaultVPCSecurityGroup specifies whether the default VPC security group ingress\nand egress rules should be removed.\n\n\nBy default, when creating a VPC, AWS creates a security group called `default` with ingress and egress\nrules that allow traffic from anywhere. The group could be used as a potential surface attack and\nit's generally suggested that the group rules are removed or modified appropriately.\n\n\nNOTE: This only applies when the VPC is managed by the Cluster API AWS controller.",
+                  "type": "boolean"
                 },
                 "id": {
                   "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
@@ -308,24 +664,81 @@
                   "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
                   "type": "string"
                 },
+                "ipamPool": {
+                  "description": "IPAMPool defines the IPAMv4 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                  "properties": {
+                    "id": {
+                      "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                      "type": "string"
+                    },
+                    "netmaskLength": {
+                      "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "ipv6": {
-                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                  "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.\nThis field cannot be set on AWSCluster object.",
                   "properties": {
                     "cidrBlock": {
-                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                      "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.\nMutually exclusive with IPAMPool.",
                       "type": "string"
                     },
                     "egressOnlyInternetGatewayId": {
                       "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
                       "type": "string"
                     },
+                    "ipamPool": {
+                      "description": "IPAMPool defines the IPAMv6 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                      "properties": {
+                        "id": {
+                          "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                          "type": "string"
+                        },
+                        "netmaskLength": {
+                          "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "poolId": {
-                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                      "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.\nMust be specified if CidrBlock is set.\nMutually exclusive with IPAMPool.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "privateDnsHostnameTypeOnLaunch": {
+                  "description": "PrivateDNSHostnameTypeOnLaunch is the type of hostname to assign to instances in the subnet at launch.\nFor IPv4-only and dual-stack (IPv4 and IPv6) subnets, an instance DNS name can be based on the instance IPv4 address (ip-name)\nor the instance ID (resource-name). For IPv6 only subnets, an instance DNS name must be based on the instance ID (resource-name).",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                },
+                "subnetSchema": {
+                  "default": "PreferPrivate",
+                  "description": "SubnetSchema specifies how CidrBlock should be divided on subnets in the VPC depending on the number of AZs.\nPreferPrivate - one private subnet for each AZ plus one other subnet that will be further sub-divided for the public subnets.\nPreferPublic - have the reverse logic of PreferPrivate, one public subnet for each AZ plus one other subnet\nthat will be further sub-divided for the private subnets.\nDefaults to PreferPrivate",
+                  "enum": [
+                    "PreferPrivate",
+                    "PreferPublic"
+                  ],
+                  "type": "string"
                 },
                 "tags": {
                   "additionalProperties": {
@@ -342,15 +755,23 @@
           "type": "object",
           "additionalProperties": false
         },
+        "partition": {
+          "description": "Partition is the AWS security partition being used. Defaults to \"aws\"",
+          "type": "string"
+        },
         "region": {
           "description": "The AWS Region the cluster lives in.",
           "type": "string"
         },
         "s3Bucket": {
-          "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+          "description": "S3Bucket contains options to configure a supporting S3 bucket for this\ncluster - currently used for nodes requiring Ignition\n(https://coreos.github.io/ignition/) for bootstrapping (requires\nBootstrapFormatIgnition feature flag to be enabled).",
           "properties": {
+            "bestEffortDeleteObjects": {
+              "description": "BestEffortDeleteObjects defines whether access/permission errors during object deletion should be ignored.",
+              "type": "boolean"
+            },
             "controlPlaneIAMInstanceProfile": {
-              "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+              "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed\nto read control-plane node bootstrap data from S3 Bucket.",
               "type": "string"
             },
             "name": {
@@ -361,18 +782,297 @@
               "type": "string"
             },
             "nodesIAMInstanceProfiles": {
-              "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+              "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read\nworker nodes bootstrap data from S3 Bucket.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "presignedURLDuration": {
+              "description": "PresignedURLDuration defines the duration for which presigned URLs are valid.\n\n\nThis is used to generate presigned URLs for S3 Bucket objects, which are used by\ncontrol-plane and worker nodes to fetch bootstrap data.\n\n\nWhen enabled, the IAM instance profiles specified are not used.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secondaryControlPlaneLoadBalancer": {
+          "description": "SecondaryControlPlaneLoadBalancer is an additional load balancer that can be used for the control plane.\n\n\nAn example use case is to have a separate internal load balancer for internal traffic,\nand a separate external load balancer for external traffic.",
+          "properties": {
+            "additionalListeners": {
+              "description": "AdditionalListeners sets the additional listeners for the control plane load balancer.\nThis is only applicable to Network Load Balancer (NLB) types for the time being.",
+              "items": {
+                "description": "AdditionalListenerSpec defines the desired state of an\nadditional listener on an AWS load balancer.",
+                "properties": {
+                  "healthCheck": {
+                    "description": "HealthCheck sets the optional custom health check configuration to the API target group.",
+                    "properties": {
+                      "intervalSeconds": {
+                        "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                        "format": "int64",
+                        "maximum": 300,
+                        "minimum": 5,
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "The destination for health checks on the targets when using the protocol HTTP or HTTPS,\notherwise the path will be ignored.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "The port the load balancer uses when performing health checks for additional target groups. When\nnot specified this value will be set for the same of listener port.",
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocol to use to health check connect with the target. When not specified the Protocol\nwill be the same of the listener.",
+                        "enum": [
+                          "TCP",
+                          "HTTP",
+                          "HTTPS"
+                        ],
+                        "type": "string"
+                      },
+                      "thresholdCount": {
+                        "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                        "format": "int64",
+                        "maximum": 10,
+                        "minimum": 2,
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                        "format": "int64",
+                        "maximum": 120,
+                        "minimum": 2,
+                        "type": "integer"
+                      },
+                      "unhealthyThresholdCount": {
+                        "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                        "format": "int64",
+                        "maximum": 10,
+                        "minimum": 2,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "description": "Port sets the port for the additional listener.",
+                    "format": "int64",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "default": "TCP",
+                    "description": "Protocol sets the protocol for the additional listener.\nCurrently only TCP is supported.",
+                    "enum": [
+                      "TCP"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "port"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "port"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "additionalSecurityGroups": {
+              "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs\nThis is optional - if not provided new security groups will be created for the load balancer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "crossZoneLoadBalancing": {
+              "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing.\n\n\nWith cross-zone load balancing, each load balancer node for your Classic Load Balancer\ndistributes requests evenly across the registered instances in all enabled Availability Zones.\nIf cross-zone load balancing is disabled, each load balancer node distributes requests evenly across\nthe registered instances in its Availability Zone only.\n\n\nDefaults to false.",
+              "type": "boolean"
+            },
+            "disableHostsRewrite": {
+              "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts\nfile of each instance. This is by default, false.",
+              "type": "boolean"
+            },
+            "healthCheck": {
+              "description": "HealthCheck sets custom health check configuration to the API target group.",
+              "properties": {
+                "intervalSeconds": {
+                  "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                  "format": "int64",
+                  "maximum": 300,
+                  "minimum": 5,
+                  "type": "integer"
+                },
+                "thresholdCount": {
+                  "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                  "format": "int64",
+                  "maximum": 10,
+                  "minimum": 2,
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                  "format": "int64",
+                  "maximum": 120,
+                  "minimum": 2,
+                  "type": "integer"
+                },
+                "unhealthyThresholdCount": {
+                  "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                  "format": "int64",
+                  "maximum": 10,
+                  "minimum": 2,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "healthCheckProtocol": {
+              "description": "HealthCheckProtocol sets the protocol type for ELB health check target\ndefault value is ELBProtocolSSL",
+              "enum": [
+                "TCP",
+                "SSL",
+                "HTTP",
+                "HTTPS",
+                "TLS",
+                "UDP"
+              ],
+              "type": "string"
+            },
+            "ingressRules": {
+              "description": "IngressRules sets the ingress rules for the control plane load balancer.",
+              "items": {
+                "description": "IngressRule defines an AWS ingress rule for security groups.",
+                "properties": {
+                  "cidrBlocks": {
+                    "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "description": {
+                    "description": "Description provides extended information about the ingress rule.",
+                    "type": "string"
+                  },
+                  "fromPort": {
+                    "description": "FromPort is the start of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "ipv6CidrBlocks": {
+                    "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "natGatewaysIPsSource": {
+                    "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                    "type": "boolean"
+                  },
+                  "protocol": {
+                    "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                    "enum": [
+                      "-1",
+                      "4",
+                      "tcp",
+                      "udp",
+                      "icmp",
+                      "58",
+                      "50"
+                    ],
+                    "type": "string"
+                  },
+                  "sourceSecurityGroupIds": {
+                    "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "sourceSecurityGroupRoles": {
+                    "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                    "items": {
+                      "description": "SecurityGroupRole defines the unique role of a security group.",
+                      "enum": [
+                        "bastion",
+                        "node",
+                        "controlplane",
+                        "apiserver-lb",
+                        "lb",
+                        "node-eks-additional"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "toPort": {
+                    "description": "ToPort is the end of port range.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "description",
+                  "fromPort",
+                  "protocol",
+                  "toPort"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "loadBalancerType": {
+              "default": "classic",
+              "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+              "enum": [
+                "classic",
+                "elb",
+                "alb",
+                "nlb",
+                "disabled"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique\nwithin your set of load balancers for the region, must have a maximum of 32 characters, must\ncontain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once\nset, the value cannot be changed.",
+              "maxLength": 32,
+              "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
+              "type": "string"
+            },
+            "preserveClientIP": {
+              "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not.\nIf this is enabled 6443 will be opened to 0.0.0.0/0.",
+              "type": "boolean"
+            },
+            "scheme": {
+              "default": "internet-facing",
+              "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+              "enum": [
+                "internet-facing",
+                "internal"
+              ],
+              "type": "string"
+            },
+            "subnets": {
+              "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
               "items": {
                 "type": "string"
               },
               "type": "array"
             }
           },
-          "required": [
-            "controlPlaneIAMInstanceProfile",
-            "name",
-            "nodesIAMInstanceProfiles"
-          ],
           "type": "object",
           "additionalProperties": false
         },
@@ -400,7 +1100,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                    "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
                     "type": "string"
                   }
                 },
@@ -415,6 +1115,10 @@
             },
             "availabilityZone": {
               "description": "Availability zone of instance",
+              "type": "string"
+            },
+            "capacityReservationId": {
+              "description": "CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.",
               "type": "string"
             },
             "ebsOptimized": {
@@ -441,7 +1145,7 @@
               "properties": {
                 "httpEndpoint": {
                   "default": "enabled",
-                  "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -450,15 +1154,15 @@
                 },
                 "httpPutResponseHopLimit": {
                   "default": 1,
-                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
                   "format": "int64",
                   "maximum": 64,
                   "minimum": 1,
                   "type": "integer"
                 },
                 "httpTokens": {
-                  "default": "required",
-                  "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                  "default": "optional",
+                  "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
                   "enum": [
                     "optional",
                     "required"
@@ -467,7 +1171,7 @@
                 },
                 "instanceMetadataTags": {
                   "default": "disabled",
-                  "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -503,7 +1207,7 @@
                     "type": "boolean"
                   },
                   "encryptionKey": {
-                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                    "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                     "type": "string"
                   },
                   "iops": {
@@ -512,7 +1216,7 @@
                     "type": "integer"
                   },
                   "size": {
-                    "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                    "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                     "format": "int64",
                     "minimum": 8,
                     "type": "integer"
@@ -535,9 +1239,47 @@
               },
               "type": "array"
             },
+            "placementGroupName": {
+              "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance.",
+              "type": "string"
+            },
+            "placementGroupPartition": {
+              "description": "PlacementGroupPartition is the partition number within the placement group in which to launch the instance.\nThis value is only valid if the placement group, referred in `PlacementGroupName`, was created with\nstrategy set to partition.",
+              "format": "int64",
+              "maximum": 7,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "privateDnsName": {
+              "description": "PrivateDNSName is the options for the instance hostname.",
+              "properties": {
+                "enableResourceNameDnsAAAARecord": {
+                  "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+                  "type": "boolean"
+                },
+                "enableResourceNameDnsARecord": {
+                  "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+                  "type": "boolean"
+                },
+                "hostnameType": {
+                  "description": "The type of hostname to assign to an instance.",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "privateIp": {
               "description": "The private IPv4 address assigned to the instance.",
               "type": "string"
+            },
+            "publicIPOnLaunch": {
+              "description": "PublicIPOnLaunch is the option to associate a public IP on instance launch",
+              "type": "boolean"
             },
             "publicIp": {
               "description": "The public IPv4 address assigned to the instance, if applicable.",
@@ -555,7 +1297,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -564,7 +1306,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -627,7 +1369,7 @@
               "type": "string"
             },
             "userData": {
-              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap. This field must not be base64 encoded and should only be used when running a new instance.",
+              "description": "UserData is the raw data script passed to the instance which is run upon bootstrap.\nThis field must not be base64 encoded and should only be used when running a new instance.",
               "type": "string"
             },
             "volumeIDs": {
@@ -650,20 +1392,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -671,7 +1413,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -687,7 +1429,7 @@
         },
         "failureDomains": {
           "additionalProperties": {
-            "description": "FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains.\nIt allows controllers to understand how many failure domains a cluster can optionally span across.",
             "properties": {
               "attributes": {
                 "additionalProperties": {
@@ -714,7 +1456,7 @@
               "description": "APIServerELB is the Kubernetes api server load balancer.",
               "properties": {
                 "arn": {
-                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly to define and get it.",
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly\nto define and get it.",
                   "type": "string"
                 },
                 "attributes": {
@@ -725,7 +1467,7 @@
                       "type": "boolean"
                     },
                     "idleTimeout": {
-                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
                       "format": "int64",
                       "type": "integer"
                     }
@@ -765,10 +1507,11 @@
                         "type": "string"
                       },
                       "targetGroup": {
-                        "description": "TargetGroupSpec specifies target group settings for a given listener. This is created first, and the ARN is then passed to the listener.",
+                        "description": "TargetGroupSpec specifies target group settings for a given listener.\nThis is created first, and the ARN is then passed to the listener.",
                         "properties": {
                           "name": {
                             "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "maxLength": 32,
                             "type": "string"
                           },
                           "port": {
@@ -781,7 +1524,10 @@
                             "enum": [
                               "tcp",
                               "tls",
-                              "upd"
+                              "udp",
+                              "TCP",
+                              "TLS",
+                              "UDP"
                             ],
                             "type": "string"
                           },
@@ -806,6 +1552,10 @@
                                 "type": "integer"
                               },
                               "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
                                 "format": "int64",
                                 "type": "integer"
                               }
@@ -845,7 +1595,7 @@
                       "type": "integer"
                     },
                     "interval": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -853,7 +1603,7 @@
                       "type": "string"
                     },
                     "timeout": {
-                      "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
                       "format": "int64",
                       "type": "integer"
                     },
@@ -916,7 +1666,260 @@
                   "type": "string"
                 },
                 "name": {
-                  "description": "The name of the load balancer. It must be unique within the set of load balancers defined in the region. It also serves as identifier.",
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
+                  "type": "string"
+                },
+                "scheme": {
+                  "description": "Scheme is the load balancer scheme, either internet-facing or private.",
+                  "type": "string"
+                },
+                "securityGroupIds": {
+                  "description": "SecurityGroupIDs is an array of security groups assigned to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "subnetIds": {
+                  "description": "SubnetIDs is an array of subnets in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags is a map of tags associated with the load balancer.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "natGatewaysIPs": {
+              "description": "NatGatewaysIPs contains the public IPs of the NAT Gateways",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secondaryAPIServerELB": {
+              "description": "SecondaryAPIServerELB is the secondary Kubernetes api server load balancer.",
+              "properties": {
+                "arn": {
+                  "description": "ARN of the load balancer. Unlike the ClassicLB, ARN is used mostly\nto define and get it.",
+                  "type": "string"
+                },
+                "attributes": {
+                  "description": "ClassicElbAttributes defines extra attributes associated with the load balancer.",
+                  "properties": {
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic load balancer load balancing.",
+                      "type": "boolean"
+                    },
+                    "idleTimeout": {
+                      "description": "IdleTimeout is time that the connection is allowed to be idle (no data\nhas been sent over the connection) before it is closed by the load balancer.",
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "availabilityZones": {
+                  "description": "AvailabilityZones is an array of availability zones in the VPC attached to the load balancer.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dnsName": {
+                  "description": "DNSName is the dns name of the load balancer.",
+                  "type": "string"
+                },
+                "elbAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ELBAttributes defines extra attributes associated with v2 load balancers.",
+                  "type": "object"
+                },
+                "elbListeners": {
+                  "description": "ELBListeners is an array of listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "Listener defines an AWS network load balancer listener.",
+                    "properties": {
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "targetGroup": {
+                        "description": "TargetGroupSpec specifies target group settings for a given listener.\nThis is created first, and the ARN is then passed to the listener.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the TargetGroup. Must be unique over the same group of listeners.",
+                            "maxLength": 32,
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port is the exposed port",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "description": "ELBProtocol defines listener protocols for a load balancer.",
+                            "enum": [
+                              "tcp",
+                              "tls",
+                              "udp",
+                              "TCP",
+                              "TLS",
+                              "UDP"
+                            ],
+                            "type": "string"
+                          },
+                          "targetGroupHealthCheck": {
+                            "description": "HealthCheck is the elb health check associated with the load balancer.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vpcId": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "port",
+                          "protocol",
+                          "vpcId"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "port",
+                      "protocol",
+                      "targetGroup"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "healthChecks": {
+                  "description": "HealthCheck is the classic elb health check associated with the load balancer.",
+                  "properties": {
+                    "healthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "interval": {
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "unhealthyThreshold": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "healthyThreshold",
+                    "interval",
+                    "target",
+                    "timeout",
+                    "unhealthyThreshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "ClassicELBListeners is an array of classic elb listeners associated with the load balancer. There must be at least one.",
+                  "items": {
+                    "description": "ClassicELBListener defines an AWS classic load balancer listener.",
+                    "properties": {
+                      "instancePort": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "instanceProtocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "ELBProtocol defines listener protocols for a load balancer.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "instancePort",
+                      "instanceProtocol",
+                      "port",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "loadBalancerType": {
+                  "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                  "enum": [
+                    "classic",
+                    "elb",
+                    "alb",
+                    "nlb"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the load balancer. It must be unique within the set of load balancers\ndefined in the region. It also serves as identifier.",
                   "type": "string"
                 },
                 "scheme": {
@@ -969,9 +1972,11 @@
                           "type": "array"
                         },
                         "description": {
+                          "description": "Description provides extended information about the ingress rule.",
                           "type": "string"
                         },
                         "fromPort": {
+                          "description": "FromPort is the start of port range.",
                           "format": "int64",
                           "type": "integer"
                         },
@@ -982,8 +1987,21 @@
                           },
                           "type": "array"
                         },
+                        "natGatewaysIPsSource": {
+                          "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                          "type": "boolean"
+                        },
                         "protocol": {
-                          "description": "SecurityGroupProtocol defines the protocol type for a security group rule.",
+                          "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                          "enum": [
+                            "-1",
+                            "4",
+                            "tcp",
+                            "udp",
+                            "icmp",
+                            "58",
+                            "50"
+                          ],
                           "type": "string"
                         },
                         "sourceSecurityGroupIds": {
@@ -993,7 +2011,24 @@
                           },
                           "type": "array"
                         },
+                        "sourceSecurityGroupRoles": {
+                          "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                          "items": {
+                            "description": "SecurityGroupRole defines the unique role of a security group.",
+                            "enum": [
+                              "bastion",
+                              "node",
+                              "controlplane",
+                              "apiserver-lb",
+                              "lb",
+                              "node-eks-additional"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "toPort": {
+                          "description": "ToPort is the end of port range.",
                           "format": "int64",
                           "type": "integer"
                         }

--- a/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta1.json
@@ -1,12 +1,12 @@
 {
-  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API It is used to grant access to use Cluster API Provider AWS Controller credentials.",
+  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API\nIt is used to grant access to use Cluster API Provider AWS Controller credentials.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "Spec for this AWSClusterControllerIdentity.",
       "properties": {
         "allowedNamespaces": {
-          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.\nNamespaces can be selected either using an array of namespaces or with label selector.\nAn empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.\nIf this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)\nA namespace should be either in the NamespaceList or match with Selector to use the identity.",
           "nullable": true,
           "properties": {
             "list": {
@@ -28,23 +28,23 @@
               "type": "array"
             },
             "selector": {
-              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "description": "An empty selector indicates that AWSClusters cannot use this\nAWSClusterIdentity from any namespace.",
               "properties": {
                 "matchExpressions": {
                   "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
                         "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -64,7 +64,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },

--- a/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta2.json
@@ -1,12 +1,12 @@
 {
-  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API It is used to grant access to use Cluster API Provider AWS Controller credentials.",
+  "description": "AWSClusterControllerIdentity is the Schema for the awsclustercontrolleridentities API\nIt is used to grant access to use Cluster API Provider AWS Controller credentials.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "Spec for this AWSClusterControllerIdentity.",
       "properties": {
         "allowedNamespaces": {
-          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.\nNamespaces can be selected either using an array of namespaces or with label selector.\nAn empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.\nIf this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)\nA namespace should be either in the NamespaceList or match with Selector to use the identity.",
           "nullable": true,
           "properties": {
             "list": {
@@ -28,23 +28,23 @@
               "type": "array"
             },
             "selector": {
-              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "description": "An empty selector indicates that AWSClusters cannot use this\nAWSClusterIdentity from any namespace.",
               "properties": {
                 "matchExpressions": {
                   "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
                         "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -64,7 +64,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },

--- a/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta1.json
@@ -1,12 +1,12 @@
 {
-  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API It is used to assume a role using the provided sourceRef.",
+  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API\nIt is used to assume a role using the provided sourceRef.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "Spec for this AWSClusterRoleIdentity.",
       "properties": {
         "allowedNamespaces": {
-          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.\nNamespaces can be selected either using an array of namespaces or with label selector.\nAn empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.\nIf this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)\nA namespace should be either in the NamespaceList or match with Selector to use the identity.",
           "nullable": true,
           "properties": {
             "list": {
@@ -28,23 +28,23 @@
               "type": "array"
             },
             "selector": {
-              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "description": "An empty selector indicates that AWSClusters cannot use this\nAWSClusterIdentity from any namespace.",
               "properties": {
                 "matchExpressions": {
                   "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
                         "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -64,7 +64,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },
@@ -84,7 +84,7 @@
           "type": "integer"
         },
         "externalID": {
-          "description": "A unique identifier that might be required when you assume a role in another account. If the administrator of the account to which the role belongs provided you with an external ID, then provide that value in the ExternalId parameter. This value can be any string, such as a passphrase or account number. A cross-account role is usually set up to trust everyone in an account. Therefore, the administrator of the trusting account might send an external ID to the administrator of the trusted account. That way, only someone with the ID can assume the role, rather than everyone in the account. For more information about the external ID, see How to Use an External ID When Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
+          "description": "A unique identifier that might be required when you assume a role in another account.\nIf the administrator of the account to which the role belongs provided you with an\nexternal ID, then provide that value in the ExternalId parameter. This value can be\nany string, such as a passphrase or account number. A cross-account role is usually\nset up to trust everyone in an account. Therefore, the administrator of the trusting\naccount might send an external ID to the administrator of the trusted account. That\nway, only someone with the ID can assume the role, rather than everyone in the\naccount. For more information about the external ID, see How to Use an External ID\nWhen Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
           "type": "string"
         },
         "inlinePolicy": {
@@ -92,7 +92,7 @@
           "type": "string"
         },
         "policyARNs": {
-          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want to use as managed session policies. The policies must exist in the same account as the role.",
+          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want\nto use as managed session policies.\nThe policies must exist in the same account as the role.",
           "items": {
             "type": "string"
           },
@@ -107,7 +107,7 @@
           "type": "string"
         },
         "sourceIdentityRef": {
-          "description": "SourceIdentityRef is a reference to another identity which will be chained to do role assumption. All identity types are accepted.",
+          "description": "SourceIdentityRef is a reference to another identity which will be chained to do\nrole assumption. All identity types are accepted.",
           "properties": {
             "kind": {
               "description": "Kind of the identity.",

--- a/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta2.json
@@ -1,12 +1,12 @@
 {
-  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API It is used to assume a role using the provided sourceRef.",
+  "description": "AWSClusterRoleIdentity is the Schema for the awsclusterroleidentities API\nIt is used to assume a role using the provided sourceRef.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "Spec for this AWSClusterRoleIdentity.",
       "properties": {
         "allowedNamespaces": {
-          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.\nNamespaces can be selected either using an array of namespaces or with label selector.\nAn empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.\nIf this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)\nA namespace should be either in the NamespaceList or match with Selector to use the identity.",
           "nullable": true,
           "properties": {
             "list": {
@@ -28,23 +28,23 @@
               "type": "array"
             },
             "selector": {
-              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "description": "An empty selector indicates that AWSClusters cannot use this\nAWSClusterIdentity from any namespace.",
               "properties": {
                 "matchExpressions": {
                   "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
                         "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -64,7 +64,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },
@@ -84,7 +84,7 @@
           "type": "integer"
         },
         "externalID": {
-          "description": "A unique identifier that might be required when you assume a role in another account. If the administrator of the account to which the role belongs provided you with an external ID, then provide that value in the ExternalId parameter. This value can be any string, such as a passphrase or account number. A cross-account role is usually set up to trust everyone in an account. Therefore, the administrator of the trusting account might send an external ID to the administrator of the trusted account. That way, only someone with the ID can assume the role, rather than everyone in the account. For more information about the external ID, see How to Use an External ID When Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
+          "description": "A unique identifier that might be required when you assume a role in another account.\nIf the administrator of the account to which the role belongs provided you with an\nexternal ID, then provide that value in the ExternalId parameter. This value can be\nany string, such as a passphrase or account number. A cross-account role is usually\nset up to trust everyone in an account. Therefore, the administrator of the trusting\naccount might send an external ID to the administrator of the trusted account. That\nway, only someone with the ID can assume the role, rather than everyone in the\naccount. For more information about the external ID, see How to Use an External ID\nWhen Granting Access to Your AWS Resources to a Third Party in the IAM User Guide.",
           "type": "string"
         },
         "inlinePolicy": {
@@ -92,7 +92,7 @@
           "type": "string"
         },
         "policyARNs": {
-          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want to use as managed session policies. The policies must exist in the same account as the role.",
+          "description": "The Amazon Resource Names (ARNs) of the IAM managed policies that you want\nto use as managed session policies.\nThe policies must exist in the same account as the role.",
           "items": {
             "type": "string"
           },
@@ -107,7 +107,7 @@
           "type": "string"
         },
         "sourceIdentityRef": {
-          "description": "SourceIdentityRef is a reference to another identity which will be chained to do role assumption. All identity types are accepted.",
+          "description": "SourceIdentityRef is a reference to another identity which will be chained to do\nrole assumption. All identity types are accepted.",
           "properties": {
             "kind": {
               "description": "Kind of the identity.",

--- a/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta1.json
@@ -1,12 +1,12 @@
 {
-  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API It represents a reference to an AWS access key ID and secret access key, stored in a secret.",
+  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API\nIt represents a reference to an AWS access key ID and secret access key, stored in a secret.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "Spec for this AWSClusterStaticIdentity",
       "properties": {
         "allowedNamespaces": {
-          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.\nNamespaces can be selected either using an array of namespaces or with label selector.\nAn empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.\nIf this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)\nA namespace should be either in the NamespaceList or match with Selector to use the identity.",
           "nullable": true,
           "properties": {
             "list": {
@@ -28,23 +28,23 @@
               "type": "array"
             },
             "selector": {
-              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "description": "An empty selector indicates that AWSClusters cannot use this\nAWSClusterIdentity from any namespace.",
               "properties": {
                 "matchExpressions": {
                   "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
                         "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -64,7 +64,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },
@@ -77,7 +77,7 @@
           "additionalProperties": false
         },
         "secretRef": {
-          "description": "Reference to a secret containing the credentials. The secret should contain the following data keys: AccessKeyID: AKIAIOSFODNN7EXAMPLE SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY SessionToken: Optional",
+          "description": "Reference to a secret containing the credentials. The secret should\ncontain the following data keys:\n AccessKeyID: AKIAIOSFODNN7EXAMPLE\n SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n SessionToken: Optional",
           "type": "string"
         }
       },

--- a/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta2.json
@@ -1,12 +1,12 @@
 {
-  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API It represents a reference to an AWS access key ID and secret access key, stored in a secret.",
+  "description": "AWSClusterStaticIdentity is the Schema for the awsclusterstaticidentities API\nIt represents a reference to an AWS access key ID and secret access key, stored in a secret.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,7 +16,7 @@
       "description": "Spec for this AWSClusterStaticIdentity",
       "properties": {
         "allowedNamespaces": {
-          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from. Namespaces can be selected either using an array of namespaces or with label selector. An empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace. If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided) A namespace should be either in the NamespaceList or match with Selector to use the identity.",
+          "description": "AllowedNamespaces is used to identify which namespaces are allowed to use the identity from.\nNamespaces can be selected either using an array of namespaces or with label selector.\nAn empty allowedNamespaces object indicates that AWSClusters can use this identity from any namespace.\nIf this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)\nA namespace should be either in the NamespaceList or match with Selector to use the identity.",
           "nullable": true,
           "properties": {
             "list": {
@@ -28,23 +28,23 @@
               "type": "array"
             },
             "selector": {
-              "description": "An empty selector indicates that AWSClusters cannot use this AWSClusterIdentity from any namespace.",
+              "description": "An empty selector indicates that AWSClusters cannot use this\nAWSClusterIdentity from any namespace.",
               "properties": {
                 "matchExpressions": {
                   "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
                         "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -64,7 +64,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },
@@ -77,7 +77,7 @@
           "additionalProperties": false
         },
         "secretRef": {
-          "description": "Reference to a secret containing the credentials. The secret should contain the following data keys: AccessKeyID: AKIAIOSFODNN7EXAMPLE SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY SessionToken: Optional",
+          "description": "Reference to a secret containing the credentials. The secret should\ncontain the following data keys:\n AccessKeyID: AKIAIOSFODNN7EXAMPLE\n SecretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n SessionToken: Optional",
           "type": "string"
         }
       },

--- a/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSClusterTemplate is the schema for Amazon EC2 based Kubernetes Cluster Templates.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,22 +16,23 @@
       "description": "AWSClusterTemplateSpec defines the desired state of AWSClusterTemplate.",
       "properties": {
         "template": {
+          "description": "AWSClusterTemplateResource defines the desired state of AWSClusterTemplate.",
           "properties": {
             "metadata": {
-              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
                   "type": "object"
                 }
               },
@@ -45,33 +46,33 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
                   "type": "object"
                 },
                 "bastion": {
                   "description": "Bastion contains options to configure the bastion host.",
                   "properties": {
                     "allowedCIDRBlocks": {
-                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.\nThey are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "ami": {
-                      "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+                      "description": "AMI will use the specified AMI to boot the bastion. If not specified,\nthe AMI will default to one picked out in public space.",
                       "type": "string"
                     },
                     "disableIngressRules": {
-                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.\nRequires AllowedCIDRBlocks to be empty.",
                       "type": "boolean"
                     },
                     "enabled": {
-                      "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+                      "description": "Enabled allows this provider to create a bastion host instance\nwith a public ip to access the VPC private network.",
                       "type": "boolean"
                     },
                     "instanceType": {
-                      "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+                      "description": "InstanceType will use the specified instance type for the bastion. If not specified,\nCluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro\nwill be the default.",
                       "type": "string"
                     }
                   },
@@ -102,22 +103,22 @@
                   "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
                   "properties": {
                     "additionalSecurityGroups": {
-                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs\nThis is optional - if not provided new security groups will be created for the load balancer",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "crossZoneLoadBalancing": {
-                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing.\n\n\nWith cross-zone load balancing, each load balancer node for your Classic Load Balancer\ndistributes requests evenly across the registered instances in all enabled Availability Zones.\nIf cross-zone load balancing is disabled, each load balancer node distributes requests evenly across\nthe registered instances in its Availability Zone only.\n\n\nDefaults to false.",
                       "type": "boolean"
                     },
                     "healthCheckProtocol": {
-                      "description": "HealthCheckProtocol sets the protocol type for classic ELB health check target default value is ClassicELBProtocolSSL",
+                      "description": "HealthCheckProtocol sets the protocol type for classic ELB health check target\ndefault value is ClassicELBProtocolSSL",
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique\nwithin your set of load balancers for the region, must have a maximum of 32 characters, must\ncontain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once\nset, the value cannot be changed.",
                       "maxLength": 32,
                       "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
                       "type": "string"
@@ -143,7 +144,7 @@
                   "additionalProperties": false
                 },
                 "identityRef": {
-                  "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+                  "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
                   "properties": {
                     "kind": {
                       "description": "Kind of the identity.",
@@ -168,15 +169,15 @@
                   "additionalProperties": false
                 },
                 "imageLookupBaseOS": {
-                  "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+                  "description": "ImageLookupBaseOS is the name of the base operating system used to look\nup machine images when a machine does not specify an AMI. When set, this\nwill be used for all cluster machines unless a machine specifies a\ndifferent ImageLookupBaseOS.",
                   "type": "string"
                 },
                 "imageLookupFormat": {
-                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when\na machine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.\nSupports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base\nOS and kubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
                   "type": "string"
                 },
                 "imageLookupOrg": {
-                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a\nmachine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.",
                   "type": "string"
                 },
                 "network": {
@@ -186,7 +187,7 @@
                       "description": "CNI configuration",
                       "properties": {
                         "cniIngressRules": {
-                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups.\nThe source for the rule will be set to control plane and worker security group IDs.",
                           "items": {
                             "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
                             "properties": {
@@ -225,7 +226,7 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances\nThis is optional - if not provided new security groups will be created for the cluster",
                       "type": "object"
                     },
                     "subnets": {
@@ -246,11 +247,11 @@
                             "type": "string"
                           },
                           "ipv6CidrBlock": {
-                            "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.\nA subnet can have an IPv4 and an IPv6 address.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                             "type": "string"
                           },
                           "isIpv6": {
-                            "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                             "type": "boolean"
                           },
                           "isPublic": {
@@ -258,7 +259,7 @@
                             "type": "boolean"
                           },
                           "natGatewayId": {
-                            "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                            "description": "NatGatewayID is the NAT gateway id associated with the subnet.\nIgnored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
                             "type": "string"
                           },
                           "routeTableId": {
@@ -283,7 +284,7 @@
                       "properties": {
                         "availabilityZoneSelection": {
                           "default": "Ordered",
-                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs\nin a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:\nOrdered - selects based on alphabetical order\nRandom - selects AZs randomly in a region\nDefaults to Ordered",
                           "enum": [
                             "Ordered",
                             "Random"
@@ -292,12 +293,12 @@
                         },
                         "availabilityZoneUsageLimit": {
                           "default": 3,
-                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that\nshould be used in a region when automatically creating subnets. If a region has more\nthan this number of AZs then this number of AZs will be picked randomly when creating\ndefault subnets. Defaults to 3",
                           "minimum": 1,
                           "type": "integer"
                         },
                         "cidrBlock": {
-                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.\nDefaults to 10.0.0.0/16.",
                           "type": "string"
                         },
                         "id": {
@@ -309,7 +310,7 @@
                           "type": "string"
                         },
                         "ipv6": {
-                          "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                          "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.\nThis field cannot be set on AWSCluster object.",
                           "properties": {
                             "cidrBlock": {
                               "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
@@ -347,10 +348,10 @@
                   "type": "string"
                 },
                 "s3Bucket": {
-                  "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+                  "description": "S3Bucket contains options to configure a supporting S3 bucket for this\ncluster - currently used for nodes requiring Ignition\n(https://coreos.github.io/ignition/) for bootstrapping (requires\nBootstrapFormatIgnition feature flag to be enabled).",
                   "properties": {
                     "controlPlaneIAMInstanceProfile": {
-                      "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+                      "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed\nto read control-plane node bootstrap data from S3 Bucket.",
                       "type": "string"
                     },
                     "name": {
@@ -361,7 +362,7 @@
                       "type": "string"
                     },
                     "nodesIAMInstanceProfiles": {
-                      "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+                      "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read\nworker nodes bootstrap data from S3 Bucket.",
                       "items": {
                         "type": "string"
                       },

--- a/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSClusterTemplate is the schema for Amazon EC2 based Kubernetes Cluster Templates.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,22 +16,23 @@
       "description": "AWSClusterTemplateSpec defines the desired state of AWSClusterTemplate.",
       "properties": {
         "template": {
+          "description": "AWSClusterTemplateResource defines the desired state of AWSClusterTemplateResource.",
           "properties": {
             "metadata": {
-              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
                   "type": "object"
                 }
               },
@@ -45,33 +46,33 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+                  "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
                   "type": "object"
                 },
                 "bastion": {
                   "description": "Bastion contains options to configure the bastion host.",
                   "properties": {
                     "allowedCIDRBlocks": {
-                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
+                      "description": "AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.\nThey are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "ami": {
-                      "description": "AMI will use the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space.",
+                      "description": "AMI will use the specified AMI to boot the bastion. If not specified,\nthe AMI will default to one picked out in public space.",
                       "type": "string"
                     },
                     "disableIngressRules": {
-                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group. Requires AllowedCIDRBlocks to be empty.",
+                      "description": "DisableIngressRules will ensure there are no Ingress rules in the bastion host's security group.\nRequires AllowedCIDRBlocks to be empty.",
                       "type": "boolean"
                     },
                     "enabled": {
-                      "description": "Enabled allows this provider to create a bastion host instance with a public ip to access the VPC private network.",
+                      "description": "Enabled allows this provider to create a bastion host instance\nwith a public ip to access the VPC private network.",
                       "type": "boolean"
                     },
                     "instanceType": {
-                      "description": "InstanceType will use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default.",
+                      "description": "InstanceType will use the specified instance type for the bastion. If not specified,\nCluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro\nwill be the default.",
                       "type": "string"
                     }
                   },
@@ -101,24 +102,237 @@
                 "controlPlaneLoadBalancer": {
                   "description": "ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.",
                   "properties": {
+                    "additionalListeners": {
+                      "description": "AdditionalListeners sets the additional listeners for the control plane load balancer.\nThis is only applicable to Network Load Balancer (NLB) types for the time being.",
+                      "items": {
+                        "description": "AdditionalListenerSpec defines the desired state of an\nadditional listener on an AWS load balancer.",
+                        "properties": {
+                          "healthCheck": {
+                            "description": "HealthCheck sets the optional custom health check configuration to the API target group.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                                "format": "int64",
+                                "maximum": 300,
+                                "minimum": 5,
+                                "type": "integer"
+                              },
+                              "path": {
+                                "description": "The destination for health checks on the targets when using the protocol HTTP or HTTPS,\notherwise the path will be ignored.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "The port the load balancer uses when performing health checks for additional target groups. When\nnot specified this value will be set for the same of listener port.",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "The protocol to use to health check connect with the target. When not specified the Protocol\nwill be the same of the listener.",
+                                "enum": [
+                                  "TCP",
+                                  "HTTP",
+                                  "HTTPS"
+                                ],
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                                "format": "int64",
+                                "maximum": 10,
+                                "minimum": 2,
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                                "format": "int64",
+                                "maximum": 120,
+                                "minimum": 2,
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
+                                "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                                "format": "int64",
+                                "maximum": 10,
+                                "minimum": 2,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "port": {
+                            "description": "Port sets the port for the additional listener.",
+                            "format": "int64",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "default": "TCP",
+                            "description": "Protocol sets the protocol for the additional listener.\nCurrently only TCP is supported.",
+                            "enum": [
+                              "TCP"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "port"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
                     "additionalSecurityGroups": {
-                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer",
+                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs\nThis is optional - if not provided new security groups will be created for the load balancer",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "crossZoneLoadBalancing": {
-                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing. \n With cross-zone load balancing, each load balancer node for your Classic Load Balancer distributes requests evenly across the registered instances in all enabled Availability Zones. If cross-zone load balancing is disabled, each load balancer node distributes requests evenly across the registered instances in its Availability Zone only. \n Defaults to false.",
+                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing.\n\n\nWith cross-zone load balancing, each load balancer node for your Classic Load Balancer\ndistributes requests evenly across the registered instances in all enabled Availability Zones.\nIf cross-zone load balancing is disabled, each load balancer node distributes requests evenly across\nthe registered instances in its Availability Zone only.\n\n\nDefaults to false.",
                       "type": "boolean"
                     },
                     "disableHostsRewrite": {
-                      "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts file of each instance. This is by default, false.",
+                      "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts\nfile of each instance. This is by default, false.",
                       "type": "boolean"
                     },
+                    "healthCheck": {
+                      "description": "HealthCheck sets custom health check configuration to the API target group.",
+                      "properties": {
+                        "intervalSeconds": {
+                          "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                          "format": "int64",
+                          "maximum": 300,
+                          "minimum": 5,
+                          "type": "integer"
+                        },
+                        "thresholdCount": {
+                          "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                          "format": "int64",
+                          "maximum": 10,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                          "format": "int64",
+                          "maximum": 120,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "unhealthyThresholdCount": {
+                          "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                          "format": "int64",
+                          "maximum": 10,
+                          "minimum": 2,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "healthCheckProtocol": {
-                      "description": "HealthCheckProtocol sets the protocol type for ELB health check target default value is ELBProtocolSSL",
+                      "description": "HealthCheckProtocol sets the protocol type for ELB health check target\ndefault value is ELBProtocolSSL",
+                      "enum": [
+                        "TCP",
+                        "SSL",
+                        "HTTP",
+                        "HTTPS",
+                        "TLS",
+                        "UDP"
+                      ],
                       "type": "string"
+                    },
+                    "ingressRules": {
+                      "description": "IngressRules sets the ingress rules for the control plane load balancer.",
+                      "items": {
+                        "description": "IngressRule defines an AWS ingress rule for security groups.",
+                        "properties": {
+                          "cidrBlocks": {
+                            "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "description": "Description provides extended information about the ingress rule.",
+                            "type": "string"
+                          },
+                          "fromPort": {
+                            "description": "FromPort is the start of port range.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "ipv6CidrBlocks": {
+                            "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "natGatewaysIPsSource": {
+                            "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                            "type": "boolean"
+                          },
+                          "protocol": {
+                            "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                            "enum": [
+                              "-1",
+                              "4",
+                              "tcp",
+                              "udp",
+                              "icmp",
+                              "58",
+                              "50"
+                            ],
+                            "type": "string"
+                          },
+                          "sourceSecurityGroupIds": {
+                            "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sourceSecurityGroupRoles": {
+                            "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                            "items": {
+                              "description": "SecurityGroupRole defines the unique role of a security group.",
+                              "enum": [
+                                "bastion",
+                                "node",
+                                "controlplane",
+                                "apiserver-lb",
+                                "lb",
+                                "node-eks-additional"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "toPort": {
+                            "description": "ToPort is the end of port range.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "description",
+                          "fromPort",
+                          "protocol",
+                          "toPort"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
                     },
                     "loadBalancerType": {
                       "default": "classic",
@@ -127,18 +341,19 @@
                         "classic",
                         "elb",
                         "alb",
-                        "nlb"
+                        "nlb",
+                        "disabled"
                       ],
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once set, the value cannot be changed.",
+                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique\nwithin your set of load balancers for the region, must have a maximum of 32 characters, must\ncontain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once\nset, the value cannot be changed.",
                       "maxLength": 32,
                       "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
                       "type": "string"
                     },
                     "preserveClientIP": {
-                      "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not. If this is enabled 6443 will be opened to 0.0.0.0/0.",
+                      "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not.\nIf this is enabled 6443 will be opened to 0.0.0.0/0.",
                       "type": "boolean"
                     },
                     "scheme": {
@@ -162,7 +377,7 @@
                   "additionalProperties": false
                 },
                 "identityRef": {
-                  "description": "IdentityRef is a reference to a identity to be used when reconciling this cluster",
+                  "description": "IdentityRef is a reference to an identity to be used when reconciling the managed control plane.\nIf no identity is specified, the default identity for this controller will be used.",
                   "properties": {
                     "kind": {
                       "description": "Kind of the identity.",
@@ -187,25 +402,110 @@
                   "additionalProperties": false
                 },
                 "imageLookupBaseOS": {
-                  "description": "ImageLookupBaseOS is the name of the base operating system used to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupBaseOS.",
+                  "description": "ImageLookupBaseOS is the name of the base operating system used to look\nup machine images when a machine does not specify an AMI. When set, this\nwill be used for all cluster machines unless a machine specifies a\ndifferent ImageLookupBaseOS.",
                   "type": "string"
                 },
                 "imageLookupFormat": {
-                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "description": "ImageLookupFormat is the AMI naming format to look up machine images when\na machine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.\nSupports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base\nOS and kubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
                   "type": "string"
                 },
                 "imageLookupOrg": {
-                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a machine does not specify an AMI. When set, this will be used for all cluster machines unless a machine specifies a different ImageLookupOrg.",
+                  "description": "ImageLookupOrg is the AWS Organization ID to look up machine images when a\nmachine does not specify an AMI. When set, this will be used for all\ncluster machines unless a machine specifies a different ImageLookupOrg.",
                   "type": "string"
                 },
                 "network": {
                   "description": "NetworkSpec encapsulates all things related to AWS network.",
                   "properties": {
+                    "additionalControlPlaneIngressRules": {
+                      "description": "AdditionalControlPlaneIngressRules is an optional set of ingress rules to add to the control plane",
+                      "items": {
+                        "description": "IngressRule defines an AWS ingress rule for security groups.",
+                        "properties": {
+                          "cidrBlocks": {
+                            "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "description": "Description provides extended information about the ingress rule.",
+                            "type": "string"
+                          },
+                          "fromPort": {
+                            "description": "FromPort is the start of port range.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "ipv6CidrBlocks": {
+                            "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "natGatewaysIPsSource": {
+                            "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                            "type": "boolean"
+                          },
+                          "protocol": {
+                            "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                            "enum": [
+                              "-1",
+                              "4",
+                              "tcp",
+                              "udp",
+                              "icmp",
+                              "58",
+                              "50"
+                            ],
+                            "type": "string"
+                          },
+                          "sourceSecurityGroupIds": {
+                            "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sourceSecurityGroupRoles": {
+                            "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                            "items": {
+                              "description": "SecurityGroupRole defines the unique role of a security group.",
+                              "enum": [
+                                "bastion",
+                                "node",
+                                "controlplane",
+                                "apiserver-lb",
+                                "lb",
+                                "node-eks-additional"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "toPort": {
+                            "description": "ToPort is the end of port range.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "description",
+                          "fromPort",
+                          "protocol",
+                          "toPort"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "cni": {
                       "description": "CNI configuration",
                       "properties": {
                         "cniIngressRules": {
-                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups. The source for the rule will be set to control plane and worker security group IDs.",
+                          "description": "CNIIngressRules specify rules to apply to control plane and worker node security groups.\nThe source for the rule will be set to control plane and worker security group IDs.",
                           "items": {
                             "description": "CNIIngressRule defines an AWS ingress rule for CNI requirements.",
                             "properties": {
@@ -244,7 +544,7 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances This is optional - if not provided new security groups will be created for the cluster",
+                      "description": "SecurityGroupOverrides is an optional set of security groups to use for cluster instances\nThis is optional - if not provided new security groups will be created for the cluster",
                       "type": "object"
                     },
                     "subnets": {
@@ -261,15 +561,15 @@
                             "type": "string"
                           },
                           "id": {
-                            "description": "ID defines a unique identifier to reference this resource.",
+                            "description": "ID defines a unique identifier to reference this resource.\nIf you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`.\n\n\nWhen the VPC is managed by CAPA, and you'd like the provider to create a subnet for you,\nthe id can be set to any placeholder value that does not start with `subnet-`;\nupon creation, the subnet AWS identifier will be populated in the `ResourceID` field and\nthe `id` field is going to be used as the subnet name. If you specify a tag\ncalled `Name`, it takes precedence.",
                             "type": "string"
                           },
                           "ipv6CidrBlock": {
-                            "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "description": "IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.\nA subnet can have an IPv4 and an IPv6 address.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                             "type": "string"
                           },
                           "isIpv6": {
-                            "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
+                            "description": "IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.\nIPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.",
                             "type": "boolean"
                           },
                           "isPublic": {
@@ -277,7 +577,15 @@
                             "type": "boolean"
                           },
                           "natGatewayId": {
-                            "description": "NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                            "description": "NatGatewayID is the NAT gateway id associated with the subnet.\nIgnored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.",
+                            "type": "string"
+                          },
+                          "parentZoneName": {
+                            "description": "ParentZoneName is the zone name where the current subnet's zone is tied when\nthe zone is a Local Zone.\n\n\nThe subnets in Local Zone or Wavelength Zone locations consume the ParentZoneName\nto select the correct private route table to egress traffic to the internet.",
+                            "type": "string"
+                          },
+                          "resourceID": {
+                            "description": "ResourceID is the subnet identifier from AWS, READ ONLY.\nThis field is populated when the provider manages the subnet.",
                             "type": "string"
                           },
                           "routeTableId": {
@@ -290,6 +598,15 @@
                             },
                             "description": "Tags is a collection of tags describing the resource.",
                             "type": "object"
+                          },
+                          "zoneType": {
+                            "description": "ZoneType defines the type of the zone where the subnet is created.\n\n\nThe valid values are availability-zone, local-zone, and wavelength-zone.\n\n\nSubnet with zone type availability-zone (regular) is always selected to create cluster\nresources, like Load Balancers, NAT Gateways, Contol Plane nodes, etc.\n\n\nSubnet with zone type local-zone or wavelength-zone is not eligible to automatically create\nregular cluster resources.\n\n\nThe public subnet in availability-zone or local-zone is associated with regular public\nroute table with default route entry to a Internet Gateway.\n\n\nThe public subnet in wavelength-zone is associated with a carrier public\nroute table with default route entry to a Carrier Gateway.\n\n\nThe private subnet in the availability-zone is associated with a private route table with\nthe default route entry to a NAT Gateway created in that zone.\n\n\nThe private subnet in the local-zone or wavelength-zone is associated with a private route table with\nthe default route entry re-using the NAT Gateway in the Region (preferred from the\nparent zone, the zone type availability-zone in the region, or first table available).",
+                            "enum": [
+                              "availability-zone",
+                              "local-zone",
+                              "wavelength-zone"
+                            ],
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -309,7 +626,7 @@
                       "properties": {
                         "availabilityZoneSelection": {
                           "default": "Ordered",
-                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs in a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes: Ordered - selects based on alphabetical order Random - selects AZs randomly in a region Defaults to Ordered",
+                          "description": "AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs\nin a region than specified by AvailabilityZoneUsageLimit. There are 2 selection schemes:\nOrdered - selects based on alphabetical order\nRandom - selects AZs randomly in a region\nDefaults to Ordered",
                           "enum": [
                             "Ordered",
                             "Random"
@@ -318,13 +635,53 @@
                         },
                         "availabilityZoneUsageLimit": {
                           "default": 3,
-                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that should be used in a region when automatically creating subnets. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating default subnets. Defaults to 3",
+                          "description": "AvailabilityZoneUsageLimit specifies the maximum number of availability zones (AZ) that\nshould be used in a region when automatically creating subnets. If a region has more\nthan this number of AZs then this number of AZs will be picked randomly when creating\ndefault subnets. Defaults to 3",
                           "minimum": 1,
                           "type": "integer"
                         },
+                        "carrierGatewayId": {
+                          "description": "CarrierGatewayID is the id of the internet gateway associated with the VPC,\nfor carrier network (Wavelength Zones).",
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Carrier Gateway ID must start with 'cagw-'",
+                              "rule": "self.startsWith('cagw-')"
+                            }
+                          ]
+                        },
                         "cidrBlock": {
-                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.",
+                          "description": "CidrBlock is the CIDR block to be used when the provider creates a managed VPC.\nDefaults to 10.0.0.0/16.\nMutually exclusive with IPAMPool.",
                           "type": "string"
+                        },
+                        "elasticIpPool": {
+                          "description": "ElasticIPPool contains specific configuration to allocate Public IPv4 address (Elastic IP) from user-defined pool\nbrought to AWS for core infrastructure resources, like NAT Gateways and Public Network Load Balancers for\nthe API Server.",
+                          "properties": {
+                            "publicIpv4Pool": {
+                              "description": "PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources\ncreated in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom\nPublic IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool\nresource ID starts with 'ipv4pool-ec2'.",
+                              "maxLength": 30,
+                              "type": "string"
+                            },
+                            "publicIpv4PoolFallbackOrder": {
+                              "description": "PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,\nno more IPv4 address available in the pool.\n\n\nWhen set to 'amazon-pool', the controller check if the pool has available IPv4 address, when pool has reached the\nIPv4 limit, the address will be claimed from Amazon-pool (default).\n\n\nWhen set to 'none', the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.",
+                              "enum": [
+                                "amazon-pool",
+                                "none"
+                              ],
+                              "type": "string",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "allowed values are 'none' and 'amazon-pool'",
+                                  "rule": "self in ['none','amazon-pool']"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "emptyRoutesDefaultVPCSecurityGroup": {
+                          "description": "EmptyRoutesDefaultVPCSecurityGroup specifies whether the default VPC security group ingress\nand egress rules should be removed.\n\n\nBy default, when creating a VPC, AWS creates a security group called `default` with ingress and egress\nrules that allow traffic from anywhere. The group could be used as a potential surface attack and\nit's generally suggested that the group rules are removed or modified appropriately.\n\n\nNOTE: This only applies when the VPC is managed by the Cluster API AWS controller.",
+                          "type": "boolean"
                         },
                         "id": {
                           "description": "ID is the vpc-id of the VPC this provider should use to create resources.",
@@ -334,24 +691,81 @@
                           "description": "InternetGatewayID is the id of the internet gateway associated with the VPC.",
                           "type": "string"
                         },
+                        "ipamPool": {
+                          "description": "IPAMPool defines the IPAMv4 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                          "properties": {
+                            "id": {
+                              "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                              "type": "string"
+                            },
+                            "netmaskLength": {
+                              "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "ipv6": {
-                          "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.",
+                          "description": "IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.\nThis field cannot be set on AWSCluster object.",
                           "properties": {
                             "cidrBlock": {
-                              "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.",
+                              "description": "CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.\nMutually exclusive with IPAMPool.",
                               "type": "string"
                             },
                             "egressOnlyInternetGatewayId": {
                               "description": "EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.",
                               "type": "string"
                             },
+                            "ipamPool": {
+                              "description": "IPAMPool defines the IPAMv6 pool to be used for VPC.\nMutually exclusive with CidrBlock.",
+                              "properties": {
+                                "id": {
+                                  "description": "ID is the ID of the IPAM pool this provider should use to create VPC.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the IPAM pool this provider should use to create VPC.",
+                                  "type": "string"
+                                },
+                                "netmaskLength": {
+                                  "description": "The netmask length of the IPv4 CIDR you want to allocate to VPC from\nan Amazon VPC IP Address Manager (IPAM) pool.\nDefaults to /16 for IPv4 if not specified.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "poolId": {
-                              "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.",
+                              "description": "PoolID is the IP pool which must be defined in case of BYO IP is defined.\nMust be specified if CidrBlock is set.\nMutually exclusive with IPAMPool.",
                               "type": "string"
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
+                        },
+                        "privateDnsHostnameTypeOnLaunch": {
+                          "description": "PrivateDNSHostnameTypeOnLaunch is the type of hostname to assign to instances in the subnet at launch.\nFor IPv4-only and dual-stack (IPv4 and IPv6) subnets, an instance DNS name can be based on the instance IPv4 address (ip-name)\nor the instance ID (resource-name). For IPv6 only subnets, an instance DNS name must be based on the instance ID (resource-name).",
+                          "enum": [
+                            "ip-name",
+                            "resource-name"
+                          ],
+                          "type": "string"
+                        },
+                        "subnetSchema": {
+                          "default": "PreferPrivate",
+                          "description": "SubnetSchema specifies how CidrBlock should be divided on subnets in the VPC depending on the number of AZs.\nPreferPrivate - one private subnet for each AZ plus one other subnet that will be further sub-divided for the public subnets.\nPreferPublic - have the reverse logic of PreferPrivate, one public subnet for each AZ plus one other subnet\nthat will be further sub-divided for the private subnets.\nDefaults to PreferPrivate",
+                          "enum": [
+                            "PreferPrivate",
+                            "PreferPublic"
+                          ],
+                          "type": "string"
                         },
                         "tags": {
                           "additionalProperties": {
@@ -368,15 +782,23 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "partition": {
+                  "description": "Partition is the AWS security partition being used. Defaults to \"aws\"",
+                  "type": "string"
+                },
                 "region": {
                   "description": "The AWS Region the cluster lives in.",
                   "type": "string"
                 },
                 "s3Bucket": {
-                  "description": "S3Bucket contains options to configure a supporting S3 bucket for this cluster - currently used for nodes requiring Ignition (https://coreos.github.io/ignition/) for bootstrapping (requires BootstrapFormatIgnition feature flag to be enabled).",
+                  "description": "S3Bucket contains options to configure a supporting S3 bucket for this\ncluster - currently used for nodes requiring Ignition\n(https://coreos.github.io/ignition/) for bootstrapping (requires\nBootstrapFormatIgnition feature flag to be enabled).",
                   "properties": {
+                    "bestEffortDeleteObjects": {
+                      "description": "BestEffortDeleteObjects defines whether access/permission errors during object deletion should be ignored.",
+                      "type": "boolean"
+                    },
                     "controlPlaneIAMInstanceProfile": {
-                      "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed to read control-plane node bootstrap data from S3 Bucket.",
+                      "description": "ControlPlaneIAMInstanceProfile is a name of the IAMInstanceProfile, which will be allowed\nto read control-plane node bootstrap data from S3 Bucket.",
                       "type": "string"
                     },
                     "name": {
@@ -387,18 +809,297 @@
                       "type": "string"
                     },
                     "nodesIAMInstanceProfiles": {
-                      "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read worker nodes bootstrap data from S3 Bucket.",
+                      "description": "NodesIAMInstanceProfiles is a list of IAM instance profiles, which will be allowed to read\nworker nodes bootstrap data from S3 Bucket.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "presignedURLDuration": {
+                      "description": "PresignedURLDuration defines the duration for which presigned URLs are valid.\n\n\nThis is used to generate presigned URLs for S3 Bucket objects, which are used by\ncontrol-plane and worker nodes to fetch bootstrap data.\n\n\nWhen enabled, the IAM instance profiles specified are not used.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secondaryControlPlaneLoadBalancer": {
+                  "description": "SecondaryControlPlaneLoadBalancer is an additional load balancer that can be used for the control plane.\n\n\nAn example use case is to have a separate internal load balancer for internal traffic,\nand a separate external load balancer for external traffic.",
+                  "properties": {
+                    "additionalListeners": {
+                      "description": "AdditionalListeners sets the additional listeners for the control plane load balancer.\nThis is only applicable to Network Load Balancer (NLB) types for the time being.",
+                      "items": {
+                        "description": "AdditionalListenerSpec defines the desired state of an\nadditional listener on an AWS load balancer.",
+                        "properties": {
+                          "healthCheck": {
+                            "description": "HealthCheck sets the optional custom health check configuration to the API target group.",
+                            "properties": {
+                              "intervalSeconds": {
+                                "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                                "format": "int64",
+                                "maximum": 300,
+                                "minimum": 5,
+                                "type": "integer"
+                              },
+                              "path": {
+                                "description": "The destination for health checks on the targets when using the protocol HTTP or HTTPS,\notherwise the path will be ignored.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "The port the load balancer uses when performing health checks for additional target groups. When\nnot specified this value will be set for the same of listener port.",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "The protocol to use to health check connect with the target. When not specified the Protocol\nwill be the same of the listener.",
+                                "enum": [
+                                  "TCP",
+                                  "HTTP",
+                                  "HTTPS"
+                                ],
+                                "type": "string"
+                              },
+                              "thresholdCount": {
+                                "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                                "format": "int64",
+                                "maximum": 10,
+                                "minimum": 2,
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                                "format": "int64",
+                                "maximum": 120,
+                                "minimum": 2,
+                                "type": "integer"
+                              },
+                              "unhealthyThresholdCount": {
+                                "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                                "format": "int64",
+                                "maximum": 10,
+                                "minimum": 2,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "port": {
+                            "description": "Port sets the port for the additional listener.",
+                            "format": "int64",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "default": "TCP",
+                            "description": "Protocol sets the protocol for the additional listener.\nCurrently only TCP is supported.",
+                            "enum": [
+                              "TCP"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "port"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "additionalSecurityGroups": {
+                      "description": "AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs\nThis is optional - if not provided new security groups will be created for the load balancer",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "crossZoneLoadBalancing": {
+                      "description": "CrossZoneLoadBalancing enables the classic ELB cross availability zone balancing.\n\n\nWith cross-zone load balancing, each load balancer node for your Classic Load Balancer\ndistributes requests evenly across the registered instances in all enabled Availability Zones.\nIf cross-zone load balancing is disabled, each load balancer node distributes requests evenly across\nthe registered instances in its Availability Zone only.\n\n\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "disableHostsRewrite": {
+                      "description": "DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts\nfile of each instance. This is by default, false.",
+                      "type": "boolean"
+                    },
+                    "healthCheck": {
+                      "description": "HealthCheck sets custom health check configuration to the API target group.",
+                      "properties": {
+                        "intervalSeconds": {
+                          "description": "The approximate amount of time, in seconds, between health checks of an individual\ntarget.",
+                          "format": "int64",
+                          "maximum": 300,
+                          "minimum": 5,
+                          "type": "integer"
+                        },
+                        "thresholdCount": {
+                          "description": "The number of consecutive health check successes required before considering\na target healthy.",
+                          "format": "int64",
+                          "maximum": 10,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "description": "The amount of time, in seconds, during which no response from a target means\na failed health check.",
+                          "format": "int64",
+                          "maximum": 120,
+                          "minimum": 2,
+                          "type": "integer"
+                        },
+                        "unhealthyThresholdCount": {
+                          "description": "The number of consecutive health check failures required before considering\na target unhealthy.",
+                          "format": "int64",
+                          "maximum": 10,
+                          "minimum": 2,
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "healthCheckProtocol": {
+                      "description": "HealthCheckProtocol sets the protocol type for ELB health check target\ndefault value is ELBProtocolSSL",
+                      "enum": [
+                        "TCP",
+                        "SSL",
+                        "HTTP",
+                        "HTTPS",
+                        "TLS",
+                        "UDP"
+                      ],
+                      "type": "string"
+                    },
+                    "ingressRules": {
+                      "description": "IngressRules sets the ingress rules for the control plane load balancer.",
+                      "items": {
+                        "description": "IngressRule defines an AWS ingress rule for security groups.",
+                        "properties": {
+                          "cidrBlocks": {
+                            "description": "List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "description": {
+                            "description": "Description provides extended information about the ingress rule.",
+                            "type": "string"
+                          },
+                          "fromPort": {
+                            "description": "FromPort is the start of port range.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "ipv6CidrBlocks": {
+                            "description": "List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "natGatewaysIPsSource": {
+                            "description": "NatGatewaysIPsSource use the NAT gateways IPs as the source for the ingress rule.",
+                            "type": "boolean"
+                          },
+                          "protocol": {
+                            "description": "Protocol is the protocol for the ingress rule. Accepted values are \"-1\" (all), \"4\" (IP in IP),\"tcp\", \"udp\", \"icmp\", and \"58\" (ICMPv6), \"50\" (ESP).",
+                            "enum": [
+                              "-1",
+                              "4",
+                              "tcp",
+                              "udp",
+                              "icmp",
+                              "58",
+                              "50"
+                            ],
+                            "type": "string"
+                          },
+                          "sourceSecurityGroupIds": {
+                            "description": "The security group id to allow access from. Cannot be specified with CidrBlocks.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "sourceSecurityGroupRoles": {
+                            "description": "The security group role to allow access from. Cannot be specified with CidrBlocks.\nThe field will be combined with source security group IDs if specified.",
+                            "items": {
+                              "description": "SecurityGroupRole defines the unique role of a security group.",
+                              "enum": [
+                                "bastion",
+                                "node",
+                                "controlplane",
+                                "apiserver-lb",
+                                "lb",
+                                "node-eks-additional"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "toPort": {
+                            "description": "ToPort is the end of port range.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "description",
+                          "fromPort",
+                          "protocol",
+                          "toPort"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "loadBalancerType": {
+                      "default": "classic",
+                      "description": "LoadBalancerType sets the type for a load balancer. The default type is classic.",
+                      "enum": [
+                        "classic",
+                        "elb",
+                        "alb",
+                        "nlb",
+                        "disabled"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name sets the name of the classic ELB load balancer. As per AWS, the name must be unique\nwithin your set of load balancers for the region, must have a maximum of 32 characters, must\ncontain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen. Once\nset, the value cannot be changed.",
+                      "maxLength": 32,
+                      "pattern": "^[A-Za-z0-9]([A-Za-z0-9]{0,31}|[-A-Za-z0-9]{0,30}[A-Za-z0-9])$",
+                      "type": "string"
+                    },
+                    "preserveClientIP": {
+                      "description": "PreserveClientIP lets the user control if preservation of client ips must be retained or not.\nIf this is enabled 6443 will be opened to 0.0.0.0/0.",
+                      "type": "boolean"
+                    },
+                    "scheme": {
+                      "default": "internet-facing",
+                      "description": "Scheme sets the scheme of the load balancer (defaults to internet-facing)",
+                      "enum": [
+                        "internet-facing",
+                        "internal"
+                      ],
+                      "type": "string"
+                    },
+                    "subnets": {
+                      "description": "Subnets sets the subnets that should be applied to the control plane load balancer (defaults to discovered subnets for managed VPCs or an empty set for unmanaged VPCs)",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     }
                   },
-                  "required": [
-                    "controlPlaneIAMInstanceProfile",
-                    "name",
-                    "nodesIAMInstanceProfiles"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },

--- a/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSFargateProfile is the Schema for the awsfargateprofiles API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "clusterName": {
@@ -32,7 +32,7 @@
           "type": "string"
         },
         "roleName": {
-          "description": "RoleName specifies the name of IAM role for this fargate pool If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "description": "RoleName specifies the name of IAM role for this fargate pool\nIf the role is pre-existing we will treat it as unmanaged\nand not delete it on deletion. If the EKSEnableIAM feature\nflag is true and no name is supplied then a role is created.",
           "type": "string"
         },
         "selectors": {
@@ -58,7 +58,7 @@
           "type": "array"
         },
         "subnetIDs": {
-          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup.",
+          "description": "SubnetIDs specifies which subnets are used for the\nauto scaling group of this nodegroup.",
           "items": {
             "type": "string"
           },
@@ -80,20 +80,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -101,7 +101,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -116,11 +116,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the FargateProfile and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the FargateProfile's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of\nFargateProfiles can be added as events to the FargateProfile\nobject and/or logged in the controller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the FargateProfile and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the FargateProfile's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of\nFargateProfiles can be added as events to the FargateProfile object\nand/or logged in the controller's output.",
           "type": "string"
         },
         "ready": {

--- a/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSFargateProfile is the Schema for the awsfargateprofiles API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "clusterName": {
@@ -32,7 +32,7 @@
           "type": "string"
         },
         "roleName": {
-          "description": "RoleName specifies the name of IAM role for this fargate pool If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "description": "RoleName specifies the name of IAM role for this fargate pool\nIf the role is pre-existing we will treat it as unmanaged\nand not delete it on deletion. If the EKSEnableIAM feature\nflag is true and no name is supplied then a role is created.",
           "type": "string"
         },
         "selectors": {
@@ -58,7 +58,7 @@
           "type": "array"
         },
         "subnetIDs": {
-          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup.",
+          "description": "SubnetIDs specifies which subnets are used for the\nauto scaling group of this nodegroup.",
           "items": {
             "type": "string"
           },
@@ -80,20 +80,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -101,7 +101,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -116,11 +116,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the FargateProfile and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the FargateProfile's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of\nFargateProfiles can be added as events to the FargateProfile\nobject and/or logged in the controller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the FargateProfile and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the FargateProfile's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of FargateProfiles can be added as events to the FargateProfile object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the FargateProfile and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the FargateProfile's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of\nFargateProfiles can be added as events to the FargateProfile object\nand/or logged in the controller's output.",
           "type": "string"
         },
         "ready": {

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSMachine is the schema for Amazon EC2 machines.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,16 +16,16 @@
       "description": "AWSMachineSpec defines the desired state of an Amazon EC2 instance.",
       "properties": {
         "additionalSecurityGroups": {
-          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstance. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters\nwill cause additional requests to AWS API and if tags change the attached security groups might change too.",
           "items": {
-            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
             "properties": {
               "arn": {
-                "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+                "description": "ARN of resource.\nDeprecated: This field has no function and is going to be removed in the next release.",
                 "type": "string"
               },
               "filters": {
-                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                 "items": {
                   "description": "Filter is a filter used to identify an AWS resource.",
                   "properties": {
@@ -64,7 +64,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the\nAWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the\nAWSMachine's value takes precedence.",
           "type": "object"
         },
         "ami": {
@@ -87,10 +87,10 @@
           "additionalProperties": false
         },
         "cloudInit": {
-          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "description": "CloudInit defines options related to the bootstrapping systems where\nCloudInit is used.",
           "properties": {
             "insecureSkipSecretsManager": {
-              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager\nor AWS Systems Manager Parameter Store to ensure privacy of userdata.\nBy default, a cloud-init boothook shell script is prepended to download\nthe userdata from Secrets Manager and additionally delete the secret.",
               "type": "boolean"
             },
             "secretCount": {
@@ -99,11 +99,11 @@
               "type": "integer"
             },
             "secretPrefix": {
-              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "description": "SecretPrefix is the prefix for the secret name. This is stored\ntemporarily, and deleted when the machine registers as a node against\nthe workload cluster.",
               "type": "string"
             },
             "secureSecretsBackend": {
-              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager\nParameter Storage to distribute secrets. By default or with the value of secrets-manager,\nwill use AWS Secrets Manager instead.",
               "enum": [
                 "secrets-manager",
                 "ssm-parameter-store"
@@ -115,7 +115,7 @@
           "additionalProperties": false
         },
         "failureDomain": {
-          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+          "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.\nFor this infrastructure provider, the ID is equivalent to an AWS Availability Zone.\nIf multiple subnets are matched for the availability zone, the first one returned is picked.",
           "type": "string"
         },
         "iamInstanceProfile": {
@@ -138,11 +138,11 @@
           "additionalProperties": false
         },
         "imageLookupBaseOS": {
-          "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+          "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
           "type": "string"
         },
         "imageLookupFormat": {
-          "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
           "type": "string"
         },
         "imageLookupOrg": {
@@ -159,7 +159,7 @@
           "type": "string"
         },
         "networkInterfaces": {
-          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance.\nA maximum of 2 may be specified.",
           "items": {
             "type": "string"
           },
@@ -180,7 +180,7 @@
                 "type": "boolean"
               },
               "encryptionKey": {
-                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                 "type": "string"
               },
               "iops": {
@@ -189,7 +189,7 @@
                 "type": "integer"
               },
               "size": {
-                "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                 "format": "int64",
                 "minimum": 8,
                 "type": "integer"
@@ -217,7 +217,7 @@
           "type": "string"
         },
         "publicIP": {
-          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "description": "PublicIP specifies whether the instance should get a public IP.\nPrecedence for this setting is as follows:\n1. This field if set\n2. Cluster/flavor setting\n3. Subnet default",
           "type": "boolean"
         },
         "rootVolume": {
@@ -232,7 +232,7 @@
               "type": "boolean"
             },
             "encryptionKey": {
-              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
               "type": "string"
             },
             "iops": {
@@ -241,7 +241,7 @@
               "type": "integer"
             },
             "size": {
-              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
               "format": "int64",
               "minimum": 8,
               "type": "integer"
@@ -278,14 +278,14 @@
           "type": "string"
         },
         "subnet": {
-          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified,\nthe cluster subnet will be used.",
           "properties": {
             "arn": {
-              "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+              "description": "ARN of resource.\nDeprecated: This field has no function and is going to be removed in the next release.",
               "type": "string"
             },
             "filters": {
-              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
               "items": {
                 "description": "Filter is a filter used to identify an AWS resource.",
                 "properties": {
@@ -328,7 +328,7 @@
           "type": "string"
         },
         "uncompressedUserData": {
-          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance.\ncloud-init has built-in support for gzip-compressed user data\nuser data stored in aws secret manager is always gzip-compressed.",
           "type": "boolean"
         }
       },
@@ -351,7 +351,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
                 "type": "string"
               }
             },
@@ -370,20 +370,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -391,7 +391,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -406,11 +406,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "instanceState": {
@@ -418,7 +418,7 @@
           "type": "string"
         },
         "interruptible": {
-          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
+          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS.\nThis will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
           "type": "boolean"
         },
         "ready": {

--- a/infrastructure.cluster.x-k8s.io/awsmachine_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachine_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSMachine is the schema for Amazon EC2 machines.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -16,12 +16,12 @@
       "description": "AWSMachineSpec defines the desired state of an Amazon EC2 instance.",
       "properties": {
         "additionalSecurityGroups": {
-          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+          "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstance. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters\nwill cause additional requests to AWS API and if tags change the attached security groups might change too.",
           "items": {
-            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
             "properties": {
               "filters": {
-                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                 "items": {
                   "description": "Filter is a filter used to identify an AWS resource.",
                   "properties": {
@@ -60,7 +60,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the\nAWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the\nAWSMachine's value takes precedence.",
           "type": "object"
         },
         "ami": {
@@ -82,11 +82,15 @@
           "type": "object",
           "additionalProperties": false
         },
+        "capacityReservationId": {
+          "description": "CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.",
+          "type": "string"
+        },
         "cloudInit": {
-          "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+          "description": "CloudInit defines options related to the bootstrapping systems where\nCloudInit is used.",
           "properties": {
             "insecureSkipSecretsManager": {
-              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager\nor AWS Systems Manager Parameter Store to ensure privacy of userdata.\nBy default, a cloud-init boothook shell script is prepended to download\nthe userdata from Secrets Manager and additionally delete the secret.",
               "type": "boolean"
             },
             "secretCount": {
@@ -95,16 +99,42 @@
               "type": "integer"
             },
             "secretPrefix": {
-              "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+              "description": "SecretPrefix is the prefix for the secret name. This is stored\ntemporarily, and deleted when the machine registers as a node against\nthe workload cluster.",
               "type": "string"
             },
             "secureSecretsBackend": {
-              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+              "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager\nParameter Storage to distribute secrets. By default or with the value of secrets-manager,\nwill use AWS Secrets Manager instead.",
               "enum": [
                 "secrets-manager",
                 "ssm-parameter-store"
               ],
               "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "elasticIpPool": {
+          "description": "ElasticIPPool is the configuration to allocate Public IPv4 address (Elastic IP/EIP) from user-defined pool.",
+          "properties": {
+            "publicIpv4Pool": {
+              "description": "PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources\ncreated in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom\nPublic IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool\nresource ID starts with 'ipv4pool-ec2'.",
+              "maxLength": 30,
+              "type": "string"
+            },
+            "publicIpv4PoolFallbackOrder": {
+              "description": "PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,\nno more IPv4 address available in the pool.\n\n\nWhen set to 'amazon-pool', the controller check if the pool has available IPv4 address, when pool has reached the\nIPv4 limit, the address will be claimed from Amazon-pool (default).\n\n\nWhen set to 'none', the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.",
+              "enum": [
+                "amazon-pool",
+                "none"
+              ],
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "allowed values are 'none' and 'amazon-pool'",
+                  "rule": "self in ['none','amazon-pool']"
+                }
+              ]
             }
           },
           "type": "object",
@@ -117,11 +147,67 @@
         "ignition": {
           "description": "Ignition defined options related to the bootstrapping systems where Ignition is used.",
           "properties": {
+            "proxy": {
+              "description": "Proxy defines proxy settings for Ignition.\nOnly valid for Ignition versions 3.1 and above.",
+              "properties": {
+                "httpProxy": {
+                  "description": "HTTPProxy is the HTTP proxy to use for Ignition.\nA single URL that specifies the proxy server to use for HTTP and HTTPS requests,\nunless overridden by the HTTPSProxy or NoProxy options.",
+                  "type": "string"
+                },
+                "httpsProxy": {
+                  "description": "HTTPSProxy is the HTTPS proxy to use for Ignition.\nA single URL that specifies the proxy server to use for HTTPS requests,\nunless overridden by the NoProxy option.",
+                  "type": "string"
+                },
+                "noProxy": {
+                  "description": "NoProxy is the list of domains to not proxy for Ignition.\nSpecifies a list of strings to hosts that should be excluded from proxying.\n\n\nEach value is represented by:\n- An IP address prefix (1.2.3.4)\n- An IP address prefix in CIDR notation (1.2.3.4/8)\n- A domain name\n  - A domain name matches that name and all subdomains\n  - A domain name with a leading . matches subdomains only\n- A special DNS label (*), indicates that no proxying should be done\n\n\nAn IP address prefix and domain name can also include a literal port number (1.2.3.4:80).",
+                  "items": {
+                    "description": "IgnitionNoProxy defines the list of domains to not proxy for Ignition.",
+                    "maxLength": 2048,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "storageType": {
+              "default": "ClusterObjectStore",
+              "description": "StorageType defines how to store the boostrap user data for Ignition.\nThis can be used to instruct Ignition from where to fetch the user data to bootstrap an instance.\n\n\nWhen omitted, the storage option will default to ClusterObjectStore.\n\n\nWhen set to \"ClusterObjectStore\", if the capability is available and a Cluster ObjectStore configuration\nis correctly provided in the Cluster object (under .spec.s3Bucket),\nan object store will be used to store bootstrap user data.\n\n\nWhen set to \"UnencryptedUserData\", EC2 Instance User Data will be used to store the machine bootstrap user data, unencrypted.\nThis option is considered less secure than others as user data may contain sensitive informations (keys, certificates, etc.)\nand users with ec2:DescribeInstances permission or users running pods\nthat can access the ec2 metadata service have access to this sensitive information.\nSo this is only to be used at ones own risk, and only when other more secure options are not viable.",
+              "enum": [
+                "ClusterObjectStore",
+                "UnencryptedUserData"
+              ],
+              "type": "string"
+            },
+            "tls": {
+              "description": "TLS defines TLS settings for Ignition.\nOnly valid for Ignition versions 3.1 and above.",
+              "properties": {
+                "certificateAuthorities": {
+                  "description": "CASources defines the list of certificate authorities to use for Ignition.\nThe value is the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates.\nSupported schemes are http, https, tftp, s3, arn, gs, and `data` (RFC 2397) URL scheme.",
+                  "items": {
+                    "description": "IgnitionCASource defines the source of the certificate authority to use for Ignition.",
+                    "maxLength": 65536,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "version": {
               "default": "2.3",
               "description": "Version defines which version of Ignition will be used to generate bootstrap data.",
               "enum": [
-                "2.3"
+                "2.3",
+                "3.0",
+                "3.1",
+                "3.2",
+                "3.3",
+                "3.4"
               ],
               "type": "string"
             }
@@ -130,11 +216,11 @@
           "additionalProperties": false
         },
         "imageLookupBaseOS": {
-          "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+          "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
           "type": "string"
         },
         "imageLookupFormat": {
-          "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+          "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
           "type": "string"
         },
         "imageLookupOrg": {
@@ -150,7 +236,7 @@
           "properties": {
             "httpEndpoint": {
               "default": "enabled",
-              "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+              "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
               "enum": [
                 "enabled",
                 "disabled"
@@ -159,15 +245,15 @@
             },
             "httpPutResponseHopLimit": {
               "default": 1,
-              "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+              "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
               "format": "int64",
               "maximum": 64,
               "minimum": 1,
               "type": "integer"
             },
             "httpTokens": {
-              "default": "required",
-              "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+              "default": "optional",
+              "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
               "enum": [
                 "optional",
                 "required"
@@ -176,7 +262,7 @@
             },
             "instanceMetadataTags": {
               "default": "disabled",
-              "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+              "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
               "enum": [
                 "enabled",
                 "disabled"
@@ -193,7 +279,7 @@
           "type": "string"
         },
         "networkInterfaces": {
-          "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+          "description": "NetworkInterfaces is a list of ENIs to associate with the instance.\nA maximum of 2 may be specified.",
           "items": {
             "type": "string"
           },
@@ -214,7 +300,7 @@
                 "type": "boolean"
               },
               "encryptionKey": {
-                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                 "type": "string"
               },
               "iops": {
@@ -223,7 +309,7 @@
                 "type": "integer"
               },
               "size": {
-                "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                 "format": "int64",
                 "minimum": 8,
                 "type": "integer"
@@ -246,12 +332,46 @@
           },
           "type": "array"
         },
+        "placementGroupName": {
+          "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance.",
+          "type": "string"
+        },
+        "placementGroupPartition": {
+          "description": "PlacementGroupPartition is the partition number within the placement group in which to launch the instance.\nThis value is only valid if the placement group, referred in `PlacementGroupName`, was created with\nstrategy set to partition.",
+          "format": "int64",
+          "maximum": 7,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "privateDnsName": {
+          "description": "PrivateDNSName is the options for the instance hostname.",
+          "properties": {
+            "enableResourceNameDnsAAAARecord": {
+              "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+              "type": "boolean"
+            },
+            "enableResourceNameDnsARecord": {
+              "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+              "type": "boolean"
+            },
+            "hostnameType": {
+              "description": "The type of hostname to assign to an instance.",
+              "enum": [
+                "ip-name",
+                "resource-name"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "providerID": {
           "description": "ProviderID is the unique identifier as specified by the cloud provider.",
           "type": "string"
         },
         "publicIP": {
-          "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+          "description": "PublicIP specifies whether the instance should get a public IP.\nPrecedence for this setting is as follows:\n1. This field if set\n2. Cluster/flavor setting\n3. Subnet default",
           "type": "boolean"
         },
         "rootVolume": {
@@ -266,7 +386,7 @@
               "type": "boolean"
             },
             "encryptionKey": {
-              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+              "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
               "type": "string"
             },
             "iops": {
@@ -275,7 +395,7 @@
               "type": "integer"
             },
             "size": {
-              "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+              "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
               "format": "int64",
               "minimum": 8,
               "type": "integer"
@@ -296,6 +416,13 @@
           "type": "object",
           "additionalProperties": false
         },
+        "securityGroupOverrides": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "SecurityGroupOverrides is an optional set of security groups to use for the node.\nThis is optional - if not provided security groups from the cluster will be used.",
+          "type": "object"
+        },
         "spotMarketOptions": {
           "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
           "properties": {
@@ -312,10 +439,10 @@
           "type": "string"
         },
         "subnet": {
-          "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+          "description": "Subnet is a reference to the subnet to use for this instance. If not specified,\nthe cluster subnet will be used.",
           "properties": {
             "filters": {
-              "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+              "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
               "items": {
                 "description": "Filter is a filter used to identify an AWS resource.",
                 "properties": {
@@ -358,7 +485,7 @@
           "type": "string"
         },
         "uncompressedUserData": {
-          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+          "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance.\ncloud-init has built-in support for gzip-compressed user data\nuser data stored in aws secret manager is always gzip-compressed.",
           "type": "boolean"
         }
       },
@@ -381,7 +508,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+                "description": "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
                 "type": "string"
               }
             },
@@ -400,20 +527,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -421,7 +548,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -436,11 +563,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "instanceState": {
@@ -448,7 +575,7 @@
           "type": "string"
         },
         "interruptible": {
-          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS. This will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
+          "description": "Interruptible reports that this machine is using spot instances and can therefore be interrupted by CAPI when it receives a notice that the spot instance is to be terminated by AWS.\nThis will be set to true when SpotMarketOptions is not nil (i.e. this machine is using a spot instance).",
           "type": "boolean"
         },
         "ready": {

--- a/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSMachinePool is the Schema for the awsmachinepools API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.",
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the\nAWS provider.",
           "type": "object"
         },
         "availabilityZones": {
@@ -33,12 +33,12 @@
           "description": "AWSLaunchTemplate specifies the launch template and version to use when an instance is launched.",
           "properties": {
             "additionalSecurityGroups": {
-              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstances. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator.",
               "items": {
-                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
                 "properties": {
                   "filters": {
-                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                     "items": {
                       "description": "Filter is a filter used to identify an AWS resource.",
                       "properties": {
@@ -93,15 +93,15 @@
               "additionalProperties": false
             },
             "iamInstanceProfile": {
-              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated\nwith the IAM role for the instance. The instance profile contains the IAM\nrole.",
               "type": "string"
             },
             "imageLookupBaseOS": {
-              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
               "type": "string"
             },
             "imageLookupFormat": {
-              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
               "type": "string"
             },
             "imageLookupOrg": {
@@ -128,7 +128,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -137,7 +137,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -170,11 +170,11 @@
               "additionalProperties": false
             },
             "sshKeyName": {
-              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string\n(do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
               "type": "string"
             },
             "versionNumber": {
-              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "description": "VersionNumber is the version of the launch template that is applied.\nTypically a new version is created when at least one of the following happens:\n1) A new launch template spec is applied.\n2) One or more parameters in an existing template is changed.\n3) A new AMI is discovered.",
               "format": "int64",
               "type": "integer"
             }
@@ -187,7 +187,7 @@
           "type": "boolean"
         },
         "defaultCoolDown": {
-          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set",
+          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.\nIf no value is supplied by user a default value of 300 seconds is set",
           "type": "string"
         },
         "maxSize": {
@@ -243,7 +243,7 @@
             },
             "overrides": {
               "items": {
-                "description": "Overrides are used to override the instance type specified by the launch template with multiple instance types that can be used to launch On-Demand Instances and Spot Instances.",
+                "description": "Overrides are used to override the instance type specified by the launch template with multiple\ninstance types that can be used to launch On-Demand Instances and Spot Instances.",
                 "properties": {
                   "instanceType": {
                     "type": "string"
@@ -266,7 +266,7 @@
           "type": "string"
         },
         "providerIDList": {
-          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider.\nThis field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
           "items": {
             "type": "string"
           },
@@ -276,17 +276,17 @@
           "description": "RefreshPreferences describes set of preferences associated with the instance refresh request.",
           "properties": {
             "instanceWarmup": {
-              "description": "The number of seconds until a newly launched instance is configured and ready to use. During this time, the next replacement will not be initiated. The default is to use the value for the health check grace period defined for the group.",
+              "description": "The number of seconds until a newly launched instance is configured and ready\nto use. During this time, the next replacement will not be initiated.\nThe default is to use the value for the health check grace period defined for the group.",
               "format": "int64",
               "type": "integer"
             },
             "minHealthyPercentage": {
-              "description": "The amount of capacity as a percentage in ASG that must remain healthy during an instance refresh. The default is 90.",
+              "description": "The amount of capacity as a percentage in ASG that must remain healthy\nduring an instance refresh. The default is 90.",
               "format": "int64",
               "type": "integer"
             },
             "strategy": {
-              "description": "The strategy to use for the instance refresh. The only valid value is Rolling. A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.",
+              "description": "The strategy to use for the instance refresh. The only valid value is Rolling.\nA rolling update is an update that is applied to all instances in an Auto\nScaling group until all instances have been updated.",
               "type": "string"
             }
           },
@@ -296,10 +296,10 @@
         "subnets": {
           "description": "Subnets is an array of subnet configurations",
           "items": {
-            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
             "properties": {
               "filters": {
-                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                 "items": {
                   "description": "Filter is a filter used to identify an AWS resource.",
                   "properties": {
@@ -356,20 +356,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -377,7 +377,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -392,11 +392,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "instances": {

--- a/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSMachinePool is the Schema for the awsmachinepools API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,8 +19,17 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.",
+          "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the\nAWS provider.",
           "type": "object"
+        },
+        "availabilityZoneSubnetType": {
+          "description": "AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.",
+          "enum": [
+            "public",
+            "private",
+            "all"
+          ],
+          "type": "string"
         },
         "availabilityZones": {
           "description": "AvailabilityZones is an array of availability zones instances can run in",
@@ -33,12 +42,12 @@
           "description": "AWSLaunchTemplate specifies the launch template and version to use when an instance is launched.",
           "properties": {
             "additionalSecurityGroups": {
-              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstances. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator.",
               "items": {
-                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
                 "properties": {
                   "filters": {
-                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                     "items": {
                       "description": "Filter is a filter used to identify an AWS resource.",
                       "properties": {
@@ -93,20 +102,62 @@
               "additionalProperties": false
             },
             "iamInstanceProfile": {
-              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated\nwith the IAM role for the instance. The instance profile contains the IAM\nrole.",
               "type": "string"
             },
             "imageLookupBaseOS": {
-              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
               "type": "string"
             },
             "imageLookupFormat": {
-              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
               "type": "string"
             },
             "imageLookupOrg": {
               "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
               "type": "string"
+            },
+            "instanceMetadataOptions": {
+              "description": "InstanceMetadataOptions defines the behavior for applying metadata to instances.",
+              "properties": {
+                "httpEndpoint": {
+                  "default": "enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                "httpPutResponseHopLimit": {
+                  "default": 1,
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
+                  "format": "int64",
+                  "maximum": 64,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "httpTokens": {
+                  "default": "optional",
+                  "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
+                  "enum": [
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                },
+                "instanceMetadataTags": {
+                  "default": "disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "instanceType": {
               "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
@@ -115,6 +166,29 @@
             "name": {
               "description": "The name of the launch template.",
               "type": "string"
+            },
+            "privateDnsName": {
+              "description": "PrivateDNSName is the options for the instance hostname.",
+              "properties": {
+                "enableResourceNameDnsAAAARecord": {
+                  "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+                  "type": "boolean"
+                },
+                "enableResourceNameDnsARecord": {
+                  "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+                  "type": "boolean"
+                },
+                "hostnameType": {
+                  "description": "The type of hostname to assign to an instance.",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "rootVolume": {
               "description": "RootVolume encapsulates the configuration options for the root volume",
@@ -128,7 +202,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -137,7 +211,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -170,11 +244,11 @@
               "additionalProperties": false
             },
             "sshKeyName": {
-              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string\n(do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
               "type": "string"
             },
             "versionNumber": {
-              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "description": "VersionNumber is the version of the launch template that is applied.\nTypically a new version is created when at least one of the following happens:\n1) A new launch template spec is applied.\n2) One or more parameters in an existing template is changed.\n3) A new AMI is discovered.",
               "format": "int64",
               "type": "integer"
             }
@@ -187,7 +261,11 @@
           "type": "boolean"
         },
         "defaultCoolDown": {
-          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set",
+          "description": "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.\nIf no value is supplied by user a default value of 300 seconds is set",
+          "type": "string"
+        },
+        "defaultInstanceWarmup": {
+          "description": "The amount of time, in seconds, until a new instance is considered to\nhave finished initializing and resource consumption to become stable\nafter it enters the InService state.\nIf no value is supplied by user a default value of 300 seconds is set",
           "type": "string"
         },
         "maxSize": {
@@ -214,7 +292,8 @@
                   "default": "prioritized",
                   "description": "OnDemandAllocationStrategy indicates how to allocate instance types to fulfill On-Demand capacity.",
                   "enum": [
-                    "prioritized"
+                    "prioritized",
+                    "lowest-price"
                   ],
                   "type": "string"
                 },
@@ -233,7 +312,9 @@
                   "description": "SpotAllocationStrategy indicates how to allocate instances across Spot Instance pools.",
                   "enum": [
                     "lowest-price",
-                    "capacity-optimized"
+                    "capacity-optimized",
+                    "capacity-optimized-prioritized",
+                    "price-capacity-optimized"
                   ],
                   "type": "string"
                 }
@@ -243,7 +324,7 @@
             },
             "overrides": {
               "items": {
-                "description": "Overrides are used to override the instance type specified by the launch template with multiple instance types that can be used to launch On-Demand Instances and Spot Instances.",
+                "description": "Overrides are used to override the instance type specified by the launch template with multiple\ninstance types that can be used to launch On-Demand Instances and Spot Instances.",
                 "properties": {
                   "instanceType": {
                     "type": "string"
@@ -266,7 +347,7 @@
           "type": "string"
         },
         "providerIDList": {
-          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
+          "description": "ProviderIDList are the identification IDs of machine instances provided by the provider.\nThis field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.",
           "items": {
             "type": "string"
           },
@@ -276,21 +357,21 @@
           "description": "RefreshPreferences describes set of preferences associated with the instance refresh request.",
           "properties": {
             "disable": {
-              "description": "Disable, if true, disables instance refresh from triggering when new launch templates are detected. This is useful in scenarios where ASG nodes are externally managed.",
+              "description": "Disable, if true, disables instance refresh from triggering when new launch templates are detected.\nThis is useful in scenarios where ASG nodes are externally managed.",
               "type": "boolean"
             },
             "instanceWarmup": {
-              "description": "The number of seconds until a newly launched instance is configured and ready to use. During this time, the next replacement will not be initiated. The default is to use the value for the health check grace period defined for the group.",
+              "description": "The number of seconds until a newly launched instance is configured and ready\nto use. During this time, the next replacement will not be initiated.\nThe default is to use the value for the health check grace period defined for the group.",
               "format": "int64",
               "type": "integer"
             },
             "minHealthyPercentage": {
-              "description": "The amount of capacity as a percentage in ASG that must remain healthy during an instance refresh. The default is 90.",
+              "description": "The amount of capacity as a percentage in ASG that must remain healthy\nduring an instance refresh. The default is 90.",
               "format": "int64",
               "type": "integer"
             },
             "strategy": {
-              "description": "The strategy to use for the instance refresh. The only valid value is Rolling. A rolling update is an update that is applied to all instances in an Auto Scaling group until all instances have been updated.",
+              "description": "The strategy to use for the instance refresh. The only valid value is Rolling.\nA rolling update is an update that is applied to all instances in an Auto\nScaling group until all instances have been updated.",
               "type": "string"
             }
           },
@@ -300,10 +381,10 @@
         "subnets": {
           "description": "Subnets is an array of subnet configurations",
           "items": {
-            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+            "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
             "properties": {
               "filters": {
-                "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                 "items": {
                   "description": "Filter is a filter used to identify an AWS resource.",
                   "properties": {
@@ -339,7 +420,7 @@
           "type": "array"
         },
         "suspendProcesses": {
-          "description": "SuspendProcesses defines a list of processes to suspend for the given ASG. This is constantly reconciled. If a process is removed from this list it will automatically be resumed.",
+          "description": "SuspendProcesses defines a list of processes to suspend for the given ASG. This is constantly reconciled.\nIf a process is removed from this list it will automatically be resumed.",
           "properties": {
             "all": {
               "type": "boolean"
@@ -404,20 +485,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -425,7 +506,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -440,11 +521,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the Machine and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of Machines\ncan be added as events to the Machine object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "instances": {

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSMachineTemplate is the schema for the Amazon EC2 Machine Templates API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,20 +19,20 @@
           "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template.",
           "properties": {
             "metadata": {
-              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
                   "type": "object"
                 }
               },
@@ -43,16 +43,16 @@
               "description": "Spec is the specification of the desired behavior of the machine.",
               "properties": {
                 "additionalSecurityGroups": {
-                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstance. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters\nwill cause additional requests to AWS API and if tags change the attached security groups might change too.",
                   "items": {
-                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
                     "properties": {
                       "arn": {
-                        "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+                        "description": "ARN of resource.\nDeprecated: This field has no function and is going to be removed in the next release.",
                         "type": "string"
                       },
                       "filters": {
-                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                         "items": {
                           "description": "Filter is a filter used to identify an AWS resource.",
                           "properties": {
@@ -91,7 +91,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the\nAWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the\nAWSMachine's value takes precedence.",
                   "type": "object"
                 },
                 "ami": {
@@ -114,10 +114,10 @@
                   "additionalProperties": false
                 },
                 "cloudInit": {
-                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "description": "CloudInit defines options related to the bootstrapping systems where\nCloudInit is used.",
                   "properties": {
                     "insecureSkipSecretsManager": {
-                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager\nor AWS Systems Manager Parameter Store to ensure privacy of userdata.\nBy default, a cloud-init boothook shell script is prepended to download\nthe userdata from Secrets Manager and additionally delete the secret.",
                       "type": "boolean"
                     },
                     "secretCount": {
@@ -126,11 +126,11 @@
                       "type": "integer"
                     },
                     "secretPrefix": {
-                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored\ntemporarily, and deleted when the machine registers as a node against\nthe workload cluster.",
                       "type": "string"
                     },
                     "secureSecretsBackend": {
-                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager\nParameter Storage to distribute secrets. By default or with the value of secrets-manager,\nwill use AWS Secrets Manager instead.",
                       "enum": [
                         "secrets-manager",
                         "ssm-parameter-store"
@@ -142,7 +142,7 @@
                   "additionalProperties": false
                 },
                 "failureDomain": {
-                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API. For this infrastructure provider, the ID is equivalent to an AWS Availability Zone. If multiple subnets are matched for the availability zone, the first one returned is picked.",
+                  "description": "FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.\nFor this infrastructure provider, the ID is equivalent to an AWS Availability Zone.\nIf multiple subnets are matched for the availability zone, the first one returned is picked.",
                   "type": "string"
                 },
                 "iamInstanceProfile": {
@@ -165,11 +165,11 @@
                   "additionalProperties": false
                 },
                 "imageLookupBaseOS": {
-                  "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+                  "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
                   "type": "string"
                 },
                 "imageLookupFormat": {
-                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
                   "type": "string"
                 },
                 "imageLookupOrg": {
@@ -186,7 +186,7 @@
                   "type": "string"
                 },
                 "networkInterfaces": {
-                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance.\nA maximum of 2 may be specified.",
                   "items": {
                     "type": "string"
                   },
@@ -207,7 +207,7 @@
                         "type": "boolean"
                       },
                       "encryptionKey": {
-                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                         "type": "string"
                       },
                       "iops": {
@@ -216,7 +216,7 @@
                         "type": "integer"
                       },
                       "size": {
-                        "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                        "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                         "format": "int64",
                         "minimum": 8,
                         "type": "integer"
@@ -244,7 +244,7 @@
                   "type": "string"
                 },
                 "publicIP": {
-                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "description": "PublicIP specifies whether the instance should get a public IP.\nPrecedence for this setting is as follows:\n1. This field if set\n2. Cluster/flavor setting\n3. Subnet default",
                   "type": "boolean"
                 },
                 "rootVolume": {
@@ -259,7 +259,7 @@
                       "type": "boolean"
                     },
                     "encryptionKey": {
-                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                       "type": "string"
                     },
                     "iops": {
@@ -268,7 +268,7 @@
                       "type": "integer"
                     },
                     "size": {
-                      "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                      "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                       "format": "int64",
                       "minimum": 8,
                       "type": "integer"
@@ -305,14 +305,14 @@
                   "type": "string"
                 },
                 "subnet": {
-                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified,\nthe cluster subnet will be used.",
                   "properties": {
                     "arn": {
-                      "description": "ARN of resource. Deprecated: This field has no function and is going to be removed in the next release.",
+                      "description": "ARN of resource.\nDeprecated: This field has no function and is going to be removed in the next release.",
                       "type": "string"
                     },
                     "filters": {
-                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                       "items": {
                         "description": "Filter is a filter used to identify an AWS resource.",
                         "properties": {
@@ -355,7 +355,7 @@
                   "type": "string"
                 },
                 "uncompressedUserData": {
-                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance.\ncloud-init has built-in support for gzip-compressed user data\nuser data stored in aws secret manager is always gzip-compressed.",
                   "type": "boolean"
                 }
               },
@@ -395,7 +395,7 @@
             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
             "x-kubernetes-int-or-string": true
           },
-          "description": "Capacity defines the resource capacity for this machine. This value is used for autoscaling from zero operations as defined in: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
+          "description": "Capacity defines the resource capacity for this machine.\nThis value is used for autoscaling from zero operations as defined in:\nhttps://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
           "type": "object"
         }
       },

--- a/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSMachineTemplate is the schema for the Amazon EC2 Machine Templates API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,20 +19,20 @@
           "description": "AWSMachineTemplateResource describes the data needed to create am AWSMachine from a template.",
           "properties": {
             "metadata": {
-              "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
                   "type": "object"
                 }
               },
@@ -43,12 +43,12 @@
               "description": "Spec is the specification of the desired behavior of the machine.",
               "properties": {
                 "additionalSecurityGroups": {
-                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instance. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters will cause additional requests to AWS API and if tags change the attached security groups might change too.",
+                  "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstance. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator. It is possible to specify either IDs of Filters. Using Filters\nwill cause additional requests to AWS API and if tags change the attached security groups might change too.",
                   "items": {
-                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                    "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
                     "properties": {
                       "filters": {
-                        "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                        "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                         "items": {
                           "description": "Filter is a filter used to identify an AWS resource.",
                           "properties": {
@@ -87,7 +87,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the AWSMachine's value takes precedence.",
+                  "description": "AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the\nAWS provider. If both the AWSCluster and the AWSMachine specify the same tag name with different values, the\nAWSMachine's value takes precedence.",
                   "type": "object"
                 },
                 "ami": {
@@ -109,11 +109,15 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "capacityReservationId": {
+                  "description": "CapacityReservationID specifies the target Capacity Reservation into which the instance should be launched.",
+                  "type": "string"
+                },
                 "cloudInit": {
-                  "description": "CloudInit defines options related to the bootstrapping systems where CloudInit is used.",
+                  "description": "CloudInit defines options related to the bootstrapping systems where\nCloudInit is used.",
                   "properties": {
                     "insecureSkipSecretsManager": {
-                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret.",
+                      "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager\nor AWS Systems Manager Parameter Store to ensure privacy of userdata.\nBy default, a cloud-init boothook shell script is prepended to download\nthe userdata from Secrets Manager and additionally delete the secret.",
                       "type": "boolean"
                     },
                     "secretCount": {
@@ -122,16 +126,42 @@
                       "type": "integer"
                     },
                     "secretPrefix": {
-                      "description": "SecretPrefix is the prefix for the secret name. This is stored temporarily, and deleted when the machine registers as a node against the workload cluster.",
+                      "description": "SecretPrefix is the prefix for the secret name. This is stored\ntemporarily, and deleted when the machine registers as a node against\nthe workload cluster.",
                       "type": "string"
                     },
                     "secureSecretsBackend": {
-                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager Parameter Storage to distribute secrets. By default or with the value of secrets-manager, will use AWS Secrets Manager instead.",
+                      "description": "SecureSecretsBackend, when set to parameter-store will utilize the AWS Systems Manager\nParameter Storage to distribute secrets. By default or with the value of secrets-manager,\nwill use AWS Secrets Manager instead.",
                       "enum": [
                         "secrets-manager",
                         "ssm-parameter-store"
                       ],
                       "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "elasticIpPool": {
+                  "description": "ElasticIPPool is the configuration to allocate Public IPv4 address (Elastic IP/EIP) from user-defined pool.",
+                  "properties": {
+                    "publicIpv4Pool": {
+                      "description": "PublicIpv4Pool sets a custom Public IPv4 Pool used to create Elastic IP address for resources\ncreated in public IPv4 subnets. Every IPv4 address, Elastic IP, will be allocated from the custom\nPublic IPv4 pool that you brought to AWS, instead of Amazon-provided pool. The public IPv4 pool\nresource ID starts with 'ipv4pool-ec2'.",
+                      "maxLength": 30,
+                      "type": "string"
+                    },
+                    "publicIpv4PoolFallbackOrder": {
+                      "description": "PublicIpv4PoolFallBackOrder defines the fallback action when the Public IPv4 Pool has been exhausted,\nno more IPv4 address available in the pool.\n\n\nWhen set to 'amazon-pool', the controller check if the pool has available IPv4 address, when pool has reached the\nIPv4 limit, the address will be claimed from Amazon-pool (default).\n\n\nWhen set to 'none', the controller will fail the Elastic IP allocation when the publicIpv4Pool is exhausted.",
+                      "enum": [
+                        "amazon-pool",
+                        "none"
+                      ],
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "allowed values are 'none' and 'amazon-pool'",
+                          "rule": "self in ['none','amazon-pool']"
+                        }
+                      ]
                     }
                   },
                   "type": "object",
@@ -144,11 +174,67 @@
                 "ignition": {
                   "description": "Ignition defined options related to the bootstrapping systems where Ignition is used.",
                   "properties": {
+                    "proxy": {
+                      "description": "Proxy defines proxy settings for Ignition.\nOnly valid for Ignition versions 3.1 and above.",
+                      "properties": {
+                        "httpProxy": {
+                          "description": "HTTPProxy is the HTTP proxy to use for Ignition.\nA single URL that specifies the proxy server to use for HTTP and HTTPS requests,\nunless overridden by the HTTPSProxy or NoProxy options.",
+                          "type": "string"
+                        },
+                        "httpsProxy": {
+                          "description": "HTTPSProxy is the HTTPS proxy to use for Ignition.\nA single URL that specifies the proxy server to use for HTTPS requests,\nunless overridden by the NoProxy option.",
+                          "type": "string"
+                        },
+                        "noProxy": {
+                          "description": "NoProxy is the list of domains to not proxy for Ignition.\nSpecifies a list of strings to hosts that should be excluded from proxying.\n\n\nEach value is represented by:\n- An IP address prefix (1.2.3.4)\n- An IP address prefix in CIDR notation (1.2.3.4/8)\n- A domain name\n  - A domain name matches that name and all subdomains\n  - A domain name with a leading . matches subdomains only\n- A special DNS label (*), indicates that no proxying should be done\n\n\nAn IP address prefix and domain name can also include a literal port number (1.2.3.4:80).",
+                          "items": {
+                            "description": "IgnitionNoProxy defines the list of domains to not proxy for Ignition.",
+                            "maxLength": 2048,
+                            "type": "string"
+                          },
+                          "maxItems": 64,
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "storageType": {
+                      "default": "ClusterObjectStore",
+                      "description": "StorageType defines how to store the boostrap user data for Ignition.\nThis can be used to instruct Ignition from where to fetch the user data to bootstrap an instance.\n\n\nWhen omitted, the storage option will default to ClusterObjectStore.\n\n\nWhen set to \"ClusterObjectStore\", if the capability is available and a Cluster ObjectStore configuration\nis correctly provided in the Cluster object (under .spec.s3Bucket),\nan object store will be used to store bootstrap user data.\n\n\nWhen set to \"UnencryptedUserData\", EC2 Instance User Data will be used to store the machine bootstrap user data, unencrypted.\nThis option is considered less secure than others as user data may contain sensitive informations (keys, certificates, etc.)\nand users with ec2:DescribeInstances permission or users running pods\nthat can access the ec2 metadata service have access to this sensitive information.\nSo this is only to be used at ones own risk, and only when other more secure options are not viable.",
+                      "enum": [
+                        "ClusterObjectStore",
+                        "UnencryptedUserData"
+                      ],
+                      "type": "string"
+                    },
+                    "tls": {
+                      "description": "TLS defines TLS settings for Ignition.\nOnly valid for Ignition versions 3.1 and above.",
+                      "properties": {
+                        "certificateAuthorities": {
+                          "description": "CASources defines the list of certificate authorities to use for Ignition.\nThe value is the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates.\nSupported schemes are http, https, tftp, s3, arn, gs, and `data` (RFC 2397) URL scheme.",
+                          "items": {
+                            "description": "IgnitionCASource defines the source of the certificate authority to use for Ignition.",
+                            "maxLength": 65536,
+                            "type": "string"
+                          },
+                          "maxItems": 64,
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "version": {
                       "default": "2.3",
                       "description": "Version defines which version of Ignition will be used to generate bootstrap data.",
                       "enum": [
-                        "2.3"
+                        "2.3",
+                        "3.0",
+                        "3.1",
+                        "3.2",
+                        "3.3",
+                        "3.4"
                       ],
                       "type": "string"
                     }
@@ -157,11 +243,11 @@
                   "additionalProperties": false
                 },
                 "imageLookupBaseOS": {
-                  "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+                  "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
                   "type": "string"
                 },
                 "imageLookupFormat": {
-                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+                  "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
                   "type": "string"
                 },
                 "imageLookupOrg": {
@@ -177,7 +263,7 @@
                   "properties": {
                     "httpEndpoint": {
                       "default": "enabled",
-                      "description": "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled",
+                      "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
                       "enum": [
                         "enabled",
                         "disabled"
@@ -186,15 +272,15 @@
                     },
                     "httpPutResponseHopLimit": {
                       "default": 1,
-                      "description": "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1",
+                      "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
                       "format": "int64",
                       "maximum": 64,
                       "minimum": 1,
                       "type": "integer"
                     },
                     "httpTokens": {
-                      "default": "required",
-                      "description": "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: required",
+                      "default": "optional",
+                      "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
                       "enum": [
                         "optional",
                         "required"
@@ -203,7 +289,7 @@
                     },
                     "instanceMetadataTags": {
                       "default": "disabled",
-                      "description": "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled",
+                      "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
                       "enum": [
                         "enabled",
                         "disabled"
@@ -220,7 +306,7 @@
                   "type": "string"
                 },
                 "networkInterfaces": {
-                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance. A maximum of 2 may be specified.",
+                  "description": "NetworkInterfaces is a list of ENIs to associate with the instance.\nA maximum of 2 may be specified.",
                   "items": {
                     "type": "string"
                   },
@@ -241,7 +327,7 @@
                         "type": "boolean"
                       },
                       "encryptionKey": {
-                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                        "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                         "type": "string"
                       },
                       "iops": {
@@ -250,7 +336,7 @@
                         "type": "integer"
                       },
                       "size": {
-                        "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                        "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                         "format": "int64",
                         "minimum": 8,
                         "type": "integer"
@@ -273,12 +359,46 @@
                   },
                   "type": "array"
                 },
+                "placementGroupName": {
+                  "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance.",
+                  "type": "string"
+                },
+                "placementGroupPartition": {
+                  "description": "PlacementGroupPartition is the partition number within the placement group in which to launch the instance.\nThis value is only valid if the placement group, referred in `PlacementGroupName`, was created with\nstrategy set to partition.",
+                  "format": "int64",
+                  "maximum": 7,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "privateDnsName": {
+                  "description": "PrivateDNSName is the options for the instance hostname.",
+                  "properties": {
+                    "enableResourceNameDnsAAAARecord": {
+                      "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+                      "type": "boolean"
+                    },
+                    "enableResourceNameDnsARecord": {
+                      "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+                      "type": "boolean"
+                    },
+                    "hostnameType": {
+                      "description": "The type of hostname to assign to an instance.",
+                      "enum": [
+                        "ip-name",
+                        "resource-name"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "providerID": {
                   "description": "ProviderID is the unique identifier as specified by the cloud provider.",
                   "type": "string"
                 },
                 "publicIP": {
-                  "description": "PublicIP specifies whether the instance should get a public IP. Precedence for this setting is as follows: 1. This field if set 2. Cluster/flavor setting 3. Subnet default",
+                  "description": "PublicIP specifies whether the instance should get a public IP.\nPrecedence for this setting is as follows:\n1. This field if set\n2. Cluster/flavor setting\n3. Subnet default",
                   "type": "boolean"
                 },
                 "rootVolume": {
@@ -293,7 +413,7 @@
                       "type": "boolean"
                     },
                     "encryptionKey": {
-                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                      "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                       "type": "string"
                     },
                     "iops": {
@@ -302,7 +422,7 @@
                       "type": "integer"
                     },
                     "size": {
-                      "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                      "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                       "format": "int64",
                       "minimum": 8,
                       "type": "integer"
@@ -323,6 +443,13 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "securityGroupOverrides": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "SecurityGroupOverrides is an optional set of security groups to use for the node.\nThis is optional - if not provided security groups from the cluster will be used.",
+                  "type": "object"
+                },
                 "spotMarketOptions": {
                   "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
                   "properties": {
@@ -339,10 +466,10 @@
                   "type": "string"
                 },
                 "subnet": {
-                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified, the cluster subnet will be used.",
+                  "description": "Subnet is a reference to the subnet to use for this instance. If not specified,\nthe cluster subnet will be used.",
                   "properties": {
                     "filters": {
-                      "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                      "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                       "items": {
                         "description": "Filter is a filter used to identify an AWS resource.",
                         "properties": {
@@ -385,7 +512,7 @@
                   "type": "string"
                 },
                 "uncompressedUserData": {
-                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance. cloud-init has built-in support for gzip-compressed user data user data stored in aws secret manager is always gzip-compressed.",
+                  "description": "UncompressedUserData specify whether the user data is gzip-compressed before it is sent to ec2 instance.\ncloud-init has built-in support for gzip-compressed user data\nuser data stored in aws secret manager is always gzip-compressed.",
                   "type": "boolean"
                 }
               },
@@ -425,7 +552,7 @@
             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
             "x-kubernetes-int-or-string": true
           },
-          "description": "Capacity defines the resource capacity for this machine. This value is used for autoscaling from zero operations as defined in: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
+          "description": "Capacity defines the resource capacity for this machine.\nThis value is used for autoscaling from zero operations as defined in:\nhttps://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210310-opt-in-autoscaling-from-zero.md",
           "type": "object"
         }
       },

--- a/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta1.json
@@ -2,11 +2,11 @@
   "description": "AWSManagedMachinePool is the Schema for the awsmanagedmachinepools API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "amiType": {
@@ -29,12 +29,14 @@
             "AL2_x86_64",
             "AL2_x86_64_GPU",
             "AL2_ARM_64",
+            "AL2023_x86_64_STANDARD",
+            "AL2023_ARM_64_STANDARD",
             "CUSTOM"
           ],
           "type": "string"
         },
         "amiVersion": {
-          "description": "AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used",
+          "description": "AMIVersion defines the desired AMI release version. If no version number\nis supplied then the latest version for the Kubernetes version\nwill be used",
           "minLength": 2,
           "type": "string"
         },
@@ -46,15 +48,15 @@
           "type": "array"
         },
         "awsLaunchTemplate": {
-          "description": "AWSLaunchTemplate specifies the launch template to use to create the managed node group. If AWSLaunchTemplate is specified, certain node group configuraions outside of launch template are prohibited (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).",
+          "description": "AWSLaunchTemplate specifies the launch template to use to create the managed node group.\nIf AWSLaunchTemplate is specified, certain node group configuraions outside of launch template\nare prohibited (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).",
           "properties": {
             "additionalSecurityGroups": {
-              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstances. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator.",
               "items": {
-                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
                 "properties": {
                   "filters": {
-                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                     "items": {
                       "description": "Filter is a filter used to identify an AWS resource.",
                       "properties": {
@@ -109,15 +111,15 @@
               "additionalProperties": false
             },
             "iamInstanceProfile": {
-              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated\nwith the IAM role for the instance. The instance profile contains the IAM\nrole.",
               "type": "string"
             },
             "imageLookupBaseOS": {
-              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
               "type": "string"
             },
             "imageLookupFormat": {
-              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
               "type": "string"
             },
             "imageLookupOrg": {
@@ -144,7 +146,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -153,7 +155,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -186,11 +188,11 @@
               "additionalProperties": false
             },
             "sshKeyName": {
-              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string\n(do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
               "type": "string"
             },
             "versionNumber": {
-              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "description": "VersionNumber is the version of the launch template that is applied.\nTypically a new version is created when at least one of the following happens:\n1) A new launch template spec is applied.\n2) One or more parameters in an existing template is changed.\n3) A new AMI is discovered.",
               "format": "int64",
               "type": "integer"
             }
@@ -213,7 +215,7 @@
           "type": "integer"
         },
         "eksNodegroupName": {
-          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool.",
+          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS\ncorresponding to this MachinePool. If you don't specify a name\nthen a default name will be created based on the namespace and\nname of the managed machine pool.",
           "type": "string"
         },
         "instanceType": {
@@ -228,7 +230,7 @@
           "type": "object"
         },
         "providerIDList": {
-          "description": "ProviderIDList are the provider IDs of instances in the autoscaling group corresponding to the nodegroup represented by this machine pool",
+          "description": "ProviderIDList are the provider IDs of instances in the\nautoscaling group corresponding to the nodegroup represented by this\nmachine pool",
           "items": {
             "type": "string"
           },
@@ -249,7 +251,7 @@
               "type": "array"
             },
             "sshKeyName": {
-              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.",
+              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines.\nIf left empty, the key from the control plane is used.",
               "type": "string"
             }
           },
@@ -257,14 +259,14 @@
           "additionalProperties": false
         },
         "roleAdditionalPolicies": {
-          "description": "RoleAdditionalPolicies allows you to attach additional polices to the node group role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to\nthe node group role. You must enable the EKSAllowAddRoles\nfeature flag to incorporate these into the created role.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "roleName": {
-          "description": "RoleName specifies the name of IAM role for the node group. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "description": "RoleName specifies the name of IAM role for the node group.\nIf the role is pre-existing we will treat it as unmanaged\nand not delete it on deletion. If the EKSEnableIAM feature\nflag is true and no name is supplied then a role is created.",
           "type": "string"
         },
         "scaling": {
@@ -283,7 +285,7 @@
           "additionalProperties": false
         },
         "subnetIDs": {
-          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup",
+          "description": "SubnetIDs specifies which subnets are used for the\nauto scaling group of this nodegroup",
           "items": {
             "type": "string"
           },
@@ -323,16 +325,16 @@
           "type": "array"
         },
         "updateConfig": {
-          "description": "UpdateConfig holds the optional config to control the behaviour of the update to the nodegroup.",
+          "description": "UpdateConfig holds the optional config to control the behaviour of the update\nto the nodegroup.",
           "properties": {
             "maxUnavailable": {
-              "description": "MaxUnavailable is the maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. The maximum number is 100.",
+              "description": "MaxUnavailable is the maximum number of nodes unavailable at once during a version update.\nNodes will be updated in parallel. The maximum number is 100.",
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
             },
             "maxUnavailablePrecentage": {
-              "description": "MaxUnavailablePercentage is the maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once.",
+              "description": "MaxUnavailablePercentage is the maximum percentage of nodes unavailable during a version update. This\npercentage of nodes will be updated in parallel, up to 100 nodes at once.",
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -354,20 +356,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -375,7 +377,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -390,11 +392,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the MachinePool and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the MachinePool's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of MachinePools\ncan be added as events to the MachinePool object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the MachinePool and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of MachinePools\ncan be added as events to the MachinePool object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "launchTemplateID": {
@@ -407,7 +409,7 @@
         },
         "ready": {
           "default": false,
-          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined the cluster",
+          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined\nthe cluster",
           "type": "boolean"
         },
         "replicas": {

--- a/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta2.json
@@ -2,11 +2,11 @@
   "description": "AWSManagedMachinePool is the Schema for the awsmanagedmachinepools API.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,7 +19,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the ones added by default.",
+          "description": "AdditionalTags is an optional set of tags to add to AWS resources managed by the AWS provider, in addition to the\nones added by default.",
           "type": "object"
         },
         "amiType": {
@@ -29,13 +29,24 @@
             "AL2_x86_64",
             "AL2_x86_64_GPU",
             "AL2_ARM_64",
+            "AL2023_x86_64_STANDARD",
+            "AL2023_ARM_64_STANDARD",
             "CUSTOM"
           ],
           "type": "string"
         },
         "amiVersion": {
-          "description": "AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used",
+          "description": "AMIVersion defines the desired AMI release version. If no version number\nis supplied then the latest version for the Kubernetes version\nwill be used",
           "minLength": 2,
+          "type": "string"
+        },
+        "availabilityZoneSubnetType": {
+          "description": "AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.",
+          "enum": [
+            "public",
+            "private",
+            "all"
+          ],
           "type": "string"
         },
         "availabilityZones": {
@@ -46,15 +57,15 @@
           "type": "array"
         },
         "awsLaunchTemplate": {
-          "description": "AWSLaunchTemplate specifies the launch template to use to create the managed node group. If AWSLaunchTemplate is specified, certain node group configuraions outside of launch template are prohibited (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).",
+          "description": "AWSLaunchTemplate specifies the launch template to use to create the managed node group.\nIf AWSLaunchTemplate is specified, certain node group configuraions outside of launch template\nare prohibited (https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).",
           "properties": {
             "additionalSecurityGroups": {
-              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the instances. These security groups would be set in addition to any security groups defined at the cluster level or in the actuator.",
+              "description": "AdditionalSecurityGroups is an array of references to security groups that should be applied to the\ninstances. These security groups would be set in addition to any security groups defined\nat the cluster level or in the actuator.",
               "items": {
-                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters. Only one of ID or Filters may be specified. Specifying more than one will result in a validation error.",
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID or filters.\nOnly one of ID or Filters may be specified. Specifying more than one will result in\na validation error.",
                 "properties": {
                   "filters": {
-                    "description": "Filters is a set of key/value pairs used to identify a resource They are applied according to the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
+                    "description": "Filters is a set of key/value pairs used to identify a resource\nThey are applied according to the rules defined by the AWS API:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html",
                     "items": {
                       "description": "Filter is a filter used to identify an AWS resource.",
                       "properties": {
@@ -109,20 +120,62 @@
               "additionalProperties": false
             },
             "iamInstanceProfile": {
-              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance. The instance profile contains the IAM role.",
+              "description": "The name or the Amazon Resource Name (ARN) of the instance profile associated\nwith the IAM role for the instance. The instance profile contains the IAM\nrole.",
               "type": "string"
             },
             "imageLookupBaseOS": {
-              "description": "ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.",
+              "description": "ImageLookupBaseOS is the name of the base operating system to use for\nimage lookup the AMI is not set.",
               "type": "string"
             },
             "imageLookupFormat": {
-              "description": "ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/",
+              "description": "ImageLookupFormat is the AMI naming format to look up the image for this\nmachine It will be ignored if an explicit AMI is set. Supports\nsubstitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and\nkubernetes version, respectively. The BaseOS will be the value in\nImageLookupBaseOS or ubuntu (the default), and the kubernetes version as\ndefined by the packages produced by kubernetes/release without v as a\nprefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default\nimage format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up\nsearching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a\nMachine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See\nalso: https://golang.org/pkg/text/template/",
               "type": "string"
             },
             "imageLookupOrg": {
               "description": "ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.",
               "type": "string"
+            },
+            "instanceMetadataOptions": {
+              "description": "InstanceMetadataOptions defines the behavior for applying metadata to instances.",
+              "properties": {
+                "httpEndpoint": {
+                  "default": "enabled",
+                  "description": "Enables or disables the HTTP metadata endpoint on your instances.\n\n\nIf you specify a value of disabled, you cannot access your instance metadata.\n\n\nDefault: enabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                "httpPutResponseHopLimit": {
+                  "default": 1,
+                  "description": "The desired HTTP PUT response hop limit for instance metadata requests. The\nlarger the number, the further instance metadata requests can travel.\n\n\nDefault: 1",
+                  "format": "int64",
+                  "maximum": 64,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "httpTokens": {
+                  "default": "optional",
+                  "description": "The state of token usage for your instance metadata requests.\n\n\nIf the state is optional, you can choose to retrieve instance metadata with\nor without a session token on your request. If you retrieve the IAM role\ncredentials without a token, the version 1.0 role credentials are returned.\nIf you retrieve the IAM role credentials using a valid session token, the\nversion 2.0 role credentials are returned.\n\n\nIf the state is required, you must send a session token with any instance\nmetadata retrieval requests. In this state, retrieving the IAM role credentials\nalways returns the version 2.0 credentials; the version 1.0 credentials are\nnot available.\n\n\nDefault: optional",
+                  "enum": [
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                },
+                "instanceMetadataTags": {
+                  "default": "disabled",
+                  "description": "Set to enabled to allow access to instance tags from the instance metadata.\nSet to disabled to turn off access to instance tags from the instance metadata.\nFor more information, see Work with instance tags using the instance metadata\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).\n\n\nDefault: disabled",
+                  "enum": [
+                    "enabled",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "instanceType": {
               "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
@@ -131,6 +184,29 @@
             "name": {
               "description": "The name of the launch template.",
               "type": "string"
+            },
+            "privateDnsName": {
+              "description": "PrivateDNSName is the options for the instance hostname.",
+              "properties": {
+                "enableResourceNameDnsAAAARecord": {
+                  "description": "EnableResourceNameDNSAAAARecord indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.",
+                  "type": "boolean"
+                },
+                "enableResourceNameDnsARecord": {
+                  "description": "EnableResourceNameDNSARecord indicates whether to respond to DNS queries for instance hostnames with DNS A records.",
+                  "type": "boolean"
+                },
+                "hostnameType": {
+                  "description": "The type of hostname to assign to an instance.",
+                  "enum": [
+                    "ip-name",
+                    "resource-name"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "rootVolume": {
               "description": "RootVolume encapsulates the configuration options for the root volume",
@@ -144,7 +220,7 @@
                   "type": "boolean"
                 },
                 "encryptionKey": {
-                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN. If Encrypted is set and this is omitted, the default AWS key will be used. The key must already exist and be accessible by the controller.",
+                  "description": "EncryptionKey is the KMS key to use to encrypt the volume. Can be either a KMS key ID or ARN.\nIf Encrypted is set and this is omitted, the default AWS key will be used.\nThe key must already exist and be accessible by the controller.",
                   "type": "string"
                 },
                 "iops": {
@@ -153,7 +229,7 @@
                   "type": "integer"
                 },
                 "size": {
-                  "description": "Size specifies size (in Gi) of the storage device. Must be greater than the image snapshot size or 8 (whichever is greater).",
+                  "description": "Size specifies size (in Gi) of the storage device.\nMust be greater than the image snapshot size or 8 (whichever is greater).",
                   "format": "int64",
                   "minimum": 8,
                   "type": "integer"
@@ -186,11 +262,11 @@
               "additionalProperties": false
             },
             "sshKeyName": {
-              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+              "description": "SSHKeyName is the name of the ssh key to attach to the instance. Valid values are empty string\n(do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
               "type": "string"
             },
             "versionNumber": {
-              "description": "VersionNumber is the version of the launch template that is applied. Typically a new version is created when at least one of the following happens: 1) A new launch template spec is applied. 2) One or more parameters in an existing template is changed. 3) A new AMI is discovered.",
+              "description": "VersionNumber is the version of the launch template that is applied.\nTypically a new version is created when at least one of the following happens:\n1) A new launch template spec is applied.\n2) One or more parameters in an existing template is changed.\n3) A new AMI is discovered.",
               "format": "int64",
               "type": "integer"
             }
@@ -213,7 +289,7 @@
           "type": "integer"
         },
         "eksNodegroupName": {
-          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool.",
+          "description": "EKSNodegroupName specifies the name of the nodegroup in AWS\ncorresponding to this MachinePool. If you don't specify a name\nthen a default name will be created based on the namespace and\nname of the managed machine pool.",
           "type": "string"
         },
         "instanceType": {
@@ -228,7 +304,7 @@
           "type": "object"
         },
         "providerIDList": {
-          "description": "ProviderIDList are the provider IDs of instances in the autoscaling group corresponding to the nodegroup represented by this machine pool",
+          "description": "ProviderIDList are the provider IDs of instances in the\nautoscaling group corresponding to the nodegroup represented by this\nmachine pool",
           "items": {
             "type": "string"
           },
@@ -249,7 +325,7 @@
               "type": "array"
             },
             "sshKeyName": {
-              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines. If left empty, the key from the control plane is used.",
+              "description": "SSHKeyName specifies which EC2 SSH key can be used to access machines.\nIf left empty, the key from the control plane is used.",
               "type": "string"
             }
           },
@@ -257,14 +333,14 @@
           "additionalProperties": false
         },
         "roleAdditionalPolicies": {
-          "description": "RoleAdditionalPolicies allows you to attach additional polices to the node group role. You must enable the EKSAllowAddRoles feature flag to incorporate these into the created role.",
+          "description": "RoleAdditionalPolicies allows you to attach additional polices to\nthe node group role. You must enable the EKSAllowAddRoles\nfeature flag to incorporate these into the created role.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "roleName": {
-          "description": "RoleName specifies the name of IAM role for the node group. If the role is pre-existing we will treat it as unmanaged and not delete it on deletion. If the EKSEnableIAM feature flag is true and no name is supplied then a role is created.",
+          "description": "RoleName specifies the name of IAM role for the node group.\nIf the role is pre-existing we will treat it as unmanaged\nand not delete it on deletion. If the EKSEnableIAM feature\nflag is true and no name is supplied then a role is created.",
           "type": "string"
         },
         "scaling": {
@@ -283,7 +359,7 @@
           "additionalProperties": false
         },
         "subnetIDs": {
-          "description": "SubnetIDs specifies which subnets are used for the auto scaling group of this nodegroup",
+          "description": "SubnetIDs specifies which subnets are used for the\nauto scaling group of this nodegroup",
           "items": {
             "type": "string"
           },
@@ -323,16 +399,16 @@
           "type": "array"
         },
         "updateConfig": {
-          "description": "UpdateConfig holds the optional config to control the behaviour of the update to the nodegroup.",
+          "description": "UpdateConfig holds the optional config to control the behaviour of the update\nto the nodegroup.",
           "properties": {
             "maxUnavailable": {
-              "description": "MaxUnavailable is the maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. The maximum number is 100.",
+              "description": "MaxUnavailable is the maximum number of nodes unavailable at once during a version update.\nNodes will be updated in parallel. The maximum number is 100.",
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
             },
             "maxUnavailablePercentage": {
-              "description": "MaxUnavailablePercentage is the maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once.",
+              "description": "MaxUnavailablePercentage is the maximum percentage of nodes unavailable during a version update. This\npercentage of nodes will be updated in parallel, up to 100 nodes at once.",
               "maximum": 100,
               "minimum": 1,
               "type": "integer"
@@ -354,20 +430,20 @@
             "description": "Condition defines an observation of a Cluster API resource operational state.",
             "properties": {
               "lastTransitionTime": {
-                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
                 "type": "string"
               },
               "reason": {
-                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
                 "type": "string"
               },
               "severity": {
-                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
                 "type": "string"
               },
               "status": {
@@ -375,7 +451,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
                 "type": "string"
               }
             },
@@ -390,11 +466,11 @@
           "type": "array"
         },
         "failureMessage": {
-          "description": "FailureMessage will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachinePool's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the MachinePool and will contain a more verbose string suitable\nfor logging and human consumption.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the MachinePool's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of MachinePools\ncan be added as events to the MachinePool object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "failureReason": {
-          "description": "FailureReason will be set in the event that there is a terminal problem reconciling the MachinePool and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of MachinePools can be added as events to the MachinePool object and/or logged in the controller's output.",
+          "description": "FailureReason will be set in the event that there is a terminal problem\nreconciling the MachinePool and will contain a succinct value suitable\nfor machine interpretation.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the Machine's spec or the configuration of\nthe controller, and that manual intervention is required. Examples\nof terminal errors would be invalid combinations of settings in the\nspec, values that are unsupported by the controller, or the\nresponsible controller itself being critically misconfigured.\n\n\nAny transient errors that occur during the reconciliation of MachinePools\ncan be added as events to the MachinePool object and/or logged in the\ncontroller's output.",
           "type": "string"
         },
         "launchTemplateID": {
@@ -407,7 +483,7 @@
         },
         "ready": {
           "default": false,
-          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined the cluster",
+          "description": "Ready denotes that the AWSManagedMachinePool nodegroup has joined\nthe cluster",
           "type": "boolean"
         },
         "replicas": {

--- a/infrastructure.cluster.x-k8s.io/rosacluster_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/rosacluster_v1beta2.json
@@ -1,5 +1,5 @@
 {
-  "description": "AWSManagedCluster is the Schema for the awsmanagedclusters API",
+  "description": "ROSACluster is the Schema for the ROSAClusters API.",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,7 +13,7 @@
       "type": "object"
     },
     "spec": {
-      "description": "AWSManagedClusterSpec defines the desired state of AWSManagedCluster",
+      "description": "ROSAClusterSpec defines the desired state of ROSACluster.",
       "properties": {
         "controlPlaneEndpoint": {
           "description": "ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.",
@@ -40,7 +40,7 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "AWSManagedClusterStatus defines the observed state of AWSManagedCluster",
+      "description": "ROSAClusterStatus defines the observed state of ROSACluster.",
       "properties": {
         "failureDomains": {
           "additionalProperties": {
@@ -65,7 +65,7 @@
           "type": "object"
         },
         "ready": {
-          "description": "Ready is when the AWSManagedControlPlane has a API server URL.",
+          "description": "Ready is when the ROSAControlPlane has a API server URL.",
           "type": "boolean"
         }
       },

--- a/infrastructure.cluster.x-k8s.io/rosamachinepool_v1beta2.json
+++ b/infrastructure.cluster.x-k8s.io/rosamachinepool_v1beta2.json
@@ -1,0 +1,264 @@
+{
+  "description": "ROSAMachinePool is the Schema for the rosamachinepools API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "RosaMachinePoolSpec defines the desired state of RosaMachinePool.",
+      "properties": {
+        "additionalSecurityGroups": {
+          "description": "AdditionalSecurityGroups is an optional set of security groups to associate\nwith all node instances of the machine pool.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "additionalTags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "AdditionalTags are user-defined tags to be added on the underlying EC2 instances associated with this machine pool.",
+          "type": "object"
+        },
+        "autoRepair": {
+          "default": true,
+          "description": "AutoRepair specifies whether health checks should be enabled for machines\nin the NodePool. The default is true.",
+          "type": "boolean"
+        },
+        "autoscaling": {
+          "description": "Autoscaling specifies auto scaling behaviour for this MachinePool.\nrequired if Replicas is not configured",
+          "properties": {
+            "maxReplicas": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "minReplicas": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "availabilityZone": {
+          "description": "AvailabilityZone is an optinal field specifying the availability zone where instances of this machine pool should run\nFor Multi-AZ clusters, you can create a machine pool in a Single-AZ of your choice.",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "InstanceType specifies the AWS instance type",
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels specifies labels for the Kubernetes node objects",
+          "type": "object"
+        },
+        "nodeDrainGracePeriod": {
+          "description": "NodeDrainGracePeriod is grace period for how long Pod Disruption Budget-protected workloads will be\nrespected during upgrades. After this grace period, any workloads protected by Pod Disruption\nBudgets that have not been successfully drained from a node will be forcibly evicted.\n\n\nValid values are from 0 to 1 week(10080m|168h) .\n0 or empty value means that the MachinePool can be drained without any time limitation.",
+          "type": "string"
+        },
+        "nodePoolName": {
+          "description": "NodePoolName specifies the name of the nodepool in Rosa\nmust be a valid DNS-1035 label, so it must consist of lower case alphanumeric and have a max length of 15 characters.",
+          "maxLength": 15,
+          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "nodepoolName is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "providerIDList": {
+          "description": "ProviderIDList contain a ProviderID for each machine instance that's currently managed by this machine pool.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "subnet": {
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "subnet is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "taints": {
+          "description": "Taints specifies the taints to apply to the nodes of the machine pool",
+          "items": {
+            "description": "RosaTaint represents a taint to be applied to a node.",
+            "properties": {
+              "effect": {
+                "description": "The effect of the taint on pods that do not tolerate the taint.\nValid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                "enum": [
+                  "NoSchedule",
+                  "PreferNoSchedule",
+                  "NoExecute"
+                ],
+                "type": "string"
+              },
+              "key": {
+                "description": "The taint key to be applied to a node.",
+                "type": "string"
+              },
+              "value": {
+                "description": "The taint value corresponding to the taint key.",
+                "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "effect",
+              "key"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "tuningConfigs": {
+          "description": "TuningConfigs specifies the names of the tuning configs to be applied to this MachinePool.\nTuning configs must already exist.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "updateConfig": {
+          "description": "UpdateConfig specifies update configurations.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "RollingUpdate specifies MaxUnavailable & MaxSurge number of nodes during update.",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": 1,
+                  "description": "MaxSurge is the maximum number of nodes that can be provisioned above the desired number of nodes.\nValue can be an absolute number (ex: 5) or a percentage of desired nodes (ex: 10%).\nAbsolute number is calculated from percentage by rounding up.\n\n\nMaxSurge can not be 0 if MaxUnavailable is 0, default is 1.\nBoth MaxSurge & MaxUnavailable must use the same units (absolute value or percentage).\n\n\nExample: when MaxSurge is set to 30%, new nodes can be provisioned immediately\nwhen the rolling update starts, such that the total number of old and new\nnodes do not exceed 130% of desired nodes. Once old nodes have been\ndeleted, new nodes can be provisioned, ensuring that total number of nodes\nrunning at any time during the update is at most 130% of desired nodes.",
+                  "pattern": "^((100|[0-9]{1,2})%|[0-9]+)$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": 0,
+                  "description": "MaxUnavailable is the maximum number of nodes that can be unavailable during the update.\nValue can be an absolute number (ex: 5) or a percentage of desired nodes (ex: 10%).\nAbsolute number is calculated from percentage by rounding down.\n\n\nMaxUnavailable can not be 0 if MaxSurge is 0, default is 0.\nBoth MaxUnavailable & MaxSurge must use the same units (absolute value or percentage).\n\n\nExample: when MaxUnavailable is set to 30%, old nodes can be deleted down to 70% of\ndesired nodes immediately when the rolling update starts. Once new nodes\nare ready, more old nodes be deleted, followed by provisioning new nodes,\nensuring that the total number of nodes available at all times during the\nupdate is at least 70% of desired nodes.",
+                  "pattern": "^((100|[0-9]{1,2})%|[0-9]+)$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "version": {
+          "description": "Version specifies the OpenShift version of the nodes associated with this machinepool.\nROSAControlPlane version is used if not set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceType",
+        "nodePoolName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "RosaMachinePoolStatus defines the observed state of RosaMachinePool.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current service state of the managed machine pool",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.\nThis field may be empty.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may not be empty.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureMessage": {
+          "description": "FailureMessage will be set in the event that there is a terminal problem\nreconciling the state and will be set to a descriptive error message.\n\n\nThis field should not be set for transitive errors that a controller\nfaces that are expected to be fixed automatically over\ntime (like service outages), but instead indicate that something is\nfundamentally wrong with the spec or the configuration of\nthe controller, and that manual intervention is required.",
+          "type": "string"
+        },
+        "id": {
+          "description": "ID is the ID given by ROSA.",
+          "type": "string"
+        },
+        "ready": {
+          "default": false,
+          "description": "Ready denotes that the RosaMachinePool nodepool has joined\nthe cluster",
+          "type": "boolean"
+        },
+        "replicas": {
+          "description": "Replicas is the most recently observed number of replicas.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ready"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Generated with
```
git clone https://github.com/kubernetes-sigs/cluster-api-provider-aws.git --depth 1 --branch v2.6.1 && \
 export FILENAME_FORMAT="{fullgroup}__{kind}_{version}" && \
 kubectl kustomize cluster-api-provider-aws/config/crd/ > crd.yaml && \
 curl -s https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py | \
 python3 ~/Repos/kubeconform/scripts/openapi2jsonschema.py crd.yaml | \
 awk '{ print $(NF) }' | \
 xargs -I {} sh -c 'f=$0; mkdir -p $(dirname $(echo $f | sed "s|__|/|")) && \
 mv $f $(echo $f | sed "s|__|/|")' '{}' && \
 rm crd.yaml && \
 rm -rf cluster-api-provider-aws
```
previous one: https://github.com/datreeio/CRDs-catalog/pull/136