### PR TITLE
feat: upgrade flink crd to flink-kubernetes-operator 1.9

### DIFF
--- a/flink.apache.org/flinkdeployment_v1beta1.json
+++ b/flink.apache.org/flinkdeployment_v1beta1.json
@@ -15,7 +15,8 @@
             "v1_15",
             "v1_16",
             "v1_17",
-            "v1_18"
+            "v1_18",
+            "v1_19"
           ],
           "type": "string"
         },
@@ -36,8 +37,32 @@
             "className": {
               "type": "string"
             },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
             "template": {
               "type": "string"
+            },
+            "tls": {
+              "items": {
+                "properties": {
+                  "hosts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "secretName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
             }
           },
           "type": "object",
@@ -69,6 +94,9 @@
             "parallelism": {
               "type": "integer"
             },
+            "savepointRedeployNonce": {
+              "type": "integer"
+            },
             "savepointTriggerNonce": {
               "type": "integer"
             },
@@ -81,8 +109,8 @@
             },
             "upgradeMode": {
               "enum": [
-                "savepoint",
                 "last-state",
+                "savepoint",
                 "stateless"
               ],
               "type": "string"
@@ -382,6 +410,18 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
                                       "namespaceSelector": {
                                         "properties": {
                                           "matchExpressions": {
@@ -472,6 +512,18 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -565,6 +617,18 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
                                       "namespaceSelector": {
                                         "properties": {
                                           "matchExpressions": {
@@ -655,6 +719,18 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -915,6 +991,15 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "tcpSocket": {
                                     "properties": {
                                       "host": {
@@ -989,6 +1074,15 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
                                       }
                                     },
                                     "type": "object",
@@ -1267,6 +1361,21 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "resources": {
                             "properties": {
                               "claims": {
@@ -1312,6 +1421,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
                           },
                           "securityContext": {
                             "properties": {
@@ -1820,6 +1932,15 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "tcpSocket": {
                                     "properties": {
                                       "host": {
@@ -1894,6 +2015,15 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
                                       }
                                     },
                                     "type": "object",
@@ -2172,6 +2302,21 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "resources": {
                             "properties": {
                               "claims": {
@@ -2217,6 +2362,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
                           },
                           "securityContext": {
                             "properties": {
@@ -2734,6 +2882,15 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "tcpSocket": {
                                     "properties": {
                                       "host": {
@@ -2808,6 +2965,15 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
                                       }
                                     },
                                     "type": "object",
@@ -3086,6 +3252,21 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "resources": {
                             "properties": {
                               "claims": {
@@ -3131,6 +3312,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
                           },
                           "securityContext": {
                             "properties": {
@@ -4113,18 +4297,6 @@
                                       },
                                       "resources": {
                                         "properties": {
-                                          "claims": {
-                                            "items": {
-                                              "properties": {
-                                                "name": {
-                                                  "type": "string"
-                                                }
-                                              },
-                                              "type": "object",
-                                              "additionalProperties": false
-                                            },
-                                            "type": "array"
-                                          },
                                           "limits": {
                                             "additionalProperties": {
                                               "anyOf": [
@@ -4191,6 +4363,9 @@
                                         "additionalProperties": false
                                       },
                                       "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
                                         "type": "string"
                                       },
                                       "volumeMode": {
@@ -4453,6 +4628,57 @@
                               "sources": {
                                 "items": {
                                   "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "configMap": {
                                       "properties": {
                                         "items": {
@@ -4819,6 +5045,20 @@
                     "containerStatuses": {
                       "items": {
                         "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
                           "containerID": {
                             "type": "string"
                           },
@@ -4887,6 +5127,52 @@
                           },
                           "ready": {
                             "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "restartCount": {
                             "type": "integer"
@@ -4957,6 +5243,20 @@
                     "ephemeralContainerStatuses": {
                       "items": {
                         "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
                           "containerID": {
                             "type": "string"
                           },
@@ -5025,6 +5325,52 @@
                           },
                           "ready": {
                             "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "restartCount": {
                             "type": "integer"
@@ -5095,9 +5441,35 @@
                     "hostIP": {
                       "type": "string"
                     },
+                    "hostIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "initContainerStatuses": {
                       "items": {
                         "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
                           "containerID": {
                             "type": "string"
                           },
@@ -5166,6 +5538,52 @@
                           },
                           "ready": {
                             "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "restartCount": {
                             "type": "integer"
@@ -5262,6 +5680,24 @@
                     },
                     "reason": {
                       "type": "string"
+                    },
+                    "resize": {
+                      "type": "string"
+                    },
+                    "resourceClaimStatuses": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
                     },
                     "startTime": {
                       "type": "string"
@@ -5598,6 +6034,18 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "namespaceSelector": {
                                     "properties": {
                                       "matchExpressions": {
@@ -5688,6 +6136,18 @@
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -5781,6 +6241,18 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "namespaceSelector": {
                                     "properties": {
                                       "matchExpressions": {
@@ -5871,6 +6343,18 @@
                                 },
                                 "type": "object",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -6131,6 +6615,15 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
                                 "properties": {
                                   "host": {
@@ -6205,6 +6698,15 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
                                   }
                                 },
                                 "type": "object",
@@ -6483,6 +6985,21 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "resources": {
                         "properties": {
                           "claims": {
@@ -6528,6 +7045,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
                       },
                       "securityContext": {
                         "properties": {
@@ -7036,6 +7556,15 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
                                 "properties": {
                                   "host": {
@@ -7110,6 +7639,15 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
                                   }
                                 },
                                 "type": "object",
@@ -7388,6 +7926,21 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "resources": {
                         "properties": {
                           "claims": {
@@ -7433,6 +7986,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
                       },
                       "securityContext": {
                         "properties": {
@@ -7950,6 +8506,15 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
                                 "properties": {
                                   "host": {
@@ -8024,6 +8589,15 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
                                   }
                                 },
                                 "type": "object",
@@ -8302,6 +8876,21 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "resources": {
                         "properties": {
                           "claims": {
@@ -8347,6 +8936,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
                       },
                       "securityContext": {
                         "properties": {
@@ -9329,18 +9921,6 @@
                                   },
                                   "resources": {
                                     "properties": {
-                                      "claims": {
-                                        "items": {
-                                          "properties": {
-                                            "name": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "type": "object",
-                                          "additionalProperties": false
-                                        },
-                                        "type": "array"
-                                      },
                                       "limits": {
                                         "additionalProperties": {
                                           "anyOf": [
@@ -9407,6 +9987,9 @@
                                     "additionalProperties": false
                                   },
                                   "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
                                     "type": "string"
                                   },
                                   "volumeMode": {
@@ -9669,6 +10252,57 @@
                           "sources": {
                             "items": {
                               "properties": {
+                                "clusterTrustBundle": {
+                                  "properties": {
+                                    "labelSelector": {
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
                                 "configMap": {
                                   "properties": {
                                     "items": {
@@ -10035,6 +10669,20 @@
                 "containerStatuses": {
                   "items": {
                     "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
                       "containerID": {
                         "type": "string"
                       },
@@ -10103,6 +10751,52 @@
                       },
                       "ready": {
                         "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartCount": {
                         "type": "integer"
@@ -10173,6 +10867,20 @@
                 "ephemeralContainerStatuses": {
                   "items": {
                     "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
                       "containerID": {
                         "type": "string"
                       },
@@ -10241,6 +10949,52 @@
                       },
                       "ready": {
                         "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartCount": {
                         "type": "integer"
@@ -10311,9 +11065,35 @@
                 "hostIP": {
                   "type": "string"
                 },
+                "hostIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "initContainerStatuses": {
                   "items": {
                     "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
                       "containerID": {
                         "type": "string"
                       },
@@ -10382,6 +11162,52 @@
                       },
                       "ready": {
                         "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartCount": {
                         "type": "integer"
@@ -10478,6 +11304,24 @@
                 },
                 "reason": {
                   "type": "string"
+                },
+                "resize": {
+                  "type": "string"
+                },
+                "resourceClaimStatuses": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
                 },
                 "startTime": {
                   "type": "string"
@@ -10787,6 +11631,18 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
                                       "namespaceSelector": {
                                         "properties": {
                                           "matchExpressions": {
@@ -10877,6 +11733,18 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -10970,6 +11838,18 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
                                       "namespaceSelector": {
                                         "properties": {
                                           "matchExpressions": {
@@ -11060,6 +11940,18 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
                                   },
                                   "namespaceSelector": {
                                     "properties": {
@@ -11320,6 +12212,15 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "tcpSocket": {
                                     "properties": {
                                       "host": {
@@ -11394,6 +12295,15 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
                                       }
                                     },
                                     "type": "object",
@@ -11672,6 +12582,21 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "resources": {
                             "properties": {
                               "claims": {
@@ -11717,6 +12642,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
                           },
                           "securityContext": {
                             "properties": {
@@ -12225,6 +13153,15 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "tcpSocket": {
                                     "properties": {
                                       "host": {
@@ -12299,6 +13236,15 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
                                       }
                                     },
                                     "type": "object",
@@ -12577,6 +13523,21 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "resources": {
                             "properties": {
                               "claims": {
@@ -12622,6 +13583,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
                           },
                           "securityContext": {
                             "properties": {
@@ -13139,6 +14103,15 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "tcpSocket": {
                                     "properties": {
                                       "host": {
@@ -13213,6 +14186,15 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
                                       }
                                     },
                                     "type": "object",
@@ -13491,6 +14473,21 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
                           "resources": {
                             "properties": {
                               "claims": {
@@ -13536,6 +14533,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
                           },
                           "securityContext": {
                             "properties": {
@@ -14518,18 +15518,6 @@
                                       },
                                       "resources": {
                                         "properties": {
-                                          "claims": {
-                                            "items": {
-                                              "properties": {
-                                                "name": {
-                                                  "type": "string"
-                                                }
-                                              },
-                                              "type": "object",
-                                              "additionalProperties": false
-                                            },
-                                            "type": "array"
-                                          },
                                           "limits": {
                                             "additionalProperties": {
                                               "anyOf": [
@@ -14596,6 +15584,9 @@
                                         "additionalProperties": false
                                       },
                                       "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
                                         "type": "string"
                                       },
                                       "volumeMode": {
@@ -14858,6 +15849,57 @@
                               "sources": {
                                 "items": {
                                   "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "configMap": {
                                       "properties": {
                                         "items": {
@@ -15224,6 +16266,20 @@
                     "containerStatuses": {
                       "items": {
                         "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
                           "containerID": {
                             "type": "string"
                           },
@@ -15292,6 +16348,52 @@
                           },
                           "ready": {
                             "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "restartCount": {
                             "type": "integer"
@@ -15362,6 +16464,20 @@
                     "ephemeralContainerStatuses": {
                       "items": {
                         "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
                           "containerID": {
                             "type": "string"
                           },
@@ -15430,6 +16546,52 @@
                           },
                           "ready": {
                             "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "restartCount": {
                             "type": "integer"
@@ -15500,9 +16662,35 @@
                     "hostIP": {
                       "type": "string"
                     },
+                    "hostIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "initContainerStatuses": {
                       "items": {
                         "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
                           "containerID": {
                             "type": "string"
                           },
@@ -15571,6 +16759,52 @@
                           },
                           "ready": {
                             "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "restartCount": {
                             "type": "integer"
@@ -15668,6 +16902,24 @@
                     "reason": {
                       "type": "string"
                     },
+                    "resize": {
+                      "type": "string"
+                    },
+                    "resourceClaimStatuses": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "startTime": {
                       "type": "string"
                     }
@@ -15718,11 +16970,11 @@
         },
         "jobManagerDeploymentStatus": {
           "enum": [
-            "READY",
             "DEPLOYED_NOT_READY",
             "DEPLOYING",
+            "ERROR",
             "MISSING",
-            "ERROR"
+            "READY"
           ],
           "type": "string"
         },
@@ -15734,8 +16986,7 @@
                   "enum": [
                     "FULL",
                     "INCREMENTAL",
-                    "UNKNOWN",
-                    "description"
+                    "UNKNOWN"
                   ],
                   "type": "string"
                 },
@@ -15745,8 +16996,7 @@
                       "enum": [
                         "FULL",
                         "INCREMENTAL",
-                        "UNKNOWN",
-                        "description"
+                        "UNKNOWN"
                       ],
                       "type": "string"
                     },
@@ -15760,8 +17010,8 @@
                       "enum": [
                         "MANUAL",
                         "PERIODIC",
-                        "UPGRADE",
-                        "UNKNOWN"
+                        "UNKNOWN",
+                        "UPGRADE"
                       ],
                       "type": "string"
                     }
@@ -15782,8 +17032,8 @@
                   "enum": [
                     "MANUAL",
                     "PERIODIC",
-                    "UPGRADE",
-                    "UNKNOWN"
+                    "UNKNOWN",
+                    "UPGRADE"
                   ],
                   "type": "string"
                 }
@@ -15833,8 +17083,8 @@
                       "enum": [
                         "MANUAL",
                         "PERIODIC",
-                        "UPGRADE",
-                        "UNKNOWN"
+                        "UNKNOWN",
+                        "UPGRADE"
                       ],
                       "type": "string"
                     }
@@ -15866,8 +17116,8 @@
                         "enum": [
                           "MANUAL",
                           "PERIODIC",
-                          "UPGRADE",
-                          "UNKNOWN"
+                          "UNKNOWN",
+                          "UPGRADE"
                         ],
                         "type": "string"
                       }
@@ -15887,8 +17137,8 @@
                   "enum": [
                     "MANUAL",
                     "PERIODIC",
-                    "UPGRADE",
-                    "UNKNOWN"
+                    "UNKNOWN",
+                    "UPGRADE"
                   ],
                   "type": "string"
                 }
@@ -15912,15 +17162,18 @@
         "lifecycleState": {
           "enum": [
             "CREATED",
-            "SUSPENDED",
-            "UPGRADING",
             "DEPLOYED",
-            "STABLE",
-            "ROLLING_BACK",
+            "FAILED",
             "ROLLED_BACK",
-            "FAILED"
+            "ROLLING_BACK",
+            "STABLE",
+            "SUSPENDED",
+            "UPGRADING"
           ],
           "type": "string"
+        },
+        "observedGeneration": {
+          "type": "integer"
         },
         "reconciliationStatus": {
           "properties": {
@@ -15936,9 +17189,9 @@
             "state": {
               "enum": [
                 "DEPLOYED",
-                "UPGRADING",
+                "ROLLED_BACK",
                 "ROLLING_BACK",
-                "ROLLED_BACK"
+                "UPGRADING"
               ],
               "type": "string"
             }

--- a/flink.apache.org/flinksessionjob_v1beta1.json
+++ b/flink.apache.org/flinksessionjob_v1beta1.json
@@ -37,6 +37,9 @@
             "parallelism": {
               "type": "integer"
             },
+            "savepointRedeployNonce": {
+              "type": "integer"
+            },
             "savepointTriggerNonce": {
               "type": "integer"
             },
@@ -49,8 +52,8 @@
             },
             "upgradeMode": {
               "enum": [
-                "savepoint",
                 "last-state",
+                "savepoint",
                 "stateless"
               ],
               "type": "string"
@@ -79,8 +82,7 @@
                   "enum": [
                     "FULL",
                     "INCREMENTAL",
-                    "UNKNOWN",
-                    "description"
+                    "UNKNOWN"
                   ],
                   "type": "string"
                 },
@@ -90,8 +92,7 @@
                       "enum": [
                         "FULL",
                         "INCREMENTAL",
-                        "UNKNOWN",
-                        "description"
+                        "UNKNOWN"
                       ],
                       "type": "string"
                     },
@@ -105,8 +106,8 @@
                       "enum": [
                         "MANUAL",
                         "PERIODIC",
-                        "UPGRADE",
-                        "UNKNOWN"
+                        "UNKNOWN",
+                        "UPGRADE"
                       ],
                       "type": "string"
                     }
@@ -127,8 +128,8 @@
                   "enum": [
                     "MANUAL",
                     "PERIODIC",
-                    "UPGRADE",
-                    "UNKNOWN"
+                    "UNKNOWN",
+                    "UPGRADE"
                   ],
                   "type": "string"
                 }
@@ -178,8 +179,8 @@
                       "enum": [
                         "MANUAL",
                         "PERIODIC",
-                        "UPGRADE",
-                        "UNKNOWN"
+                        "UNKNOWN",
+                        "UPGRADE"
                       ],
                       "type": "string"
                     }
@@ -211,8 +212,8 @@
                         "enum": [
                           "MANUAL",
                           "PERIODIC",
-                          "UPGRADE",
-                          "UNKNOWN"
+                          "UNKNOWN",
+                          "UPGRADE"
                         ],
                         "type": "string"
                       }
@@ -232,8 +233,8 @@
                   "enum": [
                     "MANUAL",
                     "PERIODIC",
-                    "UPGRADE",
-                    "UNKNOWN"
+                    "UNKNOWN",
+                    "UPGRADE"
                   ],
                   "type": "string"
                 }
@@ -257,15 +258,18 @@
         "lifecycleState": {
           "enum": [
             "CREATED",
-            "SUSPENDED",
-            "UPGRADING",
             "DEPLOYED",
-            "STABLE",
-            "ROLLING_BACK",
+            "FAILED",
             "ROLLED_BACK",
-            "FAILED"
+            "ROLLING_BACK",
+            "STABLE",
+            "SUSPENDED",
+            "UPGRADING"
           ],
           "type": "string"
+        },
+        "observedGeneration": {
+          "type": "integer"
         },
         "reconciliationStatus": {
           "properties": {
@@ -281,9 +285,9 @@
             "state": {
               "enum": [
                 "DEPLOYED",
-                "UPGRADING",
+                "ROLLED_BACK",
                 "ROLLING_BACK",
-                "ROLLED_BACK"
+                "UPGRADING"
               ],
               "type": "string"
             }


### PR DESCRIPTION
This update Flink CRDs to latest operator release 1.9
* [CRDs](https://github.com/apache/flink-kubernetes-operator/tree/release-1.9.0/helm/flink-kubernetes-operator/crds)