### PR TITLE
feat(kserve): update Kserve CRDs (v0.13.1)

### DIFF
--- a/serving.kserve.io/clusterservingruntime_v1alpha1.json
+++ b/serving.kserve.io/clusterservingruntime_v1alpha1.json
@@ -36,7 +36,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -58,7 +61,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -74,7 +80,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["preference", "weight"],
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -101,7 +110,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -123,7 +135,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -137,7 +152,9 @@
                       "type": "array"
                     }
                   },
-                  "required": ["nodeSelectorTerms"],
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
                   "type": "object",
                   "x-kubernetes-map-type": "atomic",
                   "additionalProperties": false
@@ -171,7 +188,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -206,7 +226,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -233,7 +256,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -242,7 +267,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["podAffinityTerm", "weight"],
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -269,7 +297,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -304,7 +335,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -331,7 +365,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["topologyKey"],
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -366,7 +402,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -401,7 +440,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -428,7 +470,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -437,7 +481,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["podAffinityTerm", "weight"],
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -464,7 +511,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -499,7 +549,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -526,7 +579,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["topologyKey"],
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -571,7 +626,9 @@
                             "type": "boolean"
                           }
                         },
-                        "required": ["key"],
+                        "required": [
+                          "key"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -585,7 +642,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["fieldPath"],
+                        "required": [
+                          "fieldPath"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -611,7 +670,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["resource"],
+                        "required": [
+                          "resource"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -628,7 +689,9 @@
                             "type": "boolean"
                           }
                         },
-                        "required": ["key"],
+                        "required": [
+                          "key"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -638,7 +701,9 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -698,7 +763,9 @@
                               "type": "boolean"
                             }
                           },
-                          "required": ["key"],
+                          "required": [
+                            "key"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -712,7 +779,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["fieldPath"],
+                          "required": [
+                            "fieldPath"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -738,7 +807,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["resource"],
+                          "required": [
+                            "resource"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -755,7 +826,9 @@
                               "type": "boolean"
                             }
                           },
-                          "required": ["key"],
+                          "required": [
+                            "key"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -765,7 +838,9 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -846,7 +921,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -870,7 +948,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -891,7 +971,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -928,7 +1010,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -952,7 +1037,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -973,7 +1060,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -1013,7 +1102,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1032,7 +1123,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1056,7 +1150,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1089,7 +1185,9 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1130,12 +1228,17 @@
                       "type": "string"
                     }
                   },
-                  "required": ["containerPort"],
+                  "required": [
+                    "containerPort"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
                 "type": "array",
-                "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
                 "x-kubernetes-list-type": "map"
               },
               "readinessProbe": {
@@ -1166,7 +1269,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1185,7 +1290,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1209,7 +1317,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1242,7 +1352,9 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1258,6 +1370,26 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "resizePolicy": {
+                "items": {
+                  "properties": {
+                    "resourceName": {
+                      "type": "string"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "resourceName",
+                    "restartPolicy"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
               "resources": {
                 "properties": {
                   "claims": {
@@ -1267,12 +1399,16 @@
                           "type": "string"
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["name"],
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "limits": {
@@ -1308,6 +1444,9 @@
                 },
                 "type": "object",
                 "additionalProperties": false
+              },
+              "restartPolicy": {
+                "type": "string"
               },
               "securityContext": {
                 "properties": {
@@ -1379,7 +1518,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1433,7 +1574,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1452,7 +1595,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1476,7 +1622,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1509,7 +1657,9 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1550,7 +1700,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["devicePath", "name"],
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -1578,7 +1731,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["mountPath", "name"],
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -1588,7 +1744,9 @@
                 "type": "string"
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1661,11 +1819,18 @@
               "name": {
                 "type": "string"
               },
+              "priority": {
+                "format": "int32",
+                "minimum": 1,
+                "type": "integer"
+              },
               "version": {
                 "type": "string"
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1715,7 +1880,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumeID"],
+                "required": [
+                  "volumeID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1740,7 +1907,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["diskName", "diskURI"],
+                "required": [
+                  "diskName",
+                  "diskURI"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1756,7 +1926,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["secretName", "shareName"],
+                "required": [
+                  "secretName",
+                  "shareName"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1791,7 +1964,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["monitors"],
+                "required": [
+                  "monitors"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1817,7 +1992,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumeID"],
+                "required": [
+                  "volumeID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1841,7 +2018,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["key", "path"],
+                      "required": [
+                        "key",
+                        "path"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -1886,7 +2066,9 @@
                     "type": "object"
                   }
                 },
-                "required": ["driver"],
+                "required": [
+                  "driver"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1908,7 +2090,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["fieldPath"],
+                          "required": [
+                            "fieldPath"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -1941,13 +2125,17 @@
                               "type": "string"
                             }
                           },
-                          "required": ["resource"],
+                          "required": [
+                            "resource"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2005,7 +2193,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["kind", "name"],
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -2025,7 +2216,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["kind", "name"],
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2038,12 +2232,16 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
                                 "type": "array",
-                                "x-kubernetes-list-map-keys": ["name"],
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
                                 "x-kubernetes-list-type": "map"
                               },
                               "limits": {
@@ -2098,7 +2296,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -2129,7 +2330,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["spec"],
+                    "required": [
+                      "spec"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   }
@@ -2193,7 +2396,9 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["driver"],
+                "required": [
+                  "driver"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2225,7 +2430,9 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["pdName"],
+                "required": [
+                  "pdName"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2241,7 +2448,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["repository"],
+                "required": [
+                  "repository"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2257,7 +2466,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["endpoints", "path"],
+                "required": [
+                  "endpoints",
+                  "path"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2270,7 +2482,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["path"],
+                "required": [
+                  "path"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2321,7 +2535,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["iqn", "lun", "targetPortal"],
+                "required": [
+                  "iqn",
+                  "lun",
+                  "targetPortal"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2340,7 +2558,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["path", "server"],
+                "required": [
+                  "path",
+                  "server"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2353,7 +2574,9 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["claimName"],
+                "required": [
+                  "claimName"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2366,7 +2589,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["pdID"],
+                "required": [
+                  "pdID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2382,7 +2607,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumeID"],
+                "required": [
+                  "volumeID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2411,7 +2638,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["key", "path"],
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2442,7 +2672,9 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["fieldPath"],
+                                    "required": [
+                                      "fieldPath"
+                                    ],
                                     "type": "object",
                                     "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
@@ -2475,13 +2707,17 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["resource"],
+                                    "required": [
+                                      "resource"
+                                    ],
                                     "type": "object",
                                     "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   }
                                 },
-                                "required": ["path"],
+                                "required": [
+                                  "path"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2507,7 +2743,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["key", "path"],
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2537,7 +2776,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -2572,7 +2813,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["registry", "volume"],
+                "required": [
+                  "registry",
+                  "volume"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2613,7 +2857,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["image", "monitors"],
+                "required": [
+                  "image",
+                  "monitors"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2657,7 +2904,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["gateway", "secretRef", "system"],
+                "required": [
+                  "gateway",
+                  "secretRef",
+                  "system"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2681,7 +2932,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["key", "path"],
+                      "required": [
+                        "key",
+                        "path"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2740,19 +2994,25 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumePath"],
+                "required": [
+                  "volumePath"
+                ],
                 "type": "object",
                 "additionalProperties": false
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
           "type": "array"
         }
       },
-      "required": ["containers"],
+      "required": [
+        "containers"
+      ],
       "type": "object",
       "additionalProperties": false
     },

--- a/serving.kserve.io/inferencegraph_v1alpha1.json
+++ b/serving.kserve.io/inferencegraph_v1alpha1.json
@@ -36,7 +36,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -58,7 +61,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -74,7 +80,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["preference", "weight"],
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -101,7 +110,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -123,7 +135,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -137,7 +152,9 @@
                       "type": "array"
                     }
                   },
-                  "required": ["nodeSelectorTerms"],
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
                   "type": "object",
                   "x-kubernetes-map-type": "atomic",
                   "additionalProperties": false
@@ -171,7 +188,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -206,7 +226,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -233,7 +256,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -242,7 +267,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["podAffinityTerm", "weight"],
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -269,7 +297,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -304,7 +335,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -331,7 +365,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["topologyKey"],
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -366,7 +402,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -401,7 +440,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -428,7 +470,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -437,7 +481,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["podAffinityTerm", "weight"],
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -464,7 +511,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -499,7 +549,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -526,7 +579,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["topologyKey"],
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -540,11 +595,22 @@
           "type": "object",
           "additionalProperties": false
         },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
         "nodes": {
           "additionalProperties": {
             "properties": {
               "routerType": {
-                "enum": ["Sequence", "Splitter", "Ensemble", "Switch"],
+                "enum": [
+                  "Sequence",
+                  "Splitter",
+                  "Ensemble",
+                  "Switch"
+                ],
                 "type": "string"
               },
               "steps": {
@@ -554,6 +620,13 @@
                       "type": "string"
                     },
                     "data": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "enum": [
+                        "Soft",
+                        "Hard"
+                      ],
                       "type": "string"
                     },
                     "name": {
@@ -579,7 +652,9 @@
                 "type": "array"
               }
             },
-            "required": ["routerType"],
+            "required": [
+              "routerType"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -594,12 +669,16 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "limits": {
@@ -635,9 +714,27 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "scaleMetric": {
+          "enum": [
+            "cpu",
+            "memory",
+            "concurrency",
+            "rps"
+          ],
+          "type": "string"
+        },
+        "scaleTarget": {
+          "type": "integer"
+        },
+        "timeout": {
+          "format": "int64",
+          "type": "integer"
         }
       },
-      "required": ["nodes"],
+      "required": [
+        "nodes"
+      ],
       "type": "object",
       "additionalProperties": false
     },
@@ -671,7 +768,10 @@
                 "type": "string"
               }
             },
-            "required": ["status", "type"],
+            "required": [
+              "status",
+              "type"
+            ],
             "type": "object",
             "additionalProperties": false
           },

--- a/serving.kserve.io/inferenceservice_v1beta1.json
+++ b/serving.kserve.io/inferenceservice_v1beta1.json
@@ -42,7 +42,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -64,7 +67,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -80,7 +86,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["preference", "weight"],
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -107,7 +116,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -129,7 +141,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -143,7 +158,9 @@
                           "type": "array"
                         }
                       },
-                      "required": ["nodeSelectorTerms"],
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
                       "type": "object",
                       "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
@@ -177,7 +194,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -212,7 +232,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -239,7 +262,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["topologyKey"],
+                            "required": [
+                              "topologyKey"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -248,7 +273,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["podAffinityTerm", "weight"],
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -275,7 +303,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -310,7 +341,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -337,7 +371,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -372,7 +408,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -407,7 +446,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -434,7 +476,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["topologyKey"],
+                            "required": [
+                              "topologyKey"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -443,7 +487,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["podAffinityTerm", "weight"],
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -470,7 +517,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -505,7 +555,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -532,7 +585,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -541,968 +596,6 @@
                   },
                   "type": "object",
                   "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "alibi": {
-              "properties": {
-                "args": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "command": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "config": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object"
-                },
-                "env": {
-                  "items": {
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "configMapKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": ["key"],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "fieldRef": {
-                            "properties": {
-                              "apiVersion": {
-                                "type": "string"
-                              },
-                              "fieldPath": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["fieldPath"],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "resourceFieldRef": {
-                            "properties": {
-                              "containerName": {
-                                "type": "string"
-                              },
-                              "divisor": {
-                                "anyOf": [
-                                  {
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "type": "string"
-                                  }
-                                ],
-                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                "x-kubernetes-int-or-string": true
-                              },
-                              "resource": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["resource"],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": ["key"],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "required": ["name"],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "envFrom": {
-                  "items": {
-                    "properties": {
-                      "configMapRef": {
-                        "properties": {
-                          "name": {
-                            "type": "string"
-                          },
-                          "optional": {
-                            "type": "boolean"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "prefix": {
-                        "type": "string"
-                      },
-                      "secretRef": {
-                        "properties": {
-                          "name": {
-                            "type": "string"
-                          },
-                          "optional": {
-                            "type": "boolean"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "image": {
-                  "type": "string"
-                },
-                "imagePullPolicy": {
-                  "type": "string"
-                },
-                "lifecycle": {
-                  "properties": {
-                    "postStart": {
-                      "properties": {
-                        "exec": {
-                          "properties": {
-                            "command": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "httpGet": {
-                          "properties": {
-                            "host": {
-                              "type": "string"
-                            },
-                            "httpHeaders": {
-                              "items": {
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": ["name", "value"],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "path": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "anyOf": [
-                                {
-                                  "type": "integer"
-                                },
-                                {
-                                  "type": "string"
-                                }
-                              ],
-                              "x-kubernetes-int-or-string": true
-                            },
-                            "scheme": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["port"],
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "tcpSocket": {
-                          "properties": {
-                            "host": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "anyOf": [
-                                {
-                                  "type": "integer"
-                                },
-                                {
-                                  "type": "string"
-                                }
-                              ],
-                              "x-kubernetes-int-or-string": true
-                            }
-                          },
-                          "required": ["port"],
-                          "type": "object",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "preStop": {
-                      "properties": {
-                        "exec": {
-                          "properties": {
-                            "command": {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "httpGet": {
-                          "properties": {
-                            "host": {
-                              "type": "string"
-                            },
-                            "httpHeaders": {
-                              "items": {
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": ["name", "value"],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "path": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "anyOf": [
-                                {
-                                  "type": "integer"
-                                },
-                                {
-                                  "type": "string"
-                                }
-                              ],
-                              "x-kubernetes-int-or-string": true
-                            },
-                            "scheme": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["port"],
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "tcpSocket": {
-                          "properties": {
-                            "host": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "anyOf": [
-                                {
-                                  "type": "integer"
-                                },
-                                {
-                                  "type": "string"
-                                }
-                              ],
-                              "x-kubernetes-int-or-string": true
-                            }
-                          },
-                          "required": ["port"],
-                          "type": "object",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "livenessProbe": {
-                  "properties": {
-                    "exec": {
-                      "properties": {
-                        "command": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "failureThreshold": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "grpc": {
-                      "properties": {
-                        "port": {
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "service": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["port"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "httpGet": {
-                      "properties": {
-                        "host": {
-                          "type": "string"
-                        },
-                        "httpHeaders": {
-                          "items": {
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["name", "value"],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "port": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "x-kubernetes-int-or-string": true
-                        },
-                        "scheme": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "initialDelaySeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "periodSeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "successThreshold": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "tcpSocket": {
-                      "properties": {
-                        "host": {
-                          "type": "string"
-                        },
-                        "port": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "x-kubernetes-int-or-string": true
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "terminationGracePeriodSeconds": {
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "timeoutSeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "name": {
-                  "type": "string"
-                },
-                "ports": {
-                  "items": {
-                    "properties": {
-                      "containerPort": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "hostIP": {
-                        "type": "string"
-                      },
-                      "hostPort": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "protocol": {
-                        "default": "TCP",
-                        "type": "string"
-                      }
-                    },
-                    "required": ["containerPort"],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
-                  "x-kubernetes-list-type": "map"
-                },
-                "readinessProbe": {
-                  "properties": {
-                    "exec": {
-                      "properties": {
-                        "command": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "failureThreshold": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "grpc": {
-                      "properties": {
-                        "port": {
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "service": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["port"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "httpGet": {
-                      "properties": {
-                        "host": {
-                          "type": "string"
-                        },
-                        "httpHeaders": {
-                          "items": {
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["name", "value"],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "port": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "x-kubernetes-int-or-string": true
-                        },
-                        "scheme": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "initialDelaySeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "periodSeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "successThreshold": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "tcpSocket": {
-                      "properties": {
-                        "host": {
-                          "type": "string"
-                        },
-                        "port": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "x-kubernetes-int-or-string": true
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "terminationGracePeriodSeconds": {
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "timeoutSeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "resources": {
-                  "properties": {
-                    "claims": {
-                      "items": {
-                        "properties": {
-                          "name": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["name"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
-                      "x-kubernetes-list-type": "map"
-                    },
-                    "limits": {
-                      "additionalProperties": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                        "x-kubernetes-int-or-string": true
-                      },
-                      "type": "object"
-                    },
-                    "requests": {
-                      "additionalProperties": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                        "x-kubernetes-int-or-string": true
-                      },
-                      "type": "object"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "runtimeVersion": {
-                  "type": "string"
-                },
-                "securityContext": {
-                  "properties": {
-                    "allowPrivilegeEscalation": {
-                      "type": "boolean"
-                    },
-                    "capabilities": {
-                      "properties": {
-                        "add": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "drop": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "privileged": {
-                      "type": "boolean"
-                    },
-                    "procMount": {
-                      "type": "string"
-                    },
-                    "readOnlyRootFilesystem": {
-                      "type": "boolean"
-                    },
-                    "runAsGroup": {
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "runAsNonRoot": {
-                      "type": "boolean"
-                    },
-                    "runAsUser": {
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "seLinuxOptions": {
-                      "properties": {
-                        "level": {
-                          "type": "string"
-                        },
-                        "role": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string"
-                        },
-                        "user": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "seccompProfile": {
-                      "properties": {
-                        "localhostProfile": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["type"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "windowsOptions": {
-                      "properties": {
-                        "gmsaCredentialSpec": {
-                          "type": "string"
-                        },
-                        "gmsaCredentialSpecName": {
-                          "type": "string"
-                        },
-                        "hostProcess": {
-                          "type": "boolean"
-                        },
-                        "runAsUserName": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "startupProbe": {
-                  "properties": {
-                    "exec": {
-                      "properties": {
-                        "command": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "failureThreshold": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "grpc": {
-                      "properties": {
-                        "port": {
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "service": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["port"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "httpGet": {
-                      "properties": {
-                        "host": {
-                          "type": "string"
-                        },
-                        "httpHeaders": {
-                          "items": {
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["name", "value"],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        },
-                        "path": {
-                          "type": "string"
-                        },
-                        "port": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "x-kubernetes-int-or-string": true
-                        },
-                        "scheme": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["port"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "initialDelaySeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "periodSeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "successThreshold": {
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "tcpSocket": {
-                      "properties": {
-                        "host": {
-                          "type": "string"
-                        },
-                        "port": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "x-kubernetes-int-or-string": true
-                        }
-                      },
-                      "required": ["port"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "terminationGracePeriodSeconds": {
-                      "format": "int64",
-                      "type": "integer"
-                    },
-                    "timeoutSeconds": {
-                      "format": "int32",
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "stdin": {
-                  "type": "boolean"
-                },
-                "stdinOnce": {
-                  "type": "boolean"
-                },
-                "storage": {
-                  "properties": {
-                    "key": {
-                      "type": "string"
-                    },
-                    "parameters": {
-                      "additionalProperties": {
-                        "type": "string"
-                      },
-                      "type": "object"
-                    },
-                    "path": {
-                      "type": "string"
-                    },
-                    "schemaPath": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "storageUri": {
-                  "type": "string"
-                },
-                "terminationMessagePath": {
-                  "type": "string"
-                },
-                "terminationMessagePolicy": {
-                  "type": "string"
-                },
-                "tty": {
-                  "type": "boolean"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "volumeDevices": {
-                  "items": {
-                    "properties": {
-                      "devicePath": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["devicePath", "name"],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "volumeMounts": {
-                  "items": {
-                    "properties": {
-                      "mountPath": {
-                        "type": "string"
-                      },
-                      "mountPropagation": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "readOnly": {
-                        "type": "boolean"
-                      },
-                      "subPath": {
-                        "type": "string"
-                      },
-                      "subPathExpr": {
-                        "type": "string"
-                      }
-                    },
-                    "required": ["mountPath", "name"],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "workingDir": {
-                  "type": "string"
                 }
               },
               "type": "object",
@@ -1557,7 +650,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -1571,7 +666,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -1597,7 +694,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -1614,7 +713,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -1624,7 +725,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1705,7 +808,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1729,7 +835,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1750,7 +858,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -1787,7 +897,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1811,7 +924,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1832,7 +947,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -1872,7 +989,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -1891,7 +1010,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1987,12 +1109,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "readinessProbe": {
@@ -2023,7 +1150,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2042,7 +1171,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2113,6 +1245,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -2122,12 +1274,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -2163,6 +1319,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -2237,7 +1396,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2291,7 +1452,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2310,7 +1473,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2334,7 +1500,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2367,7 +1535,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2435,7 +1605,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -2463,7 +1636,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -2540,7 +1716,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -2554,7 +1732,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -2580,7 +1760,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -2597,7 +1779,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -2607,7 +1791,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2688,7 +1874,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -2712,7 +1901,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2733,7 +1924,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -2770,7 +1963,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -2794,7 +1990,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2815,7 +2013,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -2855,7 +2055,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -2874,7 +2076,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -2930,7 +2135,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -2971,12 +2178,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["containerPort"],
+                      "required": [
+                        "containerPort"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                    "x-kubernetes-list-map-keys": [
+                      "containerPort",
+                      "protocol"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
@@ -3007,7 +2219,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3026,7 +2240,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -3082,7 +2299,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3098,6 +2317,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "items": {
+                      "properties": {
+                        "resourceName": {
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
                     "properties": {
                       "claims": {
@@ -3107,12 +2346,16 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
                         "type": "array",
-                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
                         "x-kubernetes-list-type": "map"
                       },
                       "limits": {
@@ -3148,6 +2391,9 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "restartPolicy": {
+                    "type": "string"
                   },
                   "securityContext": {
                     "properties": {
@@ -3219,7 +2465,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3273,7 +2521,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3292,7 +2542,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -3316,7 +2569,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3349,7 +2604,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3390,7 +2647,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["devicePath", "name"],
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -3418,7 +2678,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["mountPath", "name"],
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -3428,11 +2691,50 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "deploymentStrategy": {
+              "properties": {
+                "rollingUpdate": {
+                  "properties": {
+                    "maxSurge": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxUnavailable": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "dnsConfig": {
               "properties": {
@@ -3557,7 +2859,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -3571,7 +2875,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -3597,7 +2903,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -3614,7 +2922,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -3624,7 +2934,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -3705,7 +3017,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -3729,7 +3044,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -3750,7 +3067,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -3787,7 +3106,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -3811,7 +3133,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -3832,7 +3156,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -3872,7 +3198,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3891,7 +3219,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -3915,7 +3246,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3948,7 +3281,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -3989,12 +3324,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["containerPort"],
+                      "required": [
+                        "containerPort"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                    "x-kubernetes-list-map-keys": [
+                      "containerPort",
+                      "protocol"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
@@ -4025,7 +3365,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4044,7 +3386,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -4068,7 +3413,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4101,7 +3448,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4117,6 +3466,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "items": {
+                      "properties": {
+                        "resourceName": {
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
                     "properties": {
                       "claims": {
@@ -4126,12 +3495,16 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
                         "type": "array",
-                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
                         "x-kubernetes-list-type": "map"
                       },
                       "limits": {
@@ -4167,6 +3540,9 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "restartPolicy": {
+                    "type": "string"
                   },
                   "securityContext": {
                     "properties": {
@@ -4238,7 +3614,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4292,7 +3670,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4311,7 +3691,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -4335,7 +3718,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4368,7 +3753,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -4409,7 +3796,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["devicePath", "name"],
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -4437,7 +3827,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["mountPath", "name"],
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -4447,7 +3840,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -4462,7 +3857,11 @@
             "logger": {
               "properties": {
                 "mode": {
-                  "enum": ["all", "request", "response"],
+                  "enum": [
+                    "all",
+                    "request",
+                    "response"
+                  ],
                   "type": "string"
                 },
                 "url": {
@@ -4529,7 +3928,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["conditionType"],
+                "required": [
+                  "conditionType"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -4554,12 +3955,16 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "restartPolicy": {
@@ -4569,7 +3974,12 @@
               "type": "string"
             },
             "scaleMetric": {
-              "enum": ["cpu", "memory", "concurrency", "rps"],
+              "enum": [
+                "cpu",
+                "memory",
+                "concurrency",
+                "rps"
+              ],
               "type": "string"
             },
             "scaleTarget": {
@@ -4585,12 +3995,16 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "securityContext": {
@@ -4640,7 +4054,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -4661,7 +4077,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name", "value"],
+                    "required": [
+                      "name",
+                      "value"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4758,7 +4177,10 @@
                               "type": "array"
                             }
                           },
-                          "required": ["key", "operator"],
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -4803,7 +4225,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -4833,7 +4259,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4858,7 +4286,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["diskName", "diskURI"],
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4874,7 +4305,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["secretName", "shareName"],
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4909,7 +4343,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["monitors"],
+                    "required": [
+                      "monitors"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4935,7 +4371,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -4959,7 +4397,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["key", "path"],
+                          "required": [
+                            "key",
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -5004,7 +4445,9 @@
                         "type": "object"
                       }
                     },
-                    "required": ["driver"],
+                    "required": [
+                      "driver"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5026,7 +4469,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -5059,13 +4504,17 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -5123,7 +4572,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["kind", "name"],
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
@@ -5143,7 +4595,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["kind", "name"],
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5156,12 +4611,16 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["name"],
+                                      "required": [
+                                        "name"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
                                     "type": "array",
-                                    "x-kubernetes-list-map-keys": ["name"],
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
                                     "x-kubernetes-list-type": "map"
                                   },
                                   "limits": {
@@ -5216,7 +4675,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -5247,7 +4709,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["spec"],
+                        "required": [
+                          "spec"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -5311,7 +4775,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["driver"],
+                    "required": [
+                      "driver"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5343,7 +4809,9 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["pdName"],
+                    "required": [
+                      "pdName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5359,7 +4827,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["repository"],
+                    "required": [
+                      "repository"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5375,7 +4845,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["endpoints", "path"],
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5388,7 +4861,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["path"],
+                    "required": [
+                      "path"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5439,7 +4914,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["iqn", "lun", "targetPortal"],
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5458,7 +4937,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["path", "server"],
+                    "required": [
+                      "path",
+                      "server"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5471,7 +4953,9 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["claimName"],
+                    "required": [
+                      "claimName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5484,7 +4968,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["pdID"],
+                    "required": [
+                      "pdID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5500,7 +4986,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5529,7 +5017,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["key", "path"],
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5560,7 +5051,9 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["fieldPath"],
+                                        "required": [
+                                          "fieldPath"
+                                        ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
@@ -5593,13 +5086,17 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["resource"],
+                                        "required": [
+                                          "resource"
+                                        ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
-                                    "required": ["path"],
+                                    "required": [
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5625,7 +5122,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["key", "path"],
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5655,7 +5155,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["path"],
+                              "required": [
+                                "path"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             }
@@ -5690,7 +5192,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["registry", "volume"],
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5731,7 +5236,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["image", "monitors"],
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5775,7 +5283,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["gateway", "secretRef", "system"],
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -5799,7 +5311,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["key", "path"],
+                          "required": [
+                            "key",
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -5858,12 +5373,16 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumePath"],
+                    "required": [
+                      "volumePath"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -5904,7 +5423,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -5926,7 +5448,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -5942,7 +5467,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["preference", "weight"],
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -5969,7 +5497,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -5991,7 +5522,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6005,7 +5539,9 @@
                           "type": "array"
                         }
                       },
-                      "required": ["nodeSelectorTerms"],
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
                       "type": "object",
                       "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
@@ -6039,7 +5575,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -6074,7 +5613,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -6101,7 +5643,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["topologyKey"],
+                            "required": [
+                              "topologyKey"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -6110,7 +5654,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["podAffinityTerm", "weight"],
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6137,7 +5684,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6172,7 +5722,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6199,7 +5752,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6234,7 +5789,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -6269,7 +5827,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -6296,7 +5857,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["topologyKey"],
+                            "required": [
+                              "topologyKey"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -6305,7 +5868,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["podAffinityTerm", "weight"],
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6332,7 +5898,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6367,7 +5936,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6394,7 +5966,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6478,7 +6052,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -6492,7 +6068,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -6518,7 +6096,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -6535,7 +6115,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -6545,7 +6127,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -6626,7 +6210,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6650,7 +6237,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -6671,7 +6260,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -6708,7 +6299,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -6732,7 +6326,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -6753,7 +6349,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -6793,7 +6391,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6812,7 +6412,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -6868,7 +6471,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6909,12 +6514,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["containerPort"],
+                      "required": [
+                        "containerPort"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                    "x-kubernetes-list-map-keys": [
+                      "containerPort",
+                      "protocol"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
@@ -6945,7 +6555,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -6964,7 +6576,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -7020,7 +6635,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -7036,6 +6653,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "items": {
+                      "properties": {
+                        "resourceName": {
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
                     "properties": {
                       "claims": {
@@ -7045,12 +6682,16 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
                         "type": "array",
-                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
                         "x-kubernetes-list-type": "map"
                       },
                       "limits": {
@@ -7086,6 +6727,9 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "restartPolicy": {
+                    "type": "string"
                   },
                   "securityContext": {
                     "properties": {
@@ -7157,7 +6801,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -7211,7 +6857,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -7230,7 +6878,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -7254,7 +6905,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -7287,7 +6940,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -7328,7 +6983,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["devicePath", "name"],
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -7356,7 +7014,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["mountPath", "name"],
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -7366,11 +7027,50 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "deploymentStrategy": {
+              "properties": {
+                "rollingUpdate": {
+                  "properties": {
+                    "maxSurge": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxUnavailable": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "dnsConfig": {
               "properties": {
@@ -7444,960 +7144,7 @@
             "hostname": {
               "type": "string"
             },
-            "imagePullSecrets": {
-              "items": {
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "x-kubernetes-map-type": "atomic",
-                "additionalProperties": false
-              },
-              "type": "array"
-            },
-            "initContainers": {
-              "items": {
-                "properties": {
-                  "args": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "command": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "env": {
-                    "items": {
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "value": {
-                          "type": "string"
-                        },
-                        "valueFrom": {
-                          "properties": {
-                            "configMapKeyRef": {
-                              "properties": {
-                                "key": {
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "type": "string"
-                                },
-                                "optional": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "required": ["key"],
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "fieldRef": {
-                              "properties": {
-                                "apiVersion": {
-                                  "type": "string"
-                                },
-                                "fieldPath": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["fieldPath"],
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "resourceFieldRef": {
-                              "properties": {
-                                "containerName": {
-                                  "type": "string"
-                                },
-                                "divisor": {
-                                  "anyOf": [
-                                    {
-                                      "type": "integer"
-                                    },
-                                    {
-                                      "type": "string"
-                                    }
-                                  ],
-                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                  "x-kubernetes-int-or-string": true
-                                },
-                                "resource": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["resource"],
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "secretKeyRef": {
-                              "properties": {
-                                "key": {
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "type": "string"
-                                },
-                                "optional": {
-                                  "type": "boolean"
-                                }
-                              },
-                              "required": ["key"],
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": ["name"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "envFrom": {
-                    "items": {
-                      "properties": {
-                        "configMapRef": {
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "optional": {
-                              "type": "boolean"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "prefix": {
-                          "type": "string"
-                        },
-                        "secretRef": {
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "optional": {
-                              "type": "boolean"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "image": {
-                    "type": "string"
-                  },
-                  "imagePullPolicy": {
-                    "type": "string"
-                  },
-                  "lifecycle": {
-                    "properties": {
-                      "postStart": {
-                        "properties": {
-                          "exec": {
-                            "properties": {
-                              "command": {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "httpGet": {
-                            "properties": {
-                              "host": {
-                                "type": "string"
-                              },
-                              "httpHeaders": {
-                                "items": {
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": ["name", "value"],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "path": {
-                                "type": "string"
-                              },
-                              "port": {
-                                "anyOf": [
-                                  {
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "type": "string"
-                                  }
-                                ],
-                                "x-kubernetes-int-or-string": true
-                              },
-                              "scheme": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["port"],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "tcpSocket": {
-                            "properties": {
-                              "host": {
-                                "type": "string"
-                              },
-                              "port": {
-                                "anyOf": [
-                                  {
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "type": "string"
-                                  }
-                                ],
-                                "x-kubernetes-int-or-string": true
-                              }
-                            },
-                            "required": ["port"],
-                            "type": "object",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "preStop": {
-                        "properties": {
-                          "exec": {
-                            "properties": {
-                              "command": {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "httpGet": {
-                            "properties": {
-                              "host": {
-                                "type": "string"
-                              },
-                              "httpHeaders": {
-                                "items": {
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": ["name", "value"],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "path": {
-                                "type": "string"
-                              },
-                              "port": {
-                                "anyOf": [
-                                  {
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "type": "string"
-                                  }
-                                ],
-                                "x-kubernetes-int-or-string": true
-                              },
-                              "scheme": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["port"],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "tcpSocket": {
-                            "properties": {
-                              "host": {
-                                "type": "string"
-                              },
-                              "port": {
-                                "anyOf": [
-                                  {
-                                    "type": "integer"
-                                  },
-                                  {
-                                    "type": "string"
-                                  }
-                                ],
-                                "x-kubernetes-int-or-string": true
-                              }
-                            },
-                            "required": ["port"],
-                            "type": "object",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "livenessProbe": {
-                    "properties": {
-                      "exec": {
-                        "properties": {
-                          "command": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "failureThreshold": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "grpc": {
-                        "properties": {
-                          "port": {
-                            "format": "int32",
-                            "type": "integer"
-                          },
-                          "service": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "httpGet": {
-                        "properties": {
-                          "host": {
-                            "type": "string"
-                          },
-                          "httpHeaders": {
-                            "items": {
-                              "properties": {
-                                "name": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["name", "value"],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "path": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "x-kubernetes-int-or-string": true
-                          },
-                          "scheme": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "initialDelaySeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "periodSeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "successThreshold": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "tcpSocket": {
-                        "properties": {
-                          "host": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "x-kubernetes-int-or-string": true
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "terminationGracePeriodSeconds": {
-                        "format": "int64",
-                        "type": "integer"
-                      },
-                      "timeoutSeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "ports": {
-                    "items": {
-                      "properties": {
-                        "containerPort": {
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "hostIP": {
-                          "type": "string"
-                        },
-                        "hostPort": {
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "protocol": {
-                          "default": "TCP",
-                          "type": "string"
-                        }
-                      },
-                      "required": ["containerPort"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
-                    "x-kubernetes-list-type": "map"
-                  },
-                  "readinessProbe": {
-                    "properties": {
-                      "exec": {
-                        "properties": {
-                          "command": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "failureThreshold": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "grpc": {
-                        "properties": {
-                          "port": {
-                            "format": "int32",
-                            "type": "integer"
-                          },
-                          "service": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "httpGet": {
-                        "properties": {
-                          "host": {
-                            "type": "string"
-                          },
-                          "httpHeaders": {
-                            "items": {
-                              "properties": {
-                                "name": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["name", "value"],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "path": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "x-kubernetes-int-or-string": true
-                          },
-                          "scheme": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "initialDelaySeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "periodSeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "successThreshold": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "tcpSocket": {
-                        "properties": {
-                          "host": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "x-kubernetes-int-or-string": true
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "terminationGracePeriodSeconds": {
-                        "format": "int64",
-                        "type": "integer"
-                      },
-                      "timeoutSeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "resources": {
-                    "properties": {
-                      "claims": {
-                        "items": {
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["name"],
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-map-keys": ["name"],
-                        "x-kubernetes-list-type": "map"
-                      },
-                      "limits": {
-                        "additionalProperties": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                          "x-kubernetes-int-or-string": true
-                        },
-                        "type": "object"
-                      },
-                      "requests": {
-                        "additionalProperties": {
-                          "anyOf": [
-                            {
-                              "type": "integer"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                          "x-kubernetes-int-or-string": true
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "securityContext": {
-                    "properties": {
-                      "allowPrivilegeEscalation": {
-                        "type": "boolean"
-                      },
-                      "capabilities": {
-                        "properties": {
-                          "add": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "drop": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "privileged": {
-                        "type": "boolean"
-                      },
-                      "procMount": {
-                        "type": "string"
-                      },
-                      "readOnlyRootFilesystem": {
-                        "type": "boolean"
-                      },
-                      "runAsGroup": {
-                        "format": "int64",
-                        "type": "integer"
-                      },
-                      "runAsNonRoot": {
-                        "type": "boolean"
-                      },
-                      "runAsUser": {
-                        "format": "int64",
-                        "type": "integer"
-                      },
-                      "seLinuxOptions": {
-                        "properties": {
-                          "level": {
-                            "type": "string"
-                          },
-                          "role": {
-                            "type": "string"
-                          },
-                          "type": {
-                            "type": "string"
-                          },
-                          "user": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "seccompProfile": {
-                        "properties": {
-                          "localhostProfile": {
-                            "type": "string"
-                          },
-                          "type": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["type"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "windowsOptions": {
-                        "properties": {
-                          "gmsaCredentialSpec": {
-                            "type": "string"
-                          },
-                          "gmsaCredentialSpecName": {
-                            "type": "string"
-                          },
-                          "hostProcess": {
-                            "type": "boolean"
-                          },
-                          "runAsUserName": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "startupProbe": {
-                    "properties": {
-                      "exec": {
-                        "properties": {
-                          "command": {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "failureThreshold": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "grpc": {
-                        "properties": {
-                          "port": {
-                            "format": "int32",
-                            "type": "integer"
-                          },
-                          "service": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "httpGet": {
-                        "properties": {
-                          "host": {
-                            "type": "string"
-                          },
-                          "httpHeaders": {
-                            "items": {
-                              "properties": {
-                                "name": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["name", "value"],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "path": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "x-kubernetes-int-or-string": true
-                          },
-                          "scheme": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "initialDelaySeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "periodSeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "successThreshold": {
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "tcpSocket": {
-                        "properties": {
-                          "host": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "x-kubernetes-int-or-string": true
-                          }
-                        },
-                        "required": ["port"],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "terminationGracePeriodSeconds": {
-                        "format": "int64",
-                        "type": "integer"
-                      },
-                      "timeoutSeconds": {
-                        "format": "int32",
-                        "type": "integer"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "stdin": {
-                    "type": "boolean"
-                  },
-                  "stdinOnce": {
-                    "type": "boolean"
-                  },
-                  "terminationMessagePath": {
-                    "type": "string"
-                  },
-                  "terminationMessagePolicy": {
-                    "type": "string"
-                  },
-                  "tty": {
-                    "type": "boolean"
-                  },
-                  "volumeDevices": {
-                    "items": {
-                      "properties": {
-                        "devicePath": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["devicePath", "name"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "volumeMounts": {
-                    "items": {
-                      "properties": {
-                        "mountPath": {
-                          "type": "string"
-                        },
-                        "mountPropagation": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "readOnly": {
-                          "type": "boolean"
-                        },
-                        "subPath": {
-                          "type": "string"
-                        },
-                        "subPathExpr": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["mountPath", "name"],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "workingDir": {
-                    "type": "string"
-                  }
-                },
-                "required": ["name"],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "type": "array"
-            },
-            "labels": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "lightgbm": {
+            "huggingface": {
               "properties": {
                 "args": {
                   "items": {
@@ -8434,7 +7181,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -8448,7 +7197,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -8474,7 +7225,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -8491,7 +7244,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -8501,7 +7256,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -8582,7 +7339,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -8606,7 +7366,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -8627,7 +7389,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -8664,7 +7428,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -8688,7 +7455,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -8709,7 +7478,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -8749,7 +7520,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -8768,7 +7541,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -8864,12 +7640,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -8903,7 +7684,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -8922,7 +7705,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -8993,6 +7779,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -9002,12 +7808,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -9043,6 +7853,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -9117,7 +7930,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -9171,7 +7986,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -9190,7 +8007,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -9214,7 +8034,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -9247,7 +8069,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -9312,7 +8136,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -9340,7 +8167,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -9353,26 +8183,1053 @@
               "type": "object",
               "additionalProperties": false
             },
-            "logger": {
-              "properties": {
-                "mode": {
-                  "enum": ["all", "request", "response"],
-                  "type": "string"
+            "imagePullSecrets": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
                 },
-                "url": {
-                  "type": "string"
-                }
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "array"
             },
-            "maxReplicas": {
-              "type": "integer"
+            "initContainers": {
+              "items": {
+                "properties": {
+                  "args": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "command": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "env": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "properties": {
+                            "configMapKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "fieldRef": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "resourceFieldRef": {
+                              "properties": {
+                                "containerName": {
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "secretKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "envFrom": {
+                    "items": {
+                      "properties": {
+                        "configMapRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "prefix": {
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "image": {
+                    "type": "string"
+                  },
+                  "imagePullPolicy": {
+                    "type": "string"
+                  },
+                  "lifecycle": {
+                    "properties": {
+                      "postStart": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "preStop": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "livenessProbe": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "failureThreshold": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "initialDelaySeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "periodSeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "successThreshold": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "ports": {
+                    "items": {
+                      "properties": {
+                        "containerPort": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "hostIP": {
+                          "type": "string"
+                        },
+                        "hostPort": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "default": "TCP",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "containerPort"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "containerPort",
+                      "protocol"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "readinessProbe": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "failureThreshold": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "initialDelaySeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "periodSeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "successThreshold": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "resizePolicy": {
+                    "items": {
+                      "properties": {
+                        "resourceName": {
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "resources": {
+                    "properties": {
+                      "claims": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "limits": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "requests": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "restartPolicy": {
+                    "type": "string"
+                  },
+                  "securityContext": {
+                    "properties": {
+                      "allowPrivilegeEscalation": {
+                        "type": "boolean"
+                      },
+                      "capabilities": {
+                        "properties": {
+                          "add": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "drop": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "privileged": {
+                        "type": "boolean"
+                      },
+                      "procMount": {
+                        "type": "string"
+                      },
+                      "readOnlyRootFilesystem": {
+                        "type": "boolean"
+                      },
+                      "runAsGroup": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "runAsNonRoot": {
+                        "type": "boolean"
+                      },
+                      "runAsUser": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "seLinuxOptions": {
+                        "properties": {
+                          "level": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "seccompProfile": {
+                        "properties": {
+                          "localhostProfile": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "windowsOptions": {
+                        "properties": {
+                          "gmsaCredentialSpec": {
+                            "type": "string"
+                          },
+                          "gmsaCredentialSpecName": {
+                            "type": "string"
+                          },
+                          "hostProcess": {
+                            "type": "boolean"
+                          },
+                          "runAsUserName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "startupProbe": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "failureThreshold": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "grpc": {
+                        "properties": {
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "initialDelaySeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "periodSeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "successThreshold": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "timeoutSeconds": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "stdin": {
+                    "type": "boolean"
+                  },
+                  "stdinOnce": {
+                    "type": "boolean"
+                  },
+                  "terminationMessagePath": {
+                    "type": "string"
+                  },
+                  "terminationMessagePolicy": {
+                    "type": "string"
+                  },
+                  "tty": {
+                    "type": "boolean"
+                  },
+                  "volumeDevices": {
+                    "items": {
+                      "properties": {
+                        "devicePath": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "volumeMounts": {
+                    "items": {
+                      "properties": {
+                        "mountPath": {
+                          "type": "string"
+                        },
+                        "mountPropagation": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "subPath": {
+                          "type": "string"
+                        },
+                        "subPathExpr": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "workingDir": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
             },
-            "minReplicas": {
-              "type": "integer"
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
             },
-            "model": {
+            "lightgbm": {
               "properties": {
                 "args": {
                   "items": {
@@ -9409,7 +9266,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -9423,7 +9282,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -9449,7 +9310,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -9466,7 +9329,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -9476,7 +9341,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -9557,7 +9424,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -9581,7 +9451,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -9602,7 +9474,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -9639,7 +9513,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -9663,7 +9540,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -9684,7 +9563,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -9724,7 +9605,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -9743,7 +9626,1072 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "name": {
+                  "type": "string"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "containerPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "protocolVersion": {
+                  "type": "string"
+                },
+                "readinessProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "resources": {
+                  "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
+                },
+                "runtimeVersion": {
+                  "type": "string"
+                },
+                "securityContext": {
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "startupProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "stdin": {
+                  "type": "boolean"
+                },
+                "stdinOnce": {
+                  "type": "boolean"
+                },
+                "storage": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "parameters": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "schemaPath": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "storageUri": {
+                  "type": "string"
+                },
+                "terminationMessagePath": {
+                  "type": "string"
+                },
+                "terminationMessagePolicy": {
+                  "type": "string"
+                },
+                "tty": {
+                  "type": "boolean"
+                },
+                "volumeDevices": {
+                  "items": {
+                    "properties": {
+                      "devicePath": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumeMounts": {
+                  "items": {
+                    "properties": {
+                      "mountPath": {
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "subPath": {
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "workingDir": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logger": {
+              "properties": {
+                "mode": {
+                  "enum": [
+                    "all",
+                    "request",
+                    "response"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxReplicas": {
+              "type": "integer"
+            },
+            "minReplicas": {
+              "type": "integer"
+            },
+            "model": {
+              "properties": {
+                "args": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "env": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "properties": {
+                          "configMapKeyRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "fieldRef": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "resourceFieldRef": {
+                            "properties": {
+                              "containerName": {
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "resource"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secretKeyRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "envFrom": {
+                  "items": {
+                    "properties": {
+                      "configMapRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "prefix": {
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "image": {
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "type": "string"
+                },
+                "lifecycle": {
+                  "properties": {
+                    "postStart": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "livenessProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -9823,7 +10771,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -9852,12 +10802,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -9891,7 +10846,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -9910,7 +10867,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -9981,6 +10941,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -9990,12 +10970,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -10031,6 +11015,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtime": {
                   "type": "string"
@@ -10108,7 +11095,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -10162,7 +11151,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -10181,7 +11172,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -10205,7 +11199,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -10238,7 +11234,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -10303,7 +11301,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -10331,7 +11332,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -10391,7 +11395,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -10405,7 +11411,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -10431,7 +11439,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -10448,7 +11458,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -10458,7 +11470,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -10539,7 +11553,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -10563,7 +11580,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -10584,7 +11603,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -10621,7 +11642,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -10645,7 +11669,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -10666,7 +11692,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -10706,7 +11734,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -10725,7 +11755,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -10821,12 +11854,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -10860,7 +11898,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -10879,7 +11919,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -10950,6 +11993,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -10959,12 +12022,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -11000,6 +12067,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -11074,7 +12144,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -11128,7 +12200,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -11147,7 +12221,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -11171,7 +12248,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -11204,7 +12283,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -11269,7 +12350,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -11297,7 +12381,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -11371,7 +12458,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -11385,7 +12474,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -11411,7 +12502,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -11428,7 +12521,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -11438,7 +12533,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -11519,7 +12616,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -11543,7 +12643,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -11564,7 +12666,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -11601,7 +12705,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -11625,7 +12732,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -11646,7 +12755,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -11686,7 +12797,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -11705,7 +12818,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -11801,12 +12917,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -11840,7 +12961,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -11859,7 +12982,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -11930,6 +13056,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -11939,12 +13085,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -11980,6 +13130,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -12054,7 +13207,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -12108,7 +13263,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -12127,7 +13284,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -12151,7 +13311,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -12184,7 +13346,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -12249,7 +13413,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -12277,7 +13444,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -12327,7 +13497,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -12341,7 +13513,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -12367,7 +13541,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -12384,7 +13560,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -12394,7 +13572,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -12475,7 +13655,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -12499,7 +13682,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -12520,7 +13705,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -12557,7 +13744,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -12581,7 +13771,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -12602,7 +13794,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -12642,7 +13836,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -12661,7 +13857,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -12757,12 +13956,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -12796,7 +14000,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -12815,7 +14021,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -12886,6 +14095,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -12895,12 +14124,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -12936,6 +14169,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -13010,7 +14246,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -13064,7 +14302,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -13083,7 +14323,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -13107,7 +14350,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -13140,7 +14385,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -13205,7 +14452,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -13233,7 +14483,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -13293,7 +14546,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -13307,7 +14562,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -13333,7 +14590,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -13350,7 +14609,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -13360,7 +14621,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -13441,7 +14704,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -13465,7 +14731,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -13486,7 +14754,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -13523,7 +14793,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -13547,7 +14820,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -13568,7 +14843,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -13608,7 +14885,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -13627,7 +14906,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -13723,12 +15005,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -13762,7 +15049,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -13781,7 +15070,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -13852,6 +15144,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -13861,12 +15173,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -13902,6 +15218,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -13976,7 +15295,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -14030,7 +15351,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -14049,7 +15372,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -14073,7 +15399,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -14106,7 +15434,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -14171,7 +15501,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -14199,7 +15532,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -14219,7 +15555,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["conditionType"],
+                "required": [
+                  "conditionType"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -14244,12 +15582,16 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "restartPolicy": {
@@ -14259,7 +15601,12 @@
               "type": "string"
             },
             "scaleMetric": {
-              "enum": ["cpu", "memory", "concurrency", "rps"],
+              "enum": [
+                "cpu",
+                "memory",
+                "concurrency",
+                "rps"
+              ],
               "type": "string"
             },
             "scaleTarget": {
@@ -14275,12 +15622,16 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "securityContext": {
@@ -14330,7 +15681,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -14351,7 +15704,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name", "value"],
+                    "required": [
+                      "name",
+                      "value"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -14428,7 +15784,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -14442,7 +15800,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -14468,7 +15828,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -14485,7 +15847,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -14495,7 +15859,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -14576,7 +15942,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -14600,7 +15969,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -14621,7 +15992,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -14658,7 +16031,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -14682,7 +16058,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -14703,7 +16081,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -14743,7 +16123,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -14762,7 +16144,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -14858,12 +16243,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -14897,7 +16287,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -14916,7 +16308,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -14987,6 +16382,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -14996,12 +16411,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -15037,6 +16456,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -15111,7 +16533,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -15165,7 +16589,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -15184,7 +16610,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -15208,7 +16637,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -15241,7 +16672,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -15306,7 +16739,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -15334,7 +16770,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -15387,7 +16826,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -15401,7 +16842,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -15427,7 +16870,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -15444,7 +16889,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -15454,7 +16901,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -15535,7 +16984,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -15559,7 +17011,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -15580,7 +17034,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -15617,7 +17073,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -15641,7 +17100,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -15662,7 +17123,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -15702,7 +17165,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -15721,7 +17186,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -15817,12 +17285,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -15856,7 +17329,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -15875,7 +17350,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -15946,6 +17424,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -15955,12 +17453,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -15996,6 +17498,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -16070,7 +17575,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -16124,7 +17631,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -16143,7 +17652,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -16167,7 +17679,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -16200,7 +17714,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -16265,7 +17781,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -16293,7 +17812,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -16360,7 +17882,10 @@
                               "type": "array"
                             }
                           },
-                          "required": ["key", "operator"],
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -16405,7 +17930,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -16453,7 +17982,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -16467,7 +17998,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -16493,7 +18026,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -16510,7 +18045,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -16520,7 +18057,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -16601,7 +18140,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -16625,7 +18167,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -16646,7 +18190,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -16683,7 +18229,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -16707,7 +18256,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -16728,7 +18279,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -16768,7 +18321,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -16787,7 +18342,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -16883,12 +18441,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -16922,7 +18485,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -16941,7 +18506,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17012,6 +18580,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -17021,12 +18609,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -17062,6 +18654,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -17136,7 +18731,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -17190,7 +18787,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -17209,7 +18808,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -17233,7 +18835,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -17266,7 +18870,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -17331,7 +18937,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17359,7 +18968,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17391,7 +19003,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17416,7 +19030,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["diskName", "diskURI"],
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17432,7 +19049,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["secretName", "shareName"],
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17467,7 +19087,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["monitors"],
+                    "required": [
+                      "monitors"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17493,7 +19115,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17517,7 +19141,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["key", "path"],
+                          "required": [
+                            "key",
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -17562,7 +19189,9 @@
                         "type": "object"
                       }
                     },
-                    "required": ["driver"],
+                    "required": [
+                      "driver"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17584,7 +19213,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -17617,13 +19248,17 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -17681,7 +19316,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["kind", "name"],
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
@@ -17701,7 +19339,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["kind", "name"],
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -17714,12 +19355,16 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["name"],
+                                      "required": [
+                                        "name"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
                                     "type": "array",
-                                    "x-kubernetes-list-map-keys": ["name"],
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
                                     "x-kubernetes-list-type": "map"
                                   },
                                   "limits": {
@@ -17774,7 +19419,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -17805,7 +19453,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["spec"],
+                        "required": [
+                          "spec"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -17869,7 +19519,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["driver"],
+                    "required": [
+                      "driver"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17901,7 +19553,9 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["pdName"],
+                    "required": [
+                      "pdName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17917,7 +19571,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["repository"],
+                    "required": [
+                      "repository"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17933,7 +19589,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["endpoints", "path"],
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17946,7 +19605,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["path"],
+                    "required": [
+                      "path"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -17997,7 +19658,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["iqn", "lun", "targetPortal"],
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18016,7 +19681,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["path", "server"],
+                    "required": [
+                      "path",
+                      "server"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18029,7 +19697,9 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["claimName"],
+                    "required": [
+                      "claimName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18042,7 +19712,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["pdID"],
+                    "required": [
+                      "pdID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18058,7 +19730,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18087,7 +19761,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["key", "path"],
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -18118,7 +19795,9 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["fieldPath"],
+                                        "required": [
+                                          "fieldPath"
+                                        ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
@@ -18151,13 +19830,17 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["resource"],
+                                        "required": [
+                                          "resource"
+                                        ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
-                                    "required": ["path"],
+                                    "required": [
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -18183,7 +19866,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["key", "path"],
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -18213,7 +19899,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["path"],
+                              "required": [
+                                "path"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             }
@@ -18248,7 +19936,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["registry", "volume"],
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18289,7 +19980,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["image", "monitors"],
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18333,7 +20027,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["gateway", "secretRef", "system"],
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18357,7 +20055,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["key", "path"],
+                          "required": [
+                            "key",
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -18416,12 +20117,16 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumePath"],
+                    "required": [
+                      "volumePath"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -18464,7 +20169,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -18478,7 +20185,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["fieldPath"],
+                            "required": [
+                              "fieldPath"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -18504,7 +20213,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["resource"],
+                            "required": [
+                              "resource"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -18521,7 +20232,9 @@
                                 "type": "boolean"
                               }
                             },
-                            "required": ["key"],
+                            "required": [
+                              "key"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -18531,7 +20244,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -18612,7 +20327,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -18636,7 +20354,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -18657,7 +20377,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -18694,7 +20416,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["name", "value"],
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -18718,7 +20443,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -18739,7 +20466,9 @@
                               "x-kubernetes-int-or-string": true
                             }
                           },
-                          "required": ["port"],
+                          "required": [
+                            "port"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -18779,7 +20508,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -18798,7 +20529,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -18894,12 +20628,17 @@
                         "type": "string"
                       }
                     },
-                    "required": ["containerPort"],
+                    "required": [
+                      "containerPort"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array",
-                  "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                  "x-kubernetes-list-map-keys": [
+                    "containerPort",
+                    "protocol"
+                  ],
                   "x-kubernetes-list-type": "map"
                 },
                 "protocolVersion": {
@@ -18933,7 +20672,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -18952,7 +20693,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -19023,6 +20767,26 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "resizePolicy": {
+                  "items": {
+                    "properties": {
+                      "resourceName": {
+                        "type": "string"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resourceName",
+                      "restartPolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
                 "resources": {
                   "properties": {
                     "claims": {
@@ -19032,12 +20796,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["name"],
+                        "required": [
+                          "name"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
                       "type": "array",
-                      "x-kubernetes-list-map-keys": ["name"],
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
                       "x-kubernetes-list-type": "map"
                     },
                     "limits": {
@@ -19073,6 +20841,9 @@
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
                 },
                 "runtimeVersion": {
                   "type": "string"
@@ -19147,7 +20918,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -19201,7 +20974,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -19220,7 +20995,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                              "name",
+                              "value"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -19244,7 +21022,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -19277,7 +21057,9 @@
                           "x-kubernetes-int-or-string": true
                         }
                       },
-                      "required": ["port"],
+                      "required": [
+                        "port"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -19342,7 +21124,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["devicePath", "name"],
+                    "required": [
+                      "devicePath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -19370,7 +21155,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["mountPath", "name"],
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -19418,7 +21206,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19440,7 +21231,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19456,7 +21250,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["preference", "weight"],
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -19483,7 +21280,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19505,7 +21305,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19519,7 +21322,9 @@
                           "type": "array"
                         }
                       },
-                      "required": ["nodeSelectorTerms"],
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
                       "type": "object",
                       "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
@@ -19553,7 +21358,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -19588,7 +21396,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -19615,7 +21426,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["topologyKey"],
+                            "required": [
+                              "topologyKey"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -19624,7 +21437,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["podAffinityTerm", "weight"],
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -19651,7 +21467,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19686,7 +21505,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19713,7 +21535,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -19748,7 +21572,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -19783,7 +21610,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -19810,7 +21640,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["topologyKey"],
+                            "required": [
+                              "topologyKey"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -19819,7 +21651,10 @@
                             "type": "integer"
                           }
                         },
-                        "required": ["podAffinityTerm", "weight"],
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -19846,7 +21681,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19881,7 +21719,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -19908,7 +21749,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -19992,7 +21835,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -20006,7 +21851,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -20032,7 +21879,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -20049,7 +21898,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -20059,7 +21910,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -20140,7 +21993,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -20164,7 +22020,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -20185,7 +22043,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -20222,7 +22082,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -20246,7 +22109,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -20267,7 +22132,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -20307,7 +22174,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20326,7 +22195,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -20382,7 +22254,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20423,12 +22297,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["containerPort"],
+                      "required": [
+                        "containerPort"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                    "x-kubernetes-list-map-keys": [
+                      "containerPort",
+                      "protocol"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
@@ -20459,7 +22338,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20478,7 +22359,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -20534,7 +22418,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20550,6 +22436,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "items": {
+                      "properties": {
+                        "resourceName": {
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
                     "properties": {
                       "claims": {
@@ -20559,12 +22465,16 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
                         "type": "array",
-                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
                         "x-kubernetes-list-type": "map"
                       },
                       "limits": {
@@ -20600,6 +22510,9 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "restartPolicy": {
+                    "type": "string"
                   },
                   "securityContext": {
                     "properties": {
@@ -20671,7 +22584,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20725,7 +22640,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20744,7 +22661,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -20768,7 +22688,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20801,7 +22723,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -20842,7 +22766,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["devicePath", "name"],
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -20870,7 +22797,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["mountPath", "name"],
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -20880,11 +22810,50 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "deploymentStrategy": {
+              "properties": {
+                "rollingUpdate": {
+                  "properties": {
+                    "maxSurge": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxUnavailable": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "dnsConfig": {
               "properties": {
@@ -21009,7 +22978,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -21023,7 +22994,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -21049,7 +23022,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -21066,7 +23041,9 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["key"],
+                              "required": [
+                                "key"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -21076,7 +23053,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -21157,7 +23136,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -21181,7 +23163,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -21202,7 +23186,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -21239,7 +23225,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name", "value"],
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -21263,7 +23252,9 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -21284,7 +23275,9 @@
                                 "x-kubernetes-int-or-string": true
                               }
                             },
-                            "required": ["port"],
+                            "required": [
+                              "port"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           }
@@ -21324,7 +23317,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21343,7 +23338,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -21367,7 +23365,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21400,7 +23400,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21441,12 +23443,17 @@
                           "type": "string"
                         }
                       },
-                      "required": ["containerPort"],
+                      "required": [
+                        "containerPort"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                    "x-kubernetes-list-map-keys": [
+                      "containerPort",
+                      "protocol"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
@@ -21477,7 +23484,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21496,7 +23505,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -21520,7 +23532,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21553,7 +23567,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21569,6 +23585,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "items": {
+                      "properties": {
+                        "resourceName": {
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
                     "properties": {
                       "claims": {
@@ -21578,12 +23614,16 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name"],
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
                         "type": "array",
-                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
                         "x-kubernetes-list-type": "map"
                       },
                       "limits": {
@@ -21619,6 +23659,9 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "restartPolicy": {
+                    "type": "string"
                   },
                   "securityContext": {
                     "properties": {
@@ -21690,7 +23733,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21744,7 +23789,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21763,7 +23810,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -21787,7 +23837,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21820,7 +23872,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -21861,7 +23915,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["devicePath", "name"],
+                      "required": [
+                        "devicePath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -21889,7 +23946,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["mountPath", "name"],
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -21899,7 +23959,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -21914,7 +23976,11 @@
             "logger": {
               "properties": {
                 "mode": {
-                  "enum": ["all", "request", "response"],
+                  "enum": [
+                    "all",
+                    "request",
+                    "response"
+                  ],
                   "type": "string"
                 },
                 "url": {
@@ -21981,7 +24047,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["conditionType"],
+                "required": [
+                  "conditionType"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -22006,12 +24074,16 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "restartPolicy": {
@@ -22021,7 +24093,12 @@
               "type": "string"
             },
             "scaleMetric": {
-              "enum": ["cpu", "memory", "concurrency", "rps"],
+              "enum": [
+                "cpu",
+                "memory",
+                "concurrency",
+                "rps"
+              ],
               "type": "string"
             },
             "scaleTarget": {
@@ -22037,12 +24114,16 @@
                     "type": "string"
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array",
-              "x-kubernetes-list-map-keys": ["name"],
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
               "x-kubernetes-list-type": "map"
             },
             "securityContext": {
@@ -22092,7 +24173,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -22113,7 +24196,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["name", "value"],
+                    "required": [
+                      "name",
+                      "value"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22210,7 +24296,10 @@
                               "type": "array"
                             }
                           },
-                          "required": ["key", "operator"],
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -22255,7 +24344,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -22285,7 +24378,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22310,7 +24405,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["diskName", "diskURI"],
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22326,7 +24424,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["secretName", "shareName"],
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22361,7 +24462,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["monitors"],
+                    "required": [
+                      "monitors"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22387,7 +24490,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22411,7 +24516,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["key", "path"],
+                          "required": [
+                            "key",
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -22456,7 +24564,9 @@
                         "type": "object"
                       }
                     },
-                    "required": ["driver"],
+                    "required": [
+                      "driver"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22478,7 +24588,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["fieldPath"],
+                              "required": [
+                                "fieldPath"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
@@ -22511,13 +24623,17 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["resource"],
+                              "required": [
+                                "resource"
+                              ],
                               "type": "object",
                               "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -22575,7 +24691,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["kind", "name"],
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
@@ -22595,7 +24714,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["kind", "name"],
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -22608,12 +24730,16 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["name"],
+                                      "required": [
+                                        "name"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
                                     "type": "array",
-                                    "x-kubernetes-list-map-keys": ["name"],
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
                                     "x-kubernetes-list-type": "map"
                                   },
                                   "limits": {
@@ -22668,7 +24794,10 @@
                                           "type": "array"
                                         }
                                       },
-                                      "required": ["key", "operator"],
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
                                       "type": "object",
                                       "additionalProperties": false
                                     },
@@ -22699,7 +24828,9 @@
                             "additionalProperties": false
                           }
                         },
-                        "required": ["spec"],
+                        "required": [
+                          "spec"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -22763,7 +24894,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["driver"],
+                    "required": [
+                      "driver"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22795,7 +24928,9 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["pdName"],
+                    "required": [
+                      "pdName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22811,7 +24946,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["repository"],
+                    "required": [
+                      "repository"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22827,7 +24964,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["endpoints", "path"],
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22840,7 +24980,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["path"],
+                    "required": [
+                      "path"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22891,7 +25033,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["iqn", "lun", "targetPortal"],
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22910,7 +25056,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["path", "server"],
+                    "required": [
+                      "path",
+                      "server"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22923,7 +25072,9 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["claimName"],
+                    "required": [
+                      "claimName"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22936,7 +25087,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["pdID"],
+                    "required": [
+                      "pdID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22952,7 +25105,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumeID"],
+                    "required": [
+                      "volumeID"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -22981,7 +25136,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["key", "path"],
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -23012,7 +25170,9 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["fieldPath"],
+                                        "required": [
+                                          "fieldPath"
+                                        ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
@@ -23045,13 +25205,17 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["resource"],
+                                        "required": [
+                                          "resource"
+                                        ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
-                                    "required": ["path"],
+                                    "required": [
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -23077,7 +25241,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["key", "path"],
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -23107,7 +25274,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["path"],
+                              "required": [
+                                "path"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             }
@@ -23142,7 +25311,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["registry", "volume"],
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -23183,7 +25355,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["image", "monitors"],
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -23227,7 +25402,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["gateway", "secretRef", "system"],
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -23251,7 +25430,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["key", "path"],
+                          "required": [
+                            "key",
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -23310,12 +25492,16 @@
                         "type": "string"
                       }
                     },
-                    "required": ["volumePath"],
+                    "required": [
+                      "volumePath"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -23326,7 +25512,9 @@
           "additionalProperties": false
         }
       },
-      "required": ["predictor"],
+      "required": [
+        "predictor"
+      ],
       "type": "object",
       "additionalProperties": false
     },
@@ -23335,6 +25523,9 @@
         "address": {
           "properties": {
             "CACerts": {
+              "type": "string"
+            },
+            "audience": {
               "type": "string"
             },
             "name": {
@@ -23359,6 +25550,9 @@
               "address": {
                 "properties": {
                   "CACerts": {
+                    "type": "string"
+                  },
+                  "audience": {
                     "type": "string"
                   },
                   "name": {
@@ -23448,7 +25642,10 @@
                 "type": "string"
               }
             },
-            "required": ["status", "type"],
+            "required": [
+              "status",
+              "type"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -23466,7 +25663,9 @@
                   "type": "integer"
                 }
               },
-              "required": ["failedCopies"],
+              "required": [
+                "failedCopies"
+              ],
               "type": "object",
               "additionalProperties": false
             },
@@ -23531,7 +25730,9 @@
                   "type": "string"
                 }
               },
-              "required": ["activeModelState"],
+              "required": [
+                "activeModelState"
+              ],
               "type": "object",
               "additionalProperties": false
             },
@@ -23547,7 +25748,9 @@
               "type": "string"
             }
           },
-          "required": ["transitionStatus"],
+          "required": [
+            "transitionStatus"
+          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/serving.kserve.io/servingruntime_v1alpha1.json
+++ b/serving.kserve.io/servingruntime_v1alpha1.json
@@ -36,7 +36,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -58,7 +61,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -74,7 +80,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["preference", "weight"],
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -101,7 +110,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -123,7 +135,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -137,7 +152,9 @@
                       "type": "array"
                     }
                   },
-                  "required": ["nodeSelectorTerms"],
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
                   "type": "object",
                   "x-kubernetes-map-type": "atomic",
                   "additionalProperties": false
@@ -171,7 +188,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -206,7 +226,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -233,7 +256,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -242,7 +267,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["podAffinityTerm", "weight"],
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -269,7 +297,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -304,7 +335,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -331,7 +365,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["topologyKey"],
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -366,7 +402,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -401,7 +440,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -428,7 +470,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["topologyKey"],
+                        "required": [
+                          "topologyKey"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -437,7 +481,10 @@
                         "type": "integer"
                       }
                     },
-                    "required": ["podAffinityTerm", "weight"],
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -464,7 +511,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -499,7 +549,10 @@
                                   "type": "array"
                                 }
                               },
-                              "required": ["key", "operator"],
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -526,7 +579,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["topologyKey"],
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -571,7 +626,9 @@
                             "type": "boolean"
                           }
                         },
-                        "required": ["key"],
+                        "required": [
+                          "key"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -585,7 +642,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["fieldPath"],
+                        "required": [
+                          "fieldPath"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -611,7 +670,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["resource"],
+                        "required": [
+                          "resource"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -628,7 +689,9 @@
                             "type": "boolean"
                           }
                         },
-                        "required": ["key"],
+                        "required": [
+                          "key"
+                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -638,7 +701,9 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -698,7 +763,9 @@
                               "type": "boolean"
                             }
                           },
-                          "required": ["key"],
+                          "required": [
+                            "key"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -712,7 +779,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["fieldPath"],
+                          "required": [
+                            "fieldPath"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -738,7 +807,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["resource"],
+                          "required": [
+                            "resource"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -755,7 +826,9 @@
                               "type": "boolean"
                             }
                           },
-                          "required": ["key"],
+                          "required": [
+                            "key"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -765,7 +838,9 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -846,7 +921,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -870,7 +948,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -891,7 +971,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -928,7 +1010,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "value"],
+                              "required": [
+                                "name",
+                                "value"
+                              ],
                               "type": "object",
                               "additionalProperties": false
                             },
@@ -952,7 +1037,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -973,7 +1060,9 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "required": ["port"],
+                        "required": [
+                          "port"
+                        ],
                         "type": "object",
                         "additionalProperties": false
                       }
@@ -1013,7 +1102,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1032,7 +1123,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1056,7 +1150,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1089,7 +1185,9 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1130,12 +1228,17 @@
                       "type": "string"
                     }
                   },
-                  "required": ["containerPort"],
+                  "required": [
+                    "containerPort"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
                 "type": "array",
-                "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
                 "x-kubernetes-list-type": "map"
               },
               "readinessProbe": {
@@ -1166,7 +1269,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1185,7 +1290,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1209,7 +1317,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1242,7 +1352,9 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1258,6 +1370,26 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "resizePolicy": {
+                "items": {
+                  "properties": {
+                    "resourceName": {
+                      "type": "string"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "resourceName",
+                    "restartPolicy"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
               "resources": {
                 "properties": {
                   "claims": {
@@ -1267,12 +1399,16 @@
                           "type": "string"
                         }
                       },
-                      "required": ["name"],
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",
-                    "x-kubernetes-list-map-keys": ["name"],
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
                     "x-kubernetes-list-type": "map"
                   },
                   "limits": {
@@ -1308,6 +1444,9 @@
                 },
                 "type": "object",
                 "additionalProperties": false
+              },
+              "restartPolicy": {
+                "type": "string"
               },
               "securityContext": {
                 "properties": {
@@ -1379,7 +1518,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1433,7 +1574,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1452,7 +1595,10 @@
                               "type": "string"
                             }
                           },
-                          "required": ["name", "value"],
+                          "required": [
+                            "name",
+                            "value"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -1476,7 +1622,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1509,7 +1657,9 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "required": ["port"],
+                    "required": [
+                      "port"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
@@ -1550,7 +1700,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["devicePath", "name"],
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -1578,7 +1731,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["mountPath", "name"],
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -1588,7 +1744,9 @@
                 "type": "string"
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1661,11 +1819,18 @@
               "name": {
                 "type": "string"
               },
+              "priority": {
+                "format": "int32",
+                "minimum": 1,
+                "type": "integer"
+              },
               "version": {
                 "type": "string"
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -1715,7 +1880,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumeID"],
+                "required": [
+                  "volumeID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1740,7 +1907,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["diskName", "diskURI"],
+                "required": [
+                  "diskName",
+                  "diskURI"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1756,7 +1926,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["secretName", "shareName"],
+                "required": [
+                  "secretName",
+                  "shareName"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1791,7 +1964,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["monitors"],
+                "required": [
+                  "monitors"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1817,7 +1992,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumeID"],
+                "required": [
+                  "volumeID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1841,7 +2018,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["key", "path"],
+                      "required": [
+                        "key",
+                        "path"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -1886,7 +2066,9 @@
                     "type": "object"
                   }
                 },
-                "required": ["driver"],
+                "required": [
+                  "driver"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -1908,7 +2090,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["fieldPath"],
+                          "required": [
+                            "fieldPath"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
@@ -1941,13 +2125,17 @@
                               "type": "string"
                             }
                           },
-                          "required": ["resource"],
+                          "required": [
+                            "resource"
+                          ],
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
-                      "required": ["path"],
+                      "required": [
+                        "path"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2005,7 +2193,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["kind", "name"],
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
@@ -2025,7 +2216,10 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["kind", "name"],
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2038,12 +2232,16 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["name"],
+                                  "required": [
+                                    "name"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
                                 "type": "array",
-                                "x-kubernetes-list-map-keys": ["name"],
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
                                 "x-kubernetes-list-type": "map"
                               },
                               "limits": {
@@ -2098,7 +2296,10 @@
                                       "type": "array"
                                     }
                                   },
-                                  "required": ["key", "operator"],
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
                                   "type": "object",
                                   "additionalProperties": false
                                 },
@@ -2129,7 +2330,9 @@
                         "additionalProperties": false
                       }
                     },
-                    "required": ["spec"],
+                    "required": [
+                      "spec"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   }
@@ -2193,7 +2396,9 @@
                     "additionalProperties": false
                   }
                 },
-                "required": ["driver"],
+                "required": [
+                  "driver"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2225,7 +2430,9 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["pdName"],
+                "required": [
+                  "pdName"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2241,7 +2448,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["repository"],
+                "required": [
+                  "repository"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2257,7 +2466,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["endpoints", "path"],
+                "required": [
+                  "endpoints",
+                  "path"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2270,7 +2482,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["path"],
+                "required": [
+                  "path"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2321,7 +2535,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["iqn", "lun", "targetPortal"],
+                "required": [
+                  "iqn",
+                  "lun",
+                  "targetPortal"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2340,7 +2558,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["path", "server"],
+                "required": [
+                  "path",
+                  "server"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2353,7 +2574,9 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["claimName"],
+                "required": [
+                  "claimName"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2366,7 +2589,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["pdID"],
+                "required": [
+                  "pdID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2382,7 +2607,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumeID"],
+                "required": [
+                  "volumeID"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2411,7 +2638,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["key", "path"],
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2442,7 +2672,9 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["fieldPath"],
+                                    "required": [
+                                      "fieldPath"
+                                    ],
                                     "type": "object",
                                     "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
@@ -2475,13 +2707,17 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["resource"],
+                                    "required": [
+                                      "resource"
+                                    ],
                                     "type": "object",
                                     "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   }
                                 },
-                                "required": ["path"],
+                                "required": [
+                                  "path"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2507,7 +2743,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["key", "path"],
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2537,7 +2776,9 @@
                               "type": "string"
                             }
                           },
-                          "required": ["path"],
+                          "required": [
+                            "path"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         }
@@ -2572,7 +2813,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["registry", "volume"],
+                "required": [
+                  "registry",
+                  "volume"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2613,7 +2857,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["image", "monitors"],
+                "required": [
+                  "image",
+                  "monitors"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2657,7 +2904,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["gateway", "secretRef", "system"],
+                "required": [
+                  "gateway",
+                  "secretRef",
+                  "system"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -2681,7 +2932,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["key", "path"],
+                      "required": [
+                        "key",
+                        "path"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -2740,19 +2994,25 @@
                     "type": "string"
                   }
                 },
-                "required": ["volumePath"],
+                "required": [
+                  "volumePath"
+                ],
                 "type": "object",
                 "additionalProperties": false
               }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
           "type": "array"
         }
       },
-      "required": ["containers"],
+      "required": [
+        "containers"
+      ],
       "type": "object",
       "additionalProperties": false
     },

--- a/serving.kserve.io/trainedmodel_v1alpha1.json
+++ b/serving.kserve.io/trainedmodel_v1alpha1.json
@@ -35,12 +35,19 @@
               "type": "string"
             }
           },
-          "required": ["framework", "memory", "storageUri"],
+          "required": [
+            "framework",
+            "memory",
+            "storageUri"
+          ],
           "type": "object",
           "additionalProperties": false
         }
       },
-      "required": ["inferenceService", "model"],
+      "required": [
+        "inferenceService",
+        "model"
+      ],
       "type": "object",
       "additionalProperties": false
     },
@@ -49,6 +56,9 @@
         "address": {
           "properties": {
             "CACerts": {
+              "type": "string"
+            },
+            "audience": {
               "type": "string"
             },
             "name": {
@@ -89,7 +99,10 @@
                 "type": "string"
               }
             },
-            "required": ["status", "type"],
+            "required": [
+              "status",
+              "type"
+            ],
             "type": "object",
             "additionalProperties": false
           },


### PR DESCRIPTION
This PR aims to update the Kserve [CRDs](https://github.com/kserve/kserve/tree/master/charts/kserve-crd/templates) from the latest version (v0.13.1) using the crd-extractor.sh tool.
- The priority field for the ClusterServingRuntime is missing, raising invalid validation such as:
`ClusterServingRuntime kserve-mlserver is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/supportedModelFormats/0' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/master/serving.kserve.io/clusterservingruntime_v1alpha1.json#/properties/spec/properties/supportedModelFormats/items/additionalProperties: additionalProperties 'priority' not allowed`