### PR TITLE
upgrade: app.redislabs.com to version 7.4.6-2.0

### DIFF
--- a/app.redislabs.com/redisenterpriseactiveactivedatabase_v1alpha1.json
+++ b/app.redislabs.com/redisenterpriseactiveactivedatabase_v1alpha1.json
@@ -1,0 +1,836 @@
+{
+  "description": "RedisEnterpriseActiveActiveDatabase is the Schema for the redisenterpriseactiveactivedatabase API",
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "status": {
+      "description": "RedisEnterpriseActiveActiveDatabaseStatus defines the observed state of RedisEnterpriseActiveActiveDatabase",
+      "properties": {
+        "status": {
+          "description": "The status of the active active database.",
+          "type": "string"
+        },
+        "specStatus": {
+          "description": "Whether the desired specification is valid",
+          "type": "string"
+        },
+        "linkedRedbs": {
+          "description": "The linked REDBs.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "participatingClusters": {
+          "description": "The list of instances/ clusters statuses.",
+          "items": {
+            "description": "Status of participating cluster.",
+            "properties": {
+              "name": {
+                "description": "The name of the remote cluster CR that is linked.",
+                "type": "string"
+              },
+              "id": {
+                "description": "The corresponding ID of the instance in the active-active database.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "replicationStatus": {
+                "description": "The replication status of the participating cluster",
+                "enum": [
+                  "up",
+                  "down"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "guid": {
+          "description": "The active-active database corresponding GUID.",
+          "type": "string"
+        },
+        "lastTaskUid": {
+          "description": "The last active-active database task UID.",
+          "type": "string"
+        },
+        "redisEnterpriseCluster": {
+          "description": "The Redis Enterprise Cluster Object this Resource is associated with",
+          "type": "string"
+        },
+        "replicationStatus": {
+          "description": "The overall replication status",
+          "enum": [
+            "up",
+            "down"
+          ],
+          "type": "string"
+        },
+        "secretsStatus": {
+          "description": "The status of the secrets",
+          "items": {
+            "description": "Status of secrets.",
+            "properties": {
+              "name": {
+                "description": "The name of the secret.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of the secret.",
+                "enum": [
+                  "Valid",
+                  "Invalid"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "spec": {
+      "description": "RedisEnterpriseActiveActiveDatabaseSpec defines the desired state of RedisEnterpriseActiveActiveDatabase",
+      "properties": {
+        "redisEnterpriseCluster": {
+          "description": "Connection to Redis Enterprise Cluster",
+          "properties": {
+            "name": {
+              "description": "The name of the Redis Enterprise Cluster where the database should be stored.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "participatingClusters": {
+          "description": "The list of instances/ clusters specifications and configurations.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "The name of the remote cluster CR to link.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "globalConfigurations": {
+          "description": "The Active-Active database global configurations, contains the global properties for each of the participating clusters/ instances databases within the Active-Active database.",
+          "properties": {
+            "activeActive": {
+              "description": "Connection/ association to the Active-Active database.",
+              "properties": {
+                "name": {
+                  "description": "The the corresponding Active-Active database name, Redis Enterprise Active Active Database custom resource name, this Resource is associated with. In case this resource is created manually at the active active database creation this field must be filled via the user, otherwise, the operator will assign this field automatically. Note: this feature is currently unsupported.",
+                  "type": "string"
+                },
+                "participatingClusterName": {
+                  "description": "The corresponding participating cluster name, Redis Enterprise Remote Cluster custom resource name, in the Active-Active database, In case this resource is created manually at the active active database creation this field must be filled via the user, otherwise, the operator will assign this field automatically. Note: this feature is currently unsupported.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "participatingClusterName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "alertSettings": {
+              "description": "Settings for database alerts",
+              "properties": {
+                "bdb_backup_delayed": {
+                  "description": "Periodic backup has been delayed for longer than specified threshold value [minutes]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_crdt_src_high_syncer_lag": {
+                  "description": "Active-active source - sync lag is higher than specified threshold value [seconds]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_crdt_src_syncer_connection_error": {
+                  "description": "Active-active source - sync has connection error while trying to connect replica source",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_crdt_src_syncer_general_error": {
+                  "description": "Active-active source - sync encountered in general error",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_high_latency": {
+                  "description": "Latency is higher than specified threshold value [micro-sec]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_high_throughput": {
+                  "description": "Throughput is higher than specified threshold value [requests / sec.]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_long_running_action": {
+                  "description": "An alert for state-machines that are running for too long",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_low_throughput": {
+                  "description": "Throughput is lower than specified threshold value [requests / sec.]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_ram_dataset_overhead": {
+                  "description": "Dataset RAM overhead of a shard has reached the threshold value [% of its RAM limit]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_ram_values": {
+                  "description": "Percent of values kept in a shard's RAM is lower than [% of its key count]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_replica_src_high_syncer_lag": {
+                  "description": "Replica-of source - sync lag is higher than specified threshold value [seconds]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_replica_src_syncer_connection_error": {
+                  "description": "Replica-of source - sync has connection error while trying to connect replica source",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_shard_num_ram_values": {
+                  "description": "Number of values kept in a shard's RAM is lower than [values]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "bdb_size": {
+                  "description": "Dataset size has reached the threshold value [% of the memory limit]",
+                  "properties": {
+                    "enabled": {
+                      "description": "Alert enabled or disabled",
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "description": "Threshold for alert going on/off",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "threshold"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "backup": {
+              "description": "Target for automatic database backups.",
+              "properties": {
+                "abs": {
+                  "properties": {
+                    "absSecretName": {
+                      "description": "The name of the secret that holds ABS credentials. The secret must contain the keys \"AccountName\" and \"AccountKey\", and these must hold the corresponding credentials",
+                      "type": "string"
+                    },
+                    "container": {
+                      "description": "Azure Blob Storage container name.",
+                      "type": "string"
+                    },
+                    "subdir": {
+                      "description": "Optional. Azure Blob Storage subdir under container.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "absSecretName",
+                    "container"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ftp": {
+                  "properties": {
+                    "url": {
+                      "description": "a URI of the \"ftps://[USER[:PASSWORD]@]HOST[:PORT]/PATH[/]\" format",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "gcs": {
+                  "description": "GoogleStorage",
+                  "properties": {
+                    "bucketName": {
+                      "description": "Google Storage bucket name.",
+                      "type": "string"
+                    },
+                    "gcsSecretName": {
+                      "description": "The name of the secret that holds the Google Cloud Storage credentials. The secret must contain the keys \"CLIENT_ID\", \"PRIVATE_KEY\", \"PRIVATE_KEY_ID\", \"CLIENT_EMAIL\" and these must hold the corresponding credentials. The keys should correspond to the values in the key JSON.",
+                      "type": "string"
+                    },
+                    "subdir": {
+                      "description": "Optional. Google Storage subdir under bucket.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "bucketName",
+                    "gcsSecretName"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "interval": {
+                  "description": "Backup Interval in seconds",
+                  "type": "integer"
+                },
+                "mount": {
+                  "description": "MountPointStorage",
+                  "properties": {
+                    "path": {
+                      "description": "Path to the local mount point. You must create the mount point on all nodes, and the redislabs:redislabs user must have read and write permissions on the local mount point.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "s3": {
+                  "properties": {
+                    "awsSecretName": {
+                      "description": "The name of the secret that holds the AWS credentials. The secret must contain the keys \"AWS_ACCESS_KEY_ID\" and \"AWS_SECRET_ACCESS_KEY\", and these must hold the corresponding credentials.",
+                      "type": "string"
+                    },
+                    "bucketName": {
+                      "description": "Amazon S3 bucket name.",
+                      "type": "string"
+                    },
+                    "subdir": {
+                      "description": "Optional. Amazon S3 subdir under bucket.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "awsSecretName",
+                    "bucketName"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "sftp": {
+                  "properties": {
+                    "sftp_url": {
+                      "description": "SFTP url",
+                      "type": "string"
+                    },
+                    "sftpSecretName": {
+                      "description": "The name of the secret that holds SFTP credentials. The secret must contain the \"Key\" key, which is the SSH private key for connecting to the sftp server.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sftpSecretName",
+                    "sftp_url"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "swift": {
+                  "properties": {
+                    "auth_url": {
+                      "description": "Swift service authentication URL.",
+                      "type": "string"
+                    },
+                    "container": {
+                      "description": "Swift object store container for storing the backup files.",
+                      "type": "string"
+                    },
+                    "prefix": {
+                      "description": "Optional. Prefix (path) of backup files in the swift container.",
+                      "type": "string"
+                    },
+                    "swiftSecretName": {
+                      "description": "The name of the secret that holds Swift credentials. The secret must contain the keys \"Key\" and \"User\", and these must hold the corresponding credentials: service access key and service user name (pattern for the latter does not allow special characters &,<,>,\")",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "auth_url",
+                    "container",
+                    "swiftSecretName"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "clientAuthenticationCertificates": {
+              "description": "The Secrets containing TLS Client Certificate to use for Authentication",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "dataInternodeEncryption": {
+              "description": "Internode encryption (INE) setting. An optional boolean setting, overriding a similar cluster-wide policy. If set to False, INE is guaranteed to be turned off for this DB (regardless of cluster-wide policy). If set to True, INE will be turned on, unless the capability is not supported by the DB ( in such a case we will get an error and database creation will fail). If left unspecified, will be disabled if internode encryption is not supported by the DB (regardless of cluster default). Deleting this property after explicitly setting its value shall have no effect.",
+              "type": "boolean"
+            },
+            "databasePort": {
+              "description": "Database port number. TCP port on which the database is available. Will be generated automatically if omitted. can not be changed after creation",
+              "type": "integer"
+            },
+            "databaseSecretName": {
+              "description": "The name of the secret that holds the password to the database (redis databases only). If secret does not exist, it will be created. To define the password, create an opaque secret and set the name in the spec. The password will be taken from the value of the 'password' key. Use an empty string as value within the secret to disable authentication for the database. Notes - For Active-Active databases this secret will not be automatically created, and also, memcached databases must not be set with a value, and a secret/password will not be automatically created for them. Use the memcachedSaslSecretName field to set authentication parameters for memcached databases.",
+              "type": "string"
+            },
+            "defaultUser": {
+              "description": "Is connecting with a default user allowed?  If disabled, the DatabaseSecret will not be created or updated",
+              "type": "boolean"
+            },
+            "evictionPolicy": {
+              "description": "Database eviction policy. see more https://docs.redislabs.com/latest/rs/administering/database-operations/eviction-policy/",
+              "type": "string"
+            },
+            "isRof": {
+              "description": "Whether it is an RoF database or not. Applicable only for databases of type \"REDIS\". Assumed to be false if left blank.",
+              "type": "boolean"
+            },
+            "memcachedSaslSecretName": {
+              "description": "Credentials used for binary authentication in memcached databases. The credentials should be saved as an opaque secret and the name of that secret should be configured using this field. For username, use 'username' as the key and the actual username as the value. For password, use 'password' as the key and the actual password as the value. Note that connections are not encrypted.",
+              "type": "string"
+            },
+            "memorySize": {
+              "description": "memory size of database. use formats like 100MB, 0.1GB. minimum value in 100MB. When redis on flash (RoF) is enabled, this value refers to RAM+Flash memory, and it must not be below 1GB.",
+              "type": "string"
+            },
+            "modulesList": {
+              "description": "List of modules associated with database. Note - For Active-Active databases this feature is currently in preview. For this feature to take effect for Active-Active databases, set a boolean environment variable with the name \"ENABLE_ALPHA_FEATURES\" to True. This variable can be set via the redis-enterprise-operator pod spec, or through the operator-environment-config Config Map.",
+              "items": {
+                "description": "Redis Enterprise Module: https://redislabs.com/redis-enterprise/modules/",
+                "properties": {
+                  "config": {
+                    "description": "Module command line arguments e.g. VKEY_MAX_ENTITY_COUNT 30",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The module's name e.g \"ft\" for redissearch",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "Module's uid - do not set, for system use only nolint:staticcheck // custom json tag unknown to the linter",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "Module's semantic version e.g \"1.6.12\" - optional only in REDB, must be set in REAADB",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "ossCluster": {
+              "description": "OSS Cluster mode option. Note that not all client libraries support OSS cluster mode.",
+              "type": "boolean"
+            },
+            "persistence": {
+              "description": "Database on-disk persistence policy",
+              "enum": [
+                "disabled",
+                "aofEverySecond",
+                "aofAlways",
+                "snapshotEvery1Hour",
+                "snapshotEvery6Hour",
+                "snapshotEvery12Hour"
+              ],
+              "type": "string"
+            },
+            "proxyPolicy": {
+              "description": "The policy used for proxy binding to the endpoint. Supported proxy policies are: single/all-master-shards/all-nodes When left blank, the default value will be chosen according to the value of ossCluster - single if disabled, all-master-shards when enabled",
+              "type": "string"
+            },
+            "rackAware": {
+              "description": "Whether database should be rack aware. This improves availability - more information: https://docs.redislabs.com/latest/rs/concepts/high-availability/rack-zone-awareness/",
+              "type": "boolean"
+            },
+            "redisEnterpriseCluster": {
+              "description": "Connection to Redis Enterprise Cluster",
+              "properties": {
+                "name": {
+                  "description": "The name of the Redis Enterprise Cluster where the database should be stored.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "redisVersion": {
+              "description": "Redis OSS version. Version can be specified via <major.minor> prefix, or via channels - for existing databases - Upgrade Redis OSS version. For new databases - the version which the database will be created with. If set to 'major' - will always upgrade to the most recent major Redis version. If set to 'latest' - will always upgrade to the most recent Redis version. Depends on 'redisUpgradePolicy' - if you want to set the value to 'latest' for some databases, you must set redisUpgradePolicy on the cluster before. Possible values are 'major' or 'latest' When using upgrade - make sure to backup the database before. This value is used only for database type 'redis'",
+              "type": "string"
+            },
+            "upgradeSpec": {
+              "description": "Specifications for DB upgrade.",
+              "properties": {
+                "upgradeModulesToLatest": {
+                  "description": "Upgrades the modules to the latest version that supportes the DB version during a DB upgrade action, to upgrade the DB version view the 'redisVersion' field. Note - This field is currently not supported for Active-Active databases.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "upgradeModulesToLatest"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicaSources": {
+              "description": "What databases to replicate from",
+              "items": {
+                "properties": {
+                  "clientKeySecret": {
+                    "description": "Secret that defines the client certificate and key used by the syncer in the target database cluster. The secret must have 2 keys in its map: \"cert\" which is the PEM encoded certificate, and \"key\" which is the PEM encoded private key.",
+                    "type": "string"
+                  },
+                  "compression": {
+                    "description": "GZIP compression level (0-6) to use for replication.",
+                    "type": "integer"
+                  },
+                  "replicaSourceName": {
+                    "description": "The name of the resource from which the source database URI is derived. The type of resource must match the type specified in the ReplicaSourceType field.",
+                    "type": "string"
+                  },
+                  "replicaSourceType": {
+                    "description": "The type of resource from which the source database URI is derived. If set to 'SECRET', the source database URI is derived from the secret named in the ReplicaSourceName field. The secret must have a key named 'uri' that defines the URI of the source database in the form of 'redis://...'. The type of secret (kubernetes, vault, ...) is determined by the secret mechanism used by the underlying REC object. If set to 'REDB', the source database URI is derived from the RedisEnterpriseDatabase resource named in the ReplicaSourceName field.",
+                    "type": "string"
+                  },
+                  "serverCertSecret": {
+                    "description": "Secret that defines the server certificate used by the proxy in the source database cluster. The secret must have 1 key in its map: \"cert\" which is the PEM encoded certificate.",
+                    "type": "string"
+                  },
+                  "tlsSniName": {
+                    "description": "TLS SNI name to use for the replication link.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "replicaSourceName",
+                  "replicaSourceType"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "replication": {
+              "description": "In-memory database replication. When enabled, database will have replica shard for every master - leading to higher availability. Defaults to false.",
+              "type": "boolean"
+            },
+            "resp3": {
+              "description": "Whether this database supports RESP3 protocol. Note - Deleting this property after explicitly setting its value shall have no effect. Please view the corresponding field in RS doc for more info.",
+              "type": "boolean"
+            },
+            "rofRamSize": {
+              "description": "The size of the RAM portion of an RoF database. Similarly to \"memorySize\" use formats like 100MB, 0.1GB It must be at least 10% of combined memory size (RAM+Flash), as specified by \"memorySize\".",
+              "type": "string"
+            },
+            "rolesPermissions": {
+              "description": "List of Redis Enteprise ACL and Role bindings to apply",
+              "items": {
+                "description": "Redis Enterprise Role and ACL Binding",
+                "properties": {
+                  "acl": {
+                    "description": "Acl Name of RolePermissionType (note: use exact name of the ACL from the Redis Enterprise ACL list, case sensitive)",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "Role Name of RolePermissionType (note: use exact name of the role from the Redis Enterprise role list, case sensitive)",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type of Redis Enterprise Database Role Permission",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "acl",
+                  "role",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "shardingEnabled": {
+              "description": "Toggles database sharding for REAADBs (Active Active databases) and enabled by default. This field is blocked for REDB (non-Active Active databases) and sharding is toggled via the shardCount field - when shardCount is 1 this is disabled otherwise enabled.",
+              "type": "boolean"
+            },
+            "shardCount": {
+              "description": "Number of database server-side shards",
+              "type": "integer"
+            },
+            "shardsPlacement": {
+              "description": "Control the density of shards - should they reside on as few or as many nodes as possible. Available options are \"dense\" or \"sparse\". If left unset, defaults to \"dense\".",
+              "type": "string"
+            },
+            "tlsMode": {
+              "description": "Require SSL authenticated and encrypted connections to the database. enabled - all incoming connections to the Database must use SSL. disabled - no incoming connection to the Database should use SSL. replica_ssl - databases that replicate from this one need to use SSL.",
+              "enum": [
+                "disabled",
+                "enabled",
+                "replica_ssl"
+              ],
+              "type": "string"
+            },
+            "type": {
+              "description": "The type of the database.",
+              "enum": [
+                "redis",
+                "memcached"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "participatingClusters"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/app.redislabs.com/redisenterprisecluster_v1.json
+++ b/app.redislabs.com/redisenterprisecluster_v1.json
@@ -14,7 +14,7 @@
       "description": "RedisEnterpriseClusterSpec defines the desired state of RedisEnterpriseCluster",
       "properties": {
         "activeActive": {
-          "description": "Specification for ActiveActive setup",
+          "description": "Specification for ActiveActive setup. At most one of ingressOrRouteSpec or activeActive fields can be set at the same time.",
           "properties": {
             "apiIngressUrl": {
               "description": "RS API URL",
@@ -55,18 +55,45 @@
           },
           "type": "array"
         },
+        "backup": {
+          "description": "Cluster-wide backup configurations",
+          "properties": {
+            "s3": {
+              "description": "Configurations for backups to s3 and s3-compatible storage",
+              "properties": {
+                "caCertificateSecretName": {
+                  "description": "Secret name that holds the S3 CA certificate, which contains the TLS certificate mapped to the key in the secret 'cert'",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "Specifies the URL for S3 export and import",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "bootstrapperImageSpec": {
           "description": "Specification for Bootstrapper container image",
           "properties": {
+            "digestHash": {
+              "description": "The digest hash of the container image to pull. When specified, the container image is pulled according to the digest hash instead of the image tag. The versionTag field must also be specified with the image tag matching this digest hash. Note: This field is only supported for OLM deployments.",
+              "type": "string"
+            },
             "imagePullPolicy": {
-              "description": "PullPolicy describes a policy for if/when to pull a container image",
+              "description": "The image pull policy to be applied to the container image. One of Always, Never, IfNotPresent.",
               "type": "string"
             },
             "repository": {
-              "description": "Repository",
+              "description": "The repository (name) of the container image to be deployed.",
               "type": "string"
             },
             "versionTag": {
+              "description": "The tag of the container image to be deployed.",
               "type": "string"
             }
           },
@@ -76,6 +103,23 @@
         "bootstrapperResources": {
           "description": "Compute resource requirements for bootstrapper containers",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
             "limits": {
               "additionalProperties": {
                 "anyOf": [
@@ -116,23 +160,27 @@
           "description": "RS Cluster Certificates. Used to modify the certificates used by the cluster. See the \"RSClusterCertificates\" struct described above to see the supported certificates.",
           "properties": {
             "apiCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's API Certificate. If left blank, will use certificate provided by the cluster.",
+              "description": "Secret name to use for cluster's API certificate. If left blank, a cluster-provided certificate will be used.",
               "type": "string"
             },
             "cmCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's CM Certificate. If left blank, will use certificate provided by the cluster.",
+              "description": "Secret name to use for cluster's CM (Cluster Manager) certificate. If left blank, a cluster-provided certificate will be used.",
+              "type": "string"
+            },
+            "ldapClientCertificateSecretName": {
+              "description": "Secret name to use for cluster's LDAP client certificate. If left blank, LDAP client certificate authentication will be disabled.",
               "type": "string"
             },
             "metricsExporterCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's Metrics Exporter Certificate. If left blank, will use certificate provided by the cluster.",
+              "description": "Secret name to use for cluster's Metrics Exporter certificate. If left blank, a cluster-provided certificate will be used.",
               "type": "string"
             },
             "proxyCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's Proxy Certificate. If left blank, will use certificate provided by the cluster.",
+              "description": "Secret name to use for cluster's Proxy certificate. If left blank, a cluster-provided certificate will be used.",
               "type": "string"
             },
             "syncerCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's Syncer Certificate. If left blank, will use certificate provided by the cluster.",
+              "description": "Secret name to use for cluster's Syncer certificate. If left blank, a cluster-provided certificate will be used.",
               "type": "string"
             }
           },
@@ -160,11 +208,15 @@
           "type": "boolean"
         },
         "containerTimezone": {
-          "description": "Container timezone configuration. While the default timezone on all containers is UTC, this setting can be used to set the timezone on services rigger/bootstrapper/RS containers. Currently the only supported value is to propagate the host timezone to all containers.",
+          "description": "Container timezone configuration. While the default timezone on all containers is UTC, this setting can be used to set the timezone on services rigger/bootstrapper/RS containers. You can either propagate the hosts timezone to RS pods or set it manually via timezoneName.",
           "properties": {
             "propagateHost": {
-              "description": "Identifies that container timezone should be in sync with the host.",
+              "description": "Identifies that container timezone should be in sync with the host, this option mounts a hostPath volume onto RS pods that could be restricted in some systems.",
               "type": "object"
+            },
+            "timezoneName": {
+              "description": "POSIX-style timezone name as a string to be passed as EnvVar to RE pods, e.g. \"Europe/London\".",
+              "type": "string"
             }
           },
           "type": "object",
@@ -178,9 +230,116 @@
           "description": "Internode encryption (INE) cluster wide policy. An optional boolean setting. Specifies if INE should be on/off for new created REDBs. May be overridden for specific REDB via similar setting, please view the similar setting for REDB for more info.",
           "type": "boolean"
         },
+        "encryptPkeys": {
+          "description": "Private key encryption Possible values: true/false",
+          "type": "boolean"
+        },
         "enforceIPv4": {
           "description": "Sets ENFORCE_IPV4 environment variable",
           "type": "boolean"
+        },
+        "extraEnvVars": {
+          "description": "ADVANCED USAGE: use carefully. Add environment variables to RS StatefulSet's containers.",
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "valueFrom": {
+                "properties": {
+                  "configMapKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "properties": {
+                      "containerName": {
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
         },
         "extraLabels": {
           "additionalProperties": {
@@ -190,6 +349,7 @@
           "type": "object"
         },
         "hostAliases": {
+          "description": "Adds hostAliases entries to the Redis Enterprise pods",
           "items": {
             "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
             "properties": {
@@ -209,6 +369,187 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "ingressOrRouteSpec": {
+          "description": "Access configurations for the Redis Enterprise Cluster and Databases. At most one of ingressOrRouteSpec or activeActive fields can be set at the same time.",
+          "properties": {
+            "apiFqdnUrl": {
+              "description": "RS API URL",
+              "type": "string"
+            },
+            "dbFqdnSuffix": {
+              "description": "DB ENDPOINT SUFFIX - will be used to set the db host ingress <db name><db fqdn suffix>. Creates a host name so it should be unique if more than one db is created on the cluster with the same name",
+              "type": "string"
+            },
+            "ingressAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Additional annotations to set on ingress resources created by the operator",
+              "type": "object"
+            },
+            "method": {
+              "description": "Used to distinguish between different platforms implementation.",
+              "enum": [
+                "openShiftRoute",
+                "ingress",
+                "istio"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiFqdnUrl",
+            "dbFqdnSuffix",
+            "method"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ldap": {
+          "description": "Cluster-level LDAP configuration, such as server addresses, protocol, authentication and query settings.",
+          "properties": {
+            "authenticationQuery": {
+              "description": "Configuration of authentication queries, mapping between the username, provided to the cluster for authentication, and the LDAP Distinguished Name.",
+              "properties": {
+                "query": {
+                  "description": "Configuration for a search query. Mutually exclusive with the 'template' field. The substring '%u' in the query filter will be replaced with the username.",
+                  "properties": {
+                    "base": {
+                      "description": "The Distinguished Name of the entry at which to start the search, e.g., 'ou=dev,dc=example,dc=com'.",
+                      "type": "string"
+                    },
+                    "filter": {
+                      "description": "An RFC-4515 string representation of the filter to apply in the search. For an authentication query, the substring '%u' will be replaced with the username, e.g., '(cn=%u)'. For an authorization query, the substring '%D' will be replaced with the user's Distinguished Name, e.g., '(members=%D)'.",
+                      "type": "string"
+                    },
+                    "scope": {
+                      "description": "The search scope for an LDAP query. One of: BaseObject, SingleLevel, WholeSubtree",
+                      "enum": [
+                        "BaseObject",
+                        "SingleLevel",
+                        "WholeSubtree"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "base",
+                    "filter",
+                    "scope"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "template": {
+                  "description": "Configuration for a template query. Mutually exclusive with the 'query' field. The substring '%u' will be replaced with the username, e.g., 'cn=%u,ou=dev,dc=example,dc=com'.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "authorizationQuery": {
+              "description": "Configuration of authorization queries, mapping between a user's Distinguished Name and its group memberships.",
+              "properties": {
+                "attribute": {
+                  "description": "Configuration for an attribute query. Mutually exclusive with the 'query' field. Holds the name of an attribute of the LDAP user entity that contains a list of the groups that the user belongs to, e.g., 'memberOf'.",
+                  "type": "string"
+                },
+                "query": {
+                  "description": "Configuration for a search query. Mutually exclusive with the 'attribute' field. The substring '%D' in the query filter will be replaced with the user's Distinguished Name.",
+                  "properties": {
+                    "base": {
+                      "description": "The Distinguished Name of the entry at which to start the search, e.g., 'ou=dev,dc=example,dc=com'.",
+                      "type": "string"
+                    },
+                    "filter": {
+                      "description": "An RFC-4515 string representation of the filter to apply in the search. For an authentication query, the substring '%u' will be replaced with the username, e.g., '(cn=%u)'. For an authorization query, the substring '%D' will be replaced with the user's Distinguished Name, e.g., '(members=%D)'.",
+                      "type": "string"
+                    },
+                    "scope": {
+                      "description": "The search scope for an LDAP query. One of: BaseObject, SingleLevel, WholeSubtree",
+                      "enum": [
+                        "BaseObject",
+                        "SingleLevel",
+                        "WholeSubtree"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "base",
+                    "filter",
+                    "scope"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bindCredentialsSecretName": {
+              "description": "Name of a secret within the same namespace, holding the credentials used to communicate with the LDAP server for authentication queries. The secret must have a key named 'dn' with the Distinguished Name of the user to execute the query, and 'password' with its password. If left blank, credentials-based authentication is disabled.",
+              "type": "string"
+            },
+            "caCertificateSecretName": {
+              "description": "Name of a secret within the same namespace, holding a PEM-encoded CA certificate for validating the TLS connection to the LDAP server. The secret must have a key named 'cert' with the certificate data. This field is applicable only when the protocol is LDAPS or STARTTLS.",
+              "type": "string"
+            },
+            "cacheTTLSeconds": {
+              "description": "The maximum TTL of cached entries.",
+              "type": "integer"
+            },
+            "enabledForControlPlane": {
+              "description": "Whether to enable LDAP for control plane access. Disabled by default.",
+              "type": "boolean"
+            },
+            "enabledForDataPlane": {
+              "description": "Whether to enable LDAP for data plane access. Disabled by default.",
+              "type": "boolean"
+            },
+            "protocol": {
+              "description": "Specifies the LDAP protocol to use. One of: LDAP, LDAPS, STARTTLS.",
+              "enum": [
+                "LDAP",
+                "LDAPS",
+                "STARTTLS"
+              ],
+              "type": "string"
+            },
+            "servers": {
+              "description": "One or more LDAP servers. If multiple servers are specified, they must all share an identical organization tree structure.",
+              "items": {
+                "description": "Address of an LDAP server.",
+                "properties": {
+                  "host": {
+                    "description": "Host name of the LDAP server",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port number of the LDAP server. If unspecified, defaults to 389 for LDAP and STARTTLS protocols, and 636 for LDAPS protocol.",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "host"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "authenticationQuery",
+            "authorizationQuery",
+            "protocol",
+            "servers"
+          ],
+          "type": "object",
+          "additionalProperties": false
         },
         "license": {
           "description": "Redis Enterprise License",
@@ -230,15 +571,46 @@
           "format": "int32",
           "type": "integer"
         },
+        "ocspConfiguration": {
+          "description": "An API object that represents the cluster's OCSP configuration. To enable OCSP, the cluster's proxy certificate should contain the OCSP responder URL.",
+          "properties": {
+            "ocspFunctionality": {
+              "description": "Whether to enable/disable OCSP mechanism for the cluster.",
+              "type": "boolean"
+            },
+            "queryFrequency": {
+              "description": "Determines the interval (in seconds) in which the control plane will poll the OCSP responder for a new status for the server certificate. Minimum value is 60. Maximum value is 86400.",
+              "type": "integer"
+            },
+            "recoveryFrequency": {
+              "description": "Determines the interval (in seconds) in which the control plane will poll the OCSP responder for a new status for the server certificate when the current staple is invalid. Minimum value is 60. Maximum value is 86400.",
+              "type": "integer"
+            },
+            "recoveryMaxTries": {
+              "description": "Determines the maximum number for the OCSP recovery attempts. After max number of tries passed, the control plane will revert back to the regular frequency. Minimum value is 1. Maximum value is 100.",
+              "type": "integer"
+            },
+            "responseTimeout": {
+              "description": "Determines the time interval (in seconds) for which the request waits for a response from the OCSP responder. Minimum value is 1. Maximum value is 60.",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "persistentSpec": {
           "description": "Specification for Redis Enterprise Cluster persistence",
           "properties": {
+            "enablePersistentVolumeResize": {
+              "description": "Whether to enable PersistentVolumes resize. Disabled by default. Read the instruction in pvc_expansion readme carefully before using this feature.",
+              "type": "boolean"
+            },
             "enabled": {
               "description": "Whether to add persistent volume to Redis Enterprise pods",
               "type": "boolean"
             },
             "storageClassName": {
-              "description": "Storage class for persistent volume in Redis Enterprise pods Leave empty to use the default",
+              "description": "Storage class for persistent volume in Redis Enterprise pods. Leave empty to use the default. If using the default this way, make sure the Kubernetes Cluster has a default Storage Class configured. This can be done by running a `kubectl get storageclass` and see if one of the Storage Classes' names contains a `(default)` mark.",
               "type": "string"
             },
             "volumeSize": {
@@ -250,6 +622,7 @@
                   "type": "string"
                 }
               ],
+              "description": "To enable resizing after creating the cluster - please follow the instructions in the pvc_expansion readme",
               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
               "x-kubernetes-int-or-string": true
             }
@@ -261,7 +634,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "pod annotations",
+          "description": "annotations for the service rigger and redis enterprise pods",
           "type": "object"
         },
         "podAntiAffinity": {
@@ -476,7 +849,7 @@
           "additionalProperties": false
         },
         "podSecurityPolicyName": {
-          "description": "Name of pod security policy to use on pods See https://kubernetes.io/docs/concepts/policy/pod-security-policy/",
+          "description": "DEPRECATED PodSecurityPolicy support is removed in Kubernetes v1.25 and the use of this field is invalid for use when running on Kubernetes v1.25+. Future versions of the RedisEnterpriseCluster API will remove support for this field altogether. For migration instructions, see https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/ \n Name of pod security policy to use on pods",
           "type": "string"
         },
         "podStartingPolicy": {
@@ -1530,6 +1903,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -1676,6 +2065,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -1773,6 +2178,23 @@
                   },
                   "resources": {
                     "properties": {
+                      "claims": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -1922,6 +2344,22 @@
                       "failureThreshold": {
                         "format": "int32",
                         "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "httpGet": {
                         "properties": {
@@ -2123,6 +2561,9 @@
               "type": "boolean"
             },
             "hostPID": {
+              "type": "boolean"
+            },
+            "hostUsers": {
               "type": "boolean"
             },
             "hostname": {
@@ -2501,6 +2942,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -2652,6 +3109,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -2749,6 +3222,23 @@
                   },
                   "resources": {
                     "properties": {
+                      "claims": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -2898,6 +3388,22 @@
                       "failureThreshold": {
                         "format": "int32",
                         "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "httpGet": {
                         "properties": {
@@ -3081,6 +3587,18 @@
               "type": "object",
               "x-kubernetes-map-type": "atomic"
             },
+            "os": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "overhead": {
               "additionalProperties": {
                 "anyOf": [
@@ -3121,6 +3639,37 @@
               },
               "type": "array"
             },
+            "resourceClaims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "properties": {
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
             "restartPolicy": {
               "type": "string"
             },
@@ -3129,6 +3678,25 @@
             },
             "schedulerName": {
               "type": "string"
+            },
+            "schedulingGates": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
             },
             "securityContext": {
               "properties": {
@@ -3315,9 +3883,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "matchLabelKeys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "maxSkew": {
                     "format": "int32",
                     "type": "integer"
+                  },
+                  "minDomains": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string"
                   },
                   "topologyKey": {
                     "type": "string"
@@ -3684,6 +4269,9 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
                                   }
                                 },
                                 "required": [
@@ -3695,6 +4283,23 @@
                               },
                               "resources": {
                                 "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "set"
+                                  },
                                   "limits": {
                                     "additionalProperties": {
                                       "anyOf": [
@@ -4454,18 +5059,31 @@
           "type": "object",
           "additionalProperties": false
         },
+        "redisEnterpriseIPFamily": {
+          "description": "Reserved, future use, only for use if instructed by Redis. IPFamily dictates what IP family to choose for pods' internal and external communication.",
+          "enum": [
+            "IPv4",
+            "IPv6"
+          ],
+          "type": "string"
+        },
         "redisEnterpriseImageSpec": {
           "description": "Specification for Redis Enterprise container image",
           "properties": {
+            "digestHash": {
+              "description": "The digest hash of the container image to pull. When specified, the container image is pulled according to the digest hash instead of the image tag. The versionTag field must also be specified with the image tag matching this digest hash. Note: This field is only supported for OLM deployments.",
+              "type": "string"
+            },
             "imagePullPolicy": {
-              "description": "PullPolicy describes a policy for if/when to pull a container image",
+              "description": "The image pull policy to be applied to the container image. One of Always, Never, IfNotPresent.",
               "type": "string"
             },
             "repository": {
-              "description": "Repository",
+              "description": "The repository (name) of the container image to be deployed.",
               "type": "string"
             },
             "versionTag": {
+              "description": "The tag of the container image to be deployed.",
               "type": "string"
             }
           },
@@ -4475,6 +5093,23 @@
         "redisEnterpriseNodeResources": {
           "description": "Compute resource requirements for Redis Enterprise containers",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
             "limits": {
               "additionalProperties": {
                 "anyOf": [
@@ -4510,6 +5145,13 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "redisEnterprisePodAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations for redis enterprise pod",
+          "type": "object"
         },
         "redisEnterpriseServicesConfiguration": {
           "description": "RS Cluster optional services settings",
@@ -4640,15 +5282,20 @@
         "redisEnterpriseServicesRiggerImageSpec": {
           "description": "Specification for Services Rigger container image",
           "properties": {
+            "digestHash": {
+              "description": "The digest hash of the container image to pull. When specified, the container image is pulled according to the digest hash instead of the image tag. The versionTag field must also be specified with the image tag matching this digest hash. Note: This field is only supported for OLM deployments.",
+              "type": "string"
+            },
             "imagePullPolicy": {
-              "description": "PullPolicy describes a policy for if/when to pull a container image",
+              "description": "The image pull policy to be applied to the container image. One of Always, Never, IfNotPresent.",
               "type": "string"
             },
             "repository": {
-              "description": "Repository",
+              "description": "The repository (name) of the container image to be deployed.",
               "type": "string"
             },
             "versionTag": {
+              "description": "The tag of the container image to be deployed.",
               "type": "string"
             }
           },
@@ -4658,6 +5305,23 @@
         "redisEnterpriseServicesRiggerResources": {
           "description": "Compute resource requirements for Services Rigger pod",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
             "limits": {
               "additionalProperties": {
                 "anyOf": [
@@ -4731,6 +5395,48 @@
           },
           "type": "array"
         },
+        "redisOnFlashSpec": {
+          "description": "Stores configurations specific to redis on flash. If provided, the cluster will be capable of creating redis on flash databases.",
+          "properties": {
+            "bigStoreDriver": {
+              "enum": [
+                "rocksdb",
+                "speedb"
+              ],
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "flashDiskSize": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            },
+            "flashStorageEngine": {
+              "enum": [
+                "rocksdb"
+              ],
+              "type": "string"
+            },
+            "storageClassName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "enabled",
+            "storageClassName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "redisUpgradePolicy": {
           "description": "Redis upgrade policy to be set on the Redis Enterprise Cluster. Possible values: major/latest This value is used by the cluster to choose the Redis version of the database when an upgrade is performed. The Redis Enterprise Cluster includes multiple versions of OSS Redis that can be used for databases.",
           "enum": [
@@ -4739,9 +5445,43 @@
           ],
           "type": "string"
         },
+        "resp3Default": {
+          "description": "Whether databases will turn on RESP3 compatibility upon database upgrade. Note - Deleting this property after explicitly setting its value shall have no effect. Please view the corresponding field in RS doc for more info.",
+          "type": "boolean"
+        },
         "serviceAccountName": {
           "description": "Name of the service account to use",
           "type": "string"
+        },
+        "services": {
+          "description": "Customization options for operator-managed service resources created for Redis Enterprise clusters and databases",
+          "properties": {
+            "apiService": {
+              "description": "Customization options for the REC API service.",
+              "properties": {
+                "type": {
+                  "description": "Type of service to create for the REC API service. Defaults to ClusterIP service, if not specified otherwise.",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "servicesAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Global additional annotations to set on service resources created by the operator. The specified annotations will not override annotations that already exist and didn't originate from the operator.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "servicesRiggerSpec": {
           "description": "Specification for service rigger",
@@ -4870,7 +5610,15 @@
               },
               "type": "array"
             },
+            "podAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations for the service rigger pod",
+              "type": "object"
+            },
             "serviceNaming": {
+              "description": "Used to determine how to name the services created automatically when a database is created. When bdb_name is used, the database name will be also used for the service name. When redis-port is used, the service will be named redis-<port>.",
               "enum": [
                 "bdb_name",
                 "redis-port"
@@ -5860,6 +6608,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -6006,6 +6770,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -6103,6 +6883,23 @@
                       },
                       "resources": {
                         "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -6252,6 +7049,22 @@
                           "failureThreshold": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -6453,6 +7266,9 @@
                   "type": "boolean"
                 },
                 "hostPID": {
+                  "type": "boolean"
+                },
+                "hostUsers": {
                   "type": "boolean"
                 },
                 "hostname": {
@@ -6831,6 +7647,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -6982,6 +7814,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -7079,6 +7927,23 @@
                       },
                       "resources": {
                         "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -7228,6 +8093,22 @@
                           "failureThreshold": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -7411,6 +8292,18 @@
                   "type": "object",
                   "x-kubernetes-map-type": "atomic"
                 },
+                "os": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "overhead": {
                   "additionalProperties": {
                     "anyOf": [
@@ -7451,6 +8344,37 @@
                   },
                   "type": "array"
                 },
+                "resourceClaims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "properties": {
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
                 "restartPolicy": {
                   "type": "string"
                 },
@@ -7459,6 +8383,25 @@
                 },
                 "schedulerName": {
                   "type": "string"
+                },
+                "schedulingGates": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "securityContext": {
                   "properties": {
@@ -7645,9 +8588,26 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "matchLabelKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
                       "maxSkew": {
                         "format": "int32",
                         "type": "integer"
+                      },
+                      "minDomains": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -8014,6 +8974,9 @@
                                       },
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
                                       }
                                     },
                                     "required": [
@@ -8025,6 +8988,23 @@
                                   },
                                   "resources": {
                                     "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      },
                                       "limits": {
                                         "additionalProperties": {
                                           "anyOf": [
@@ -9149,6 +10129,22 @@
                     "format": "int32",
                     "type": "integer"
                   },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "httpGet": {
                     "properties": {
                       "host": {
@@ -9300,6 +10296,22 @@
                     "format": "int32",
                     "type": "integer"
                   },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "httpGet": {
                     "properties": {
                       "host": {
@@ -9397,6 +10409,23 @@
               },
               "resources": {
                 "properties": {
+                  "claims": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
                   "limits": {
                     "additionalProperties": {
                       "anyOf": [
@@ -9546,6 +10575,22 @@
                   "failureThreshold": {
                     "format": "int32",
                     "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "httpGet": {
                     "properties": {
@@ -9738,7 +10783,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Annotations for Redis Enterprise UI service",
+          "description": "Annotations for Redis Enterprise UI service. This annotations will override the overlapping global annotations set under spec.services.servicesAnnotations The specified annotations will not override annotations that already exist and didn't originate from the operator, except for the 'redis.io/last-keys' annotation which is reserved.",
           "type": "object"
         },
         "uiServiceType": {
@@ -10750,6 +11795,9 @@
               "dbType": {
                 "type": "string"
               },
+              "major": {
+                "type": "boolean"
+              },
               "version": {
                 "type": "string"
               }
@@ -10762,6 +11810,10 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "ingressOrRouteMethodStatus": {
+          "description": "The ingressOrRouteSpec/ActiveActive spec method that exist",
+          "type": "string"
         },
         "licenseStatus": {
           "properties": {
@@ -10776,6 +11828,17 @@
             },
             "shardsLimit": {
               "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "managedAPIs": {
+          "description": "Indicates cluster APIs that are being managed by the operator. This only applies to cluster APIs which are optionally-managed by the operator, such as cluster LDAP configuration. Most other APIs are automatically managed by the operator, and are not listed here.",
+          "properties": {
+            "ldap": {
+              "description": "Indicate whether cluster LDAP configuration is managed by the operator. When this is enabled, the operator will reconcile the cluster LDAP configuration according to the '.spec.ldap' field in the RedisEnterpriseCluster resource.",
+              "type": "boolean"
             }
           },
           "type": "object",
@@ -10832,6 +11895,24 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "persistenceStatus": {
+          "description": "The status of the Persistent Volume Claims that are used for Redis Enterprise Cluster persistence. The status will correspond to the status of one or more of the PVCs (failed/resizing if one of them is in resize or failed to resize)",
+          "properties": {
+            "status": {
+              "description": "The current status of the PVCs",
+              "type": "string"
+            },
+            "succeeded": {
+              "description": "The number of PVCs that are provisioned with the expected size",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "redisEnterpriseIPFamily": {
+          "type": "string"
         },
         "specStatus": {
           "type": "string"

--- a/app.redislabs.com/redisenterprisecluster_v1alpha1.json
+++ b/app.redislabs.com/redisenterprisecluster_v1alpha1.json
@@ -1,5 +1,4 @@
 {
-  "description": "RedisEnterpriseCluster is the Schema for the redisenterpriseclusters API",
   "properties": {
     "apiVersion": {
       "type": "string"
@@ -11,31 +10,26 @@
       "type": "object"
     },
     "spec": {
-      "description": "RedisEnterpriseClusterSpec defines the desired state of RedisEnterpriseCluster",
       "properties": {
         "activeActive": {
-          "description": "Specification for ActiveActive setup",
           "properties": {
             "apiIngressUrl": {
-              "description": "RS API URL",
               "type": "string"
             },
             "dbIngressSuffix": {
-              "description": "DB ENDPOINT SUFFIX - will be used to set the db host. ingress <db name><db ingress suffix> Creates a host name so it should be unique if more than one db is created on the cluster with the same name",
               "type": "string"
             },
             "ingressAnnotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Used for ingress controllers such as ha-proxy or nginx in GKE",
               "type": "object"
             },
             "method": {
-              "description": "Used to distinguish between different platforms implementation",
               "enum": [
                 "openShiftRoute",
-                "ingress"
+                "ingress",
+                "istio"
               ],
               "type": "string"
             }
@@ -49,21 +43,38 @@
           "additionalProperties": false
         },
         "antiAffinityAdditionalTopologyKeys": {
-          "description": "Additional antiAffinity terms in order to support installation on different zones/vcenters",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "bootstrapperImageSpec": {
-          "description": "Specification for Bootstrapper container image",
+        "backup": {
           "properties": {
+            "s3": {
+              "properties": {
+                "caCertificateSecretName": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "bootstrapperImageSpec": {
+          "properties": {
+            "digestHash": {
+              "type": "string"
+            },
             "imagePullPolicy": {
-              "description": "PullPolicy describes a policy for if/when to pull a container image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository",
               "type": "string"
             },
             "versionTag": {
@@ -74,8 +85,24 @@
           "additionalProperties": false
         },
         "bootstrapperResources": {
-          "description": "Compute resource requirements for bootstrapper containers",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
             "limits": {
               "additionalProperties": {
                 "anyOf": [
@@ -89,7 +116,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
               "type": "object"
             },
             "requests": {
@@ -105,7 +131,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
               "type": "object"
             }
           },
@@ -113,26 +138,23 @@
           "additionalProperties": false
         },
         "certificates": {
-          "description": "RS Cluster Certificates. Used to modify the certificates used by the cluster. See the \"RSClusterCertificates\" struct described above to see the supported certificates.",
           "properties": {
             "apiCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's API Certificate. If left blank, will use certificate provided by the cluster.",
               "type": "string"
             },
             "cmCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's CM Certificate. If left blank, will use certificate provided by the cluster.",
+              "type": "string"
+            },
+            "ldapClientCertificateSecretName": {
               "type": "string"
             },
             "metricsExporterCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's Metrics Exporter Certificate. If left blank, will use certificate provided by the cluster.",
               "type": "string"
             },
             "proxyCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's Proxy Certificate. If left blank, will use certificate provided by the cluster.",
               "type": "string"
             },
             "syncerCertificateSecretName": {
-              "description": "Secret Name/Path to use for Cluster's Syncer Certificate. If left blank, will use certificate provided by the cluster.",
               "type": "string"
             }
           },
@@ -140,15 +162,12 @@
           "additionalProperties": false
         },
         "clusterCredentialSecretName": {
-          "description": "Secret Name/Path to use for Cluster Credentials. To be used only if ClusterCredentialSecretType is vault. If left blank, will use cluster name.",
           "type": "string"
         },
         "clusterCredentialSecretRole": {
-          "description": "Used only if ClusterCredentialSecretType is vault, to define vault role to be used.  If blank, defaults to \"redis-enterprise-operator\"",
           "type": "string"
         },
         "clusterCredentialSecretType": {
-          "description": "Type of Secret to use for ClusterCredential, Vault, Kuberetes,... If left blank, will default ot kubernetes secrets",
           "enum": [
             "vault",
             "kubernetes"
@@ -156,52 +175,152 @@
           "type": "string"
         },
         "clusterRecovery": {
-          "description": "ClusterRecovery initiates cluster recovery when set to true. Note that this field is cleared automatically after the cluster is recovered",
           "type": "boolean"
         },
         "containerTimezone": {
-          "description": "Container timezone configuration. While the default timezone on all containers is UTC, this setting can be used to set the timezone on services rigger/bootstrapper/RS containers. Currently the only supported value is to propagate the host timezone to all containers.",
           "properties": {
             "propagateHost": {
-              "description": "Identifies that container timezone should be in sync with the host.",
               "type": "object"
+            },
+            "timezoneName": {
+              "type": "string"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "createServiceAccount": {
-          "description": "Whether to create service account",
           "type": "boolean"
         },
         "dataInternodeEncryption": {
-          "description": "Internode encryption (INE) cluster wide policy. An optional boolean setting. Specifies if INE should be on/off for new created REDBs. May be overridden for specific REDB via similar setting, please view the similar setting for REDB for more info.",
+          "type": "boolean"
+        },
+        "encryptPkeys": {
           "type": "boolean"
         },
         "enforceIPv4": {
-          "description": "Sets ENFORCE_IPV4 environment variable",
           "type": "boolean"
+        },
+        "extraEnvVars": {
+          "description": "ADVANCED USAGE: use carefully. Add environment variables to RS StatefulSet's containers.",
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "valueFrom": {
+                "properties": {
+                  "configMapKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "properties": {
+                      "containerName": {
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
         },
         "extraLabels": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Labels that the user defines for their convenience",
           "type": "object"
         },
         "hostAliases": {
+          "description": "Adds hostAliases entries to the Redis Enterprise pods",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -210,35 +329,205 @@
           },
           "type": "array"
         },
+        "ingressOrRouteSpec": {
+          "properties": {
+            "apiFqdnUrl": {
+              "type": "string"
+            },
+            "dbFqdnSuffix": {
+              "type": "string"
+            },
+            "ingressAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "method": {
+              "enum": [
+                "openShiftRoute",
+                "ingress",
+                "istio"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiFqdnUrl",
+            "dbFqdnSuffix",
+            "method"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ldap": {
+          "properties": {
+            "authenticationQuery": {
+              "properties": {
+                "query": {
+                  "properties": {
+                    "base": {
+                      "type": "string"
+                    },
+                    "filter": {
+                      "type": "string"
+                    },
+                    "scope": {
+                      "enum": [
+                        "BaseObject",
+                        "SingleLevel",
+                        "WholeSubtree"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "base",
+                    "filter",
+                    "scope"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "template": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "authorizationQuery": {
+              "properties": {
+                "attribute": {
+                  "type": "string"
+                },
+                "query": {
+                  "properties": {
+                    "base": {
+                      "type": "string"
+                    },
+                    "filter": {
+                      "type": "string"
+                    },
+                    "scope": {
+                      "enum": [
+                        "BaseObject",
+                        "SingleLevel",
+                        "WholeSubtree"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "base",
+                    "filter",
+                    "scope"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bindCredentialsSecretName": {
+              "type": "string"
+            },
+            "caCertificateSecretName": {
+              "type": "string"
+            },
+            "cacheTTLSeconds": {
+              "type": "integer"
+            },
+            "enabledForControlPlane": {
+              "type": "boolean"
+            },
+            "enabledForDataPlane": {
+              "type": "boolean"
+            },
+            "protocol": {
+              "enum": [
+                "LDAP",
+                "LDAPS",
+                "STARTTLS"
+              ],
+              "type": "string"
+            },
+            "servers": {
+              "items": {
+                "properties": {
+                  "host": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "host"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "authenticationQuery",
+            "authorizationQuery",
+            "protocol",
+            "servers"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "license": {
-          "description": "Redis Enterprise License",
           "type": "string"
         },
         "licenseSecretName": {
-          "description": "K8s secret or Vault Secret Name/Path to use for Cluster License. When left blank, the license is read from the \"license\" field. Note that you can't specify non-empty values in both \"license\" and \"licenseSecretName\", only one of these fields can be used to pass the license string. The license needs to be stored under the key \"license\".",
           "type": "string"
         },
         "nodeSelector": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Selector for nodes that could fit Redis Enterprise pod",
           "type": "object"
         },
         "nodes": {
-          "description": "Number of Redis Enterprise nodes (pods)",
           "format": "int32",
           "type": "integer"
         },
-        "persistentSpec": {
-          "description": "Specification for Redis Enterprise Cluster persistence",
+        "ocspConfiguration": {
           "properties": {
+            "ocspFunctionality": {
+              "type": "boolean"
+            },
+            "queryFrequency": {
+              "type": "integer"
+            },
+            "recoveryFrequency": {
+              "type": "integer"
+            },
+            "recoveryMaxTries": {
+              "type": "integer"
+            },
+            "responseTimeout": {
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "persistentSpec": {
+          "properties": {
+            "enablePersistentVolumeResize": {
+              "type": "boolean"
+            },
             "enabled": {
-              "description": "Whether to add persistent volume to Redis Enterprise pods",
               "type": "boolean"
             },
             "storageClassName": {
-              "description": "Storage class for persistent volume in Redis Enterprise pods Leave empty to use the default",
               "type": "string"
             },
             "volumeSize": {
@@ -261,11 +550,10 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "pod annotations",
+          "description": "annotations for the service rigger and redis enterprise pods",
           "type": "object"
         },
         "podAntiAffinity": {
-          "description": "Override for the default anti-affinity rules of the Redis Enterprise pods. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#an-example-of-a-pod-that-uses-pod-affinity",
           "properties": {
             "preferredDuringSchedulingIgnoredDuringExecution": {
               "items": {
@@ -476,18 +764,14 @@
           "additionalProperties": false
         },
         "podSecurityPolicyName": {
-          "description": "Name of pod security policy to use on pods See https://kubernetes.io/docs/concepts/policy/pod-security-policy/",
           "type": "string"
         },
         "podStartingPolicy": {
-          "description": "Mitigation setting for STS pods stuck in \"ContainerCreating\"",
           "properties": {
             "enabled": {
-              "description": "Whether to detect and attempt to mitigate pod startup issues",
               "type": "boolean"
             },
             "startingThresholdSeconds": {
-              "description": "Time in seconds to wait for a pod to be stuck while starting up before action is taken. If set to 0, will be treated as if disabled.",
               "format": "int32",
               "type": "integer"
             }
@@ -500,7 +784,6 @@
           "additionalProperties": false
         },
         "podTolerations": {
-          "description": "Tolerations that are added to all managed pods. More information: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
           "items": {
             "properties": {
               "effect": {
@@ -526,15 +809,12 @@
           "type": "array"
         },
         "priorityClassName": {
-          "description": "Adds the priority class to pods managed by the operator",
           "type": "string"
         },
         "pullSecrets": {
-          "description": "PullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/",
           "items": {
             "properties": {
               "name": {
-                "description": "Secret name",
                 "type": "string"
               }
             },
@@ -544,11 +824,9 @@
           "type": "array"
         },
         "rackAwarenessNodeLabel": {
-          "description": "Node label that specifies rack ID - if specified, will create rack aware cluster. Rack awareness requires node label must exist on all nodes. Additionally, operator needs a special cluster role with permission to list nodes.",
           "type": "string"
         },
         "redisEnterpriseAdditionalPodSpecAttributes": {
-          "description": "ADVANCED USAGE USE AT YOUR OWN RISK - specify pod attributes that are required for the statefulset - Redis Enterprise pods. Pod attributes managed by the operator might override these settings. Also make sure the attributes are supported by the K8s version running on the cluster - the operator does not validate that.",
           "properties": {
             "activeDeadlineSeconds": {
               "format": "int64",
@@ -1530,6 +1808,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -1676,6 +1970,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -1773,6 +2083,23 @@
                   },
                   "resources": {
                     "properties": {
+                      "claims": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -1922,6 +2249,22 @@
                       "failureThreshold": {
                         "format": "int32",
                         "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "httpGet": {
                         "properties": {
@@ -2123,6 +2466,9 @@
               "type": "boolean"
             },
             "hostPID": {
+              "type": "boolean"
+            },
+            "hostUsers": {
               "type": "boolean"
             },
             "hostname": {
@@ -2501,6 +2847,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -2652,6 +3014,22 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
                         "properties": {
                           "host": {
@@ -2749,6 +3127,23 @@
                   },
                   "resources": {
                     "properties": {
+                      "claims": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "set"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -2898,6 +3293,22 @@
                       "failureThreshold": {
                         "format": "int32",
                         "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "httpGet": {
                         "properties": {
@@ -3081,6 +3492,18 @@
               "type": "object",
               "x-kubernetes-map-type": "atomic"
             },
+            "os": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "overhead": {
               "additionalProperties": {
                 "anyOf": [
@@ -3121,6 +3544,37 @@
               },
               "type": "array"
             },
+            "resourceClaims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "properties": {
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
             "restartPolicy": {
               "type": "string"
             },
@@ -3129,6 +3583,25 @@
             },
             "schedulerName": {
               "type": "string"
+            },
+            "schedulingGates": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
             },
             "securityContext": {
               "properties": {
@@ -3315,9 +3788,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "matchLabelKeys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "maxSkew": {
                     "format": "int32",
                     "type": "integer"
+                  },
+                  "minDomains": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string"
                   },
                   "topologyKey": {
                     "type": "string"
@@ -3684,6 +4174,9 @@
                                   },
                                   "name": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
                                   }
                                 },
                                 "required": [
@@ -3695,6 +4188,23 @@
                               },
                               "resources": {
                                 "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "set"
+                                  },
                                   "limits": {
                                     "additionalProperties": {
                                       "anyOf": [
@@ -4454,15 +4964,22 @@
           "type": "object",
           "additionalProperties": false
         },
+        "redisEnterpriseIPFamily": {
+          "enum": [
+            "IPv4",
+            "IPv6"
+          ],
+          "type": "string"
+        },
         "redisEnterpriseImageSpec": {
-          "description": "Specification for Redis Enterprise container image",
           "properties": {
+            "digestHash": {
+              "type": "string"
+            },
             "imagePullPolicy": {
-              "description": "PullPolicy describes a policy for if/when to pull a container image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository",
               "type": "string"
             },
             "versionTag": {
@@ -4473,8 +4990,24 @@
           "additionalProperties": false
         },
         "redisEnterpriseNodeResources": {
-          "description": "Compute resource requirements for Redis Enterprise containers",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
             "limits": {
               "additionalProperties": {
                 "anyOf": [
@@ -4488,7 +5021,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
               "type": "object"
             },
             "requests": {
@@ -4504,20 +5036,24 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
               "type": "object"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
+        "redisEnterprisePodAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "annotations for redis enterprise pod",
+          "type": "object"
+        },
         "redisEnterpriseServicesConfiguration": {
-          "description": "RS Cluster optional services settings",
           "properties": {
             "cmServer": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the CM server",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4534,7 +5070,6 @@
             "crdbCoordinator": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the crdb coordinator process",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4551,7 +5086,6 @@
             "crdbWorker": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the crdb worker processes",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4568,7 +5102,6 @@
             "mdnsServer": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the Multicast DNS server",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4585,7 +5118,6 @@
             "pdnsServer": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the pdns server",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4602,7 +5134,6 @@
             "saslauthd": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the saslauthd service",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4619,7 +5150,6 @@
             "statsArchiver": {
               "properties": {
                 "operatingMode": {
-                  "description": "Whether to enable/disable the stats archiver service",
                   "enum": [
                     "enabled",
                     "disabled"
@@ -4638,14 +5168,14 @@
           "additionalProperties": false
         },
         "redisEnterpriseServicesRiggerImageSpec": {
-          "description": "Specification for Services Rigger container image",
           "properties": {
+            "digestHash": {
+              "type": "string"
+            },
             "imagePullPolicy": {
-              "description": "PullPolicy describes a policy for if/when to pull a container image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository",
               "type": "string"
             },
             "versionTag": {
@@ -4656,8 +5186,24 @@
           "additionalProperties": false
         },
         "redisEnterpriseServicesRiggerResources": {
-          "description": "Compute resource requirements for Services Rigger pod",
           "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
             "limits": {
               "additionalProperties": {
                 "anyOf": [
@@ -4671,7 +5217,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
               "type": "object"
             },
             "requests": {
@@ -4687,7 +5232,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
               "type": "object"
             }
           },
@@ -4695,12 +5239,10 @@
           "additionalProperties": false
         },
         "redisEnterpriseTerminationGracePeriodSeconds": {
-          "description": "The TerminationGracePeriodSeconds value for the (STS created) REC pods",
           "format": "int64",
           "type": "integer"
         },
         "redisEnterpriseVolumeMounts": {
-          "description": "additional volume mounts within the redis enterprise containers. More info: https://kubernetes.io/docs/concepts/storage/volumes/",
           "items": {
             "properties": {
               "mountPath": {
@@ -4731,52 +5273,111 @@
           },
           "type": "array"
         },
+        "redisOnFlashSpec": {
+          "properties": {
+            "bigStoreDriver": {
+              "enum": [
+                "rocksdb",
+                "speedb"
+              ],
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "flashDiskSize": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            },
+            "flashStorageEngine": {
+              "enum": [
+                "rocksdb"
+              ],
+              "type": "string"
+            },
+            "storageClassName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "enabled",
+            "storageClassName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "redisUpgradePolicy": {
-          "description": "Redis upgrade policy to be set on the Redis Enterprise Cluster. Possible values: major/latest This value is used by the cluster to choose the Redis version of the database when an upgrade is performed. The Redis Enterprise Cluster includes multiple versions of OSS Redis that can be used for databases.",
           "enum": [
             "major",
             "latest"
           ],
           "type": "string"
         },
+        "resp3Default": {
+          "type": "boolean"
+        },
         "serviceAccountName": {
-          "description": "Name of the service account to use",
           "type": "string"
         },
+        "services": {
+          "properties": {
+            "apiService": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "servicesAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "servicesRiggerSpec": {
-          "description": "Specification for service rigger",
           "properties": {
             "databaseServiceType": {
-              "description": "Service types for access to databases. should be a comma separated list. The possible values are cluster_ip, headless and load_balancer.",
               "type": "string"
             },
             "extraEnvVars": {
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container. More info: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.",
                     "type": "string"
                   },
                   "value": {
                     "type": "string"
                   },
                   "valueFrom": {
-                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                     "properties": {
                       "configMapKeyRef": {
-                        "description": "Selects a key of a ConfigMap.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
-                            "description": "Name of the referent",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -4787,14 +5388,11 @@
                         "additionalProperties": false
                       },
                       "fieldRef": {
-                        "description": "Selects a field of the pod",
                         "properties": {
                           "apiVersion": {
-                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                             "type": "string"
                           },
                           "fieldPath": {
-                            "description": "Path of the field to select in the specified API version.",
                             "type": "string"
                           }
                         },
@@ -4805,10 +5403,8 @@
                         "additionalProperties": false
                       },
                       "resourceFieldRef": {
-                        "description": "Selects a resource of the container: only resources limits and requests are currently supported.",
                         "properties": {
                           "containerName": {
-                            "description": "Container name: required for volumes, optional for env vars",
                             "type": "string"
                           },
                           "divisor": {
@@ -4820,12 +5416,10 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "resource": {
-                            "description": "Required: resource to select",
                             "type": "string"
                           }
                         },
@@ -4836,18 +5430,14 @@
                         "additionalProperties": false
                       },
                       "secretKeyRef": {
-                        "description": "Selects a key of a secret in the pod's namespace",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
-                            "description": "Name of the referent",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -4870,7 +5460,15 @@
               },
               "type": "array"
             },
+            "podAnnotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "annotations for the service rigger pod",
+              "type": "object"
+            },
             "serviceNaming": {
+              "description": "Used to determine how to name the services created automatically when a database is created. When bdb_name is used, the database name will be also used for the service name. When redis-port is used, the service will be named redis-<port>.",
               "enum": [
                 "bdb_name",
                 "redis-port"
@@ -4878,7 +5476,6 @@
               "type": "string"
             },
             "servicesRiggerAdditionalPodSpecAttributes": {
-              "description": "ADVANCED USAGE USE AT YOUR OWN RISK - specify pod attributes that are required for the rigger deployment pod. Pod attributes managed by the operator might override these settings (Containers, serviceAccountName, podTolerations, ImagePullSecrets, nodeSelector, PriorityClassName, PodSecurityContext). Also make sure the attributes are supported by the K8s version running on the cluster - the operator does not validate that.",
               "properties": {
                 "activeDeadlineSeconds": {
                   "format": "int64",
@@ -5860,6 +6457,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -6006,6 +6619,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -6103,6 +6732,23 @@
                       },
                       "resources": {
                         "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -6252,6 +6898,22 @@
                           "failureThreshold": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -6453,6 +7115,9 @@
                   "type": "boolean"
                 },
                 "hostPID": {
+                  "type": "boolean"
+                },
+                "hostUsers": {
                   "type": "boolean"
                 },
                 "hostname": {
@@ -6831,6 +7496,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -6982,6 +7663,22 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
                             "properties": {
                               "host": {
@@ -7079,6 +7776,23 @@
                       },
                       "resources": {
                         "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -7228,6 +7942,22 @@
                           "failureThreshold": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -7411,6 +8141,18 @@
                   "type": "object",
                   "x-kubernetes-map-type": "atomic"
                 },
+                "os": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "overhead": {
                   "additionalProperties": {
                     "anyOf": [
@@ -7451,6 +8193,37 @@
                   },
                   "type": "array"
                 },
+                "resourceClaims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "properties": {
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
                 "restartPolicy": {
                   "type": "string"
                 },
@@ -7459,6 +8232,25 @@
                 },
                 "schedulerName": {
                   "type": "string"
+                },
+                "schedulingGates": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "securityContext": {
                   "properties": {
@@ -7645,9 +8437,26 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "matchLabelKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
                       "maxSkew": {
                         "format": "int32",
                         "type": "integer"
+                      },
+                      "minDomains": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -8014,6 +8823,9 @@
                                       },
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
                                       }
                                     },
                                     "required": [
@@ -8025,6 +8837,23 @@
                                   },
                                   "resources": {
                                     "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      },
                                       "limits": {
                                         "additionalProperties": {
                                           "anyOf": [
@@ -9149,6 +9978,22 @@
                     "format": "int32",
                     "type": "integer"
                   },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "httpGet": {
                     "properties": {
                       "host": {
@@ -9300,6 +10145,22 @@
                     "format": "int32",
                     "type": "integer"
                   },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "httpGet": {
                     "properties": {
                       "host": {
@@ -9397,6 +10258,23 @@
               },
               "resources": {
                 "properties": {
+                  "claims": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                  },
                   "limits": {
                     "additionalProperties": {
                       "anyOf": [
@@ -9546,6 +10424,22 @@
                   "failureThreshold": {
                     "format": "int32",
                     "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "httpGet": {
                     "properties": {
@@ -9720,10 +10614,8 @@
           "type": "array"
         },
         "slaveHA": {
-          "description": "Slave high availability mechanism configuration.",
           "properties": {
             "slaveHAGracePeriod": {
-              "description": "Time in seconds between when a node fails, and when slave high availability mechanism starts relocating shards. If set to 0, will not affect cluster configuration.",
               "format": "int32",
               "type": "integer"
             }
@@ -9738,11 +10630,9 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Annotations for Redis Enterprise UI service",
           "type": "object"
         },
         "uiServiceType": {
-          "description": "Type of service used to expose Redis Enterprise UI (https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)",
           "enum": [
             "ClusterIP",
             "NodePort",
@@ -9752,10 +10642,8 @@
           "type": "string"
         },
         "upgradeSpec": {
-          "description": "Specification for upgrades of Redis Enterprise",
           "properties": {
             "autoUpgradeRedisEnterprise": {
-              "description": "Whether to upgrade Redis Enterprise automatically when operator is upgraded",
               "type": "boolean"
             }
           },
@@ -9766,17 +10654,13 @@
           "additionalProperties": false
         },
         "username": {
-          "description": "Username for the admin user of Redis Enterprise",
           "type": "string"
         },
         "vaultCASecret": {
-          "description": "K8s secret name containing Vault's CA cert - defaults to \"vault-ca-cert\"",
           "type": "string"
         },
         "volumes": {
-          "description": "additional volumes",
           "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
             "properties": {
               "awsElasticBlockStore": {
                 "properties": {
@@ -10744,11 +11628,13 @@
     "status": {
       "properties": {
         "bundledDatabaseVersions": {
-          "description": "Versions of open source databases bundled by Redis Enterprise Software - please note that in order to use a specific version it should be supported by the \u2018upgradePolicy\u2019 - \u2018major\u2019 or \u2018latest\u2019 according to the desired version (major/minor)",
           "items": {
             "properties": {
               "dbType": {
                 "type": "string"
+              },
+              "major": {
+                "type": "boolean"
               },
               "version": {
                 "type": "string"
@@ -10763,6 +11649,9 @@
           },
           "type": "array"
         },
+        "ingressOrRouteMethodStatus": {
+          "type": "string"
+        },
         "licenseStatus": {
           "properties": {
             "activationDate": {
@@ -10776,6 +11665,15 @@
             },
             "shardsLimit": {
               "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "managedAPIs": {
+          "properties": {
+            "ldap": {
+              "type": "boolean"
             }
           },
           "type": "object",
@@ -10803,35 +11701,43 @@
           "type": "array"
         },
         "ocspStatus": {
-          "description": "An API object that represents the cluster's OCSP status",
           "properties": {
             "certStatus": {
-              "description": "Indicates the proxy certificate status - GOOD/REVOKED/UNKNOWN.",
               "type": "string"
             },
             "nextUpdate": {
-              "description": "The time at or before which newer information will be available about the status of the certificate (if available)",
               "type": "string"
             },
             "producedAt": {
-              "description": "The time at which the OCSP responder signed this response.",
               "type": "string"
             },
             "responderUrl": {
-              "description": "The OCSP responder url from which this status came from.",
               "type": "string"
             },
             "revocationTime": {
-              "description": "The time at which the certificate was revoked or placed on hold.",
               "type": "string"
             },
             "thisUpdate": {
-              "description": "The most recent time at which the status being indicated is known by the responder to have been correct.",
               "type": "string"
             }
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "persistenceStatus": {
+          "properties": {
+            "status": {
+              "type": "string"
+            },
+            "succeeded": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "redisEnterpriseIPFamily": {
+          "type": "string"
         },
         "specStatus": {
           "type": "string"

--- a/app.redislabs.com/redisenterprisedatabase_v1alpha1.json
+++ b/app.redislabs.com/redisenterprisedatabase_v1alpha1.json
@@ -357,7 +357,7 @@
           "type": "integer"
         },
         "databaseSecretName": {
-          "description": "The name of the K8s secret that holds the password to the database.",
+          "description": "The name of the secret that holds the password to the database (redis databases only). If secret does not exist, it will be created. To define the password, create an opaque secret and set the name in the spec. The password will be taken from the value of the 'password' key. Use an empty string as value within the secret to disable authentication for the database. Notes - For Active-Active databases this secret will not be automatically created, and also, memcached databases must not be set with a value, and a secret/password will not be automatically created for them. Use the memcachedSaslSecretName field to set authentication parameters for memcached databases.",
           "type": "string"
         },
         "defaultUser": {
@@ -368,16 +368,20 @@
           "description": "Database eviction policy. see more https://docs.redislabs.com/latest/rs/administering/database-operations/eviction-policy/",
           "type": "string"
         },
+        "isRof": {
+          "description": "Whether it is an RoF database or not. Applicable only for databases of type \"REDIS\". Assumed to be false if left blank.",
+          "type": "boolean"
+        },
         "memcachedSaslSecretName": {
           "description": "Credentials used for binary authentication in memcached databases. The credentials should be saved as an opaque secret and the name of that secret should be configured using this field. For username, use 'username' as the key and the actual username as the value. For password, use 'password' as the key and the actual password as the value. Note that connections are not encrypted.",
           "type": "string"
         },
         "memorySize": {
-          "description": "memory size of database. use formats like 100MB, 0.1GB. minimum value in 100MB.",
+          "description": "memory size of database. use formats like 100MB, 0.1GB. minimum value in 100MB. When redis on flash (RoF) is enabled, this value refers to RAM+Flash memory, and it must not be below 1GB.",
           "type": "string"
         },
         "modulesList": {
-          "description": "List of modules associated with database",
+          "description": "List of modules associated with database. Note - For Active-Active databases this feature is currently in preview. For this feature to take effect for Active-Active databases, set a boolean environment variable with the name \"ENABLE_ALPHA_FEATURES\" to True. This variable can be set via the redis-enterprise-operator pod spec, or through the operator-environment-config Config Map.",
           "items": {
             "description": "Redis Enterprise Module: https://redislabs.com/redis-enterprise/modules/",
             "properties": {
@@ -390,13 +394,12 @@
                 "type": "string"
               },
               "version": {
-                "description": "Module's semantic version e.g \"1.6.12\"",
+                "description": "Module's semantic version e.g \"1.6.12\" - optional only in REDB, must be set in REAADB",
                 "type": "string"
               }
             },
             "required": [
-              "name",
-              "version"
+              "name"
             ],
             "type": "object",
             "additionalProperties": false
@@ -442,11 +445,7 @@
           "additionalProperties": false
         },
         "redisVersion": {
-          "description": "Redis OSS version. For existing databases - Upgrade Redis OSS version. For new databases - the version which the database will be created with. If set to 'major' - will always upgrade to the most recent major Redis version. If set to 'latest' - will always upgrade to the most recent Redis version. Depends on 'redisUpgradePolicy' - if you want to set the value to 'latest' for some databases, you must set redisUpgradePolicy on the cluster before. Possible values are 'major' or 'latest' When using upgrade - make sure to backup the database before. This value is used only for database type 'redis'",
-          "enum": [
-            "major",
-            "latest"
-          ],
+          "description": "Redis OSS version. Version can be specified via <major.minor> prefix, or via channels - for existing databases - Upgrade Redis OSS version. For new databases - the version which the database will be created with. If set to 'major' - will always upgrade to the most recent major Redis version. If set to 'latest' - will always upgrade to the most recent Redis version. Depends on 'redisUpgradePolicy' - if you want to set the value to 'latest' for some databases, you must set redisUpgradePolicy on the cluster before. Possible values are 'major' or 'latest' When using upgrade - make sure to backup the database before. This value is used only for database type 'redis'",
           "type": "string"
         },
         "replicaSources": {
@@ -454,27 +453,27 @@
           "items": {
             "properties": {
               "clientKeySecret": {
-                "description": "Secret that defines what client key to use.  The secret needs 2 keys in it's map, \"cert\" that is the PEM encoded certificate and \"key\" that is the PEM encoded private key",
+                "description": "Secret that defines the client certificate and key used by the syncer in the target database cluster. The secret must have 2 keys in its map: \"cert\" which is the PEM encoded certificate, and \"key\" which is the PEM encoded private key.",
                 "type": "string"
               },
               "compression": {
-                "description": "GZIP Compression level (0-9) to use for replication",
+                "description": "GZIP compression level (0-6) to use for replication.",
                 "type": "integer"
               },
               "replicaSourceName": {
-                "description": "Kubernetes resource name of type ReplicaSourceType",
+                "description": "The name of the resource from which the source database URI is derived. The type of resource must match the type specified in the ReplicaSourceType field.",
                 "type": "string"
               },
               "replicaSourceType": {
-                "description": "Determines what Kuberetes resource ReplicaSourceName refers to SECRET - Get URI from secret named in ReplicaSourceName.  The secret will have a uri key that defines the complete, redis:// URI REDB - Determine URI from Kubernetes REDB resource named in ReplicaSourceName",
+                "description": "The type of resource from which the source database URI is derived. If set to 'SECRET', the source database URI is derived from the secret named in the ReplicaSourceName field. The secret must have a key named 'uri' that defines the URI of the source database in the form of 'redis://...'. The type of secret (kubernetes, vault, ...) is determined by the secret mechanism used by the underlying REC object. If set to 'REDB', the source database URI is derived from the RedisEnterpriseDatabase resource named in the ReplicaSourceName field.",
                 "type": "string"
               },
               "serverCertSecret": {
-                "description": "Secret that defines the Server's certificate.  The secret needs 1 key in it's map, \"cert\" that is the PEM encoded certificate",
+                "description": "Secret that defines the server certificate used by the proxy in the source database cluster. The secret must have 1 key in its map: \"cert\" which is the PEM encoded certificate.",
                 "type": "string"
               },
               "tlsSniName": {
-                "description": "TLS SNI Name to use",
+                "description": "TLS SNI name to use for the replication link.",
                 "type": "string"
               }
             },
@@ -488,8 +487,16 @@
           "type": "array"
         },
         "replication": {
-          "description": "In-memory database replication. When enabled, database will have replica shard for every master - leading to higher availability.",
+          "description": "In-memory database replication. When enabled, database will have replica shard for every master - leading to higher availability. Defaults to false.",
           "type": "boolean"
+        },
+        "resp3": {
+          "description": "Whether this database supports RESP3 protocol. Note - Deleting this property after explicitly setting its value shall have no effect. Please view the corresponding field in RS doc for more info.",
+          "type": "boolean"
+        },
+        "rofRamSize": {
+          "description": "The size of the RAM portion of an RoF database. Similarly to \"memorySize\" use formats like 100MB, 0.1GB. It must be at least 10% of combined memory size (RAM and Flash), as specified by \"memorySize\".",
+          "type": "string"
         },
         "rolesPermissions": {
           "description": "List of Redis Enteprise ACL and Role bindings to apply",
@@ -523,6 +530,10 @@
           "description": "Number of database server-side shards",
           "type": "integer"
         },
+        "shardingEnabled": {
+          "description": "Toggles database sharding for REAADBs (Active Active databases) and enabled by default. This field is blocked for REDB (non-Active Active databases) and sharding is toggled via the shardCount field - when shardCount is 1 this is disabled otherwise enabled.",
+          "type": "boolean"
+        },
         "shardsPlacement": {
           "description": "Control the density of shards - should they reside on as few or as many nodes as possible. Available options are \"dense\" or \"sparse\". If left unset, defaults to \"dense\".",
           "enum": [
@@ -547,6 +558,20 @@
             "memcached"
           ],
           "type": "string"
+        },
+        "upgradeSpec": {
+          "description": "Specifications for DB upgrade.",
+          "properties": {
+            "upgradeModulesToLatest": {
+              "description": "Upgrades the modules to the latest version that supportes the DB version during a DB upgrade action, to upgrade the DB version view the 'redisVersion' field. Notes - All modules must be without specifing the version. in addition, This field is currently not supported for Active-Active databases.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "upgradeModulesToLatest"
+          ],
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -555,9 +580,24 @@
     "status": {
       "description": "RedisEnterpriseDatabaseStatus defines the observed state of RedisEnterpriseDatabase",
       "properties": {
-        "activeActiveName": {
-          "description": "The Redis Enterprise Active Active Peering custom resource this Resource is associated with, also, the corresponding active active database name. Note: this feature is currently unsupported.",
-          "type": "string"
+        "activeActive": {
+          "description": "Connection/ association to the Active-Active database.",
+          "properties": {
+            "name": {
+              "description": "The the corresponding Active-Active database name, Redis Enterprise Active Active Database custom resource name, this Resource is associated with. In case this resource is created manually at the active active database creation this field must be filled via the user, otherwise, the operator will assign this field automatically. Note: this feature is currently unsupported.",
+              "type": "string"
+            },
+            "participatingClusterName": {
+              "description": "The corresponding participating cluster name, Redis Enterprise Remote Cluster custom resource name, in the Active-Active database, In case this resource is created manually at the active active database creation this field must be filled via the user, otherwise, the operator will assign this field automatically. Note: this feature is currently unsupported.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "participatingClusterName"
+          ],
+          "type": "object",
+          "additionalProperties": false
         },
         "backupInfo": {
           "description": "Information on the database's periodic backup",
@@ -591,9 +631,6 @@
               "type": "string"
             }
           },
-          "required": [
-            "backupHistory"
-          ],
           "type": "object",
           "additionalProperties": false
         },
@@ -604,10 +641,6 @@
         "databaseUID": {
           "description": "Database UID provided by redis enterprise",
           "type": "string"
-        },
-        "globalConfigurations": {
-          "description": "Flag to determine if this is the default global configurations for active active database. Note: this feature is currently unsupported.",
-          "type": "boolean"
         },
         "internalEndpoints": {
           "description": "Endpoints listed internally by the Redis Enterprise Cluster. Can be used to correlate a ReplicaSourceStatus entry.",

--- a/app.redislabs.com/redisenterpriseremotecluster_v1alpha1.json
+++ b/app.redislabs.com/redisenterpriseremotecluster_v1alpha1.json
@@ -1,0 +1,68 @@
+{
+  "description": "RedisEntepriseRemoteCluster represents a remote participating cluster.",
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "status": {
+      "properties": {
+        "local": {
+          "description": "Indicates whether this object represents a local or a remote cluster.",
+          "type": "boolean"
+        },
+        "specStatus": {
+          "description": "Whether the desired specification is valid.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the remote cluster.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "The most recent generation observed for this RERC. It corresponds to the RERC's generation, which is updated by the API Server.",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "spec": {
+      "properties": {
+        "apiFqdnUrl": {
+          "description": "The URL of the cluster, will be used for the active-active database URL.",
+          "type": "string"
+        },
+        "dbFqdnSuffix": {
+          "description": "The database URL suffix, will be used for the active-active database replication endpoint and replication endpoint SNI.",
+          "type": "string"
+        },
+        "recNamespace": {
+          "description": "The namespace of the REC that the RERC is pointing at",
+          "type": "string"
+        },
+        "recName": {
+          "description": "The name of the REC that the RERC is pointing at",
+          "type": "string"
+        },
+        "secretName": {
+          "description": "The name of the secret containing cluster credentials. Must be of the following format: \"redis-enterprise-<RERC name>\"",
+          "type": "string"
+        }
+      },
+      "required": [
+        "apiFqdnUrl",
+        "recName",
+        "recNamespace"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Follow up to #383

When looking further, I realized that the manifest I was using was out of date. I've re-generated using the latest manifests: https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/redis-enterprise-operator-cert/7.4.6-2.0/manifests

Redis enterprise operator is now maintained as part of the official redhat ecosystem certified operators.

```
rm -rf app.redislabs.com && mkdir -p app.redislabs.com && pushd app.redislabs.com && \
curl -sO https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py && \
python openapi2jsonschema.py \
    https://github.com/redhat-openshift-ecosystem/certified-operators/raw/main/operators/redis-enterprise-operator-cert/7.4.6-2.0/manifests/reaadb_crd.yaml \
    https://github.com/redhat-openshift-ecosystem/certified-operators/raw/main/operators/redis-enterprise-operator-cert/7.4.6-2.0/manifests/rec_crd.yaml \
    https://github.com/redhat-openshift-ecosystem/certified-operators/raw/main/operators/redis-enterprise-operator-cert/7.4.6-2.0/manifests/redb_crd.yaml \
    https://github.com/redhat-openshift-ecosystem/certified-operators/raw/main/operators/redis-enterprise-operator-cert/7.4.6-2.0/manifests/rerc_crd.yaml && \
rm openapi2jsonschema.py && popd
```