### PR TITLE
feat: fluent-operator CRDs (v3.2.0)

### DIFF
--- a/fluentbit.fluent.io/clusterfilter_v1alpha2.json
+++ b/fluentbit.fluent.io/clusterfilter_v1alpha2.json
@@ -1,0 +1,935 @@
+{
+  "description": "ClusterFilter defines a cluster-level Filter configuration.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Filter configuration.",
+      "properties": {
+        "filters": {
+          "description": "A set of filter plugins in order.",
+          "items": {
+            "properties": {
+              "aws": {
+                "description": "Aws defines a Aws configuration.",
+                "properties": {
+                  "accountID": {
+                    "description": "The account ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "amiID": {
+                    "description": "The EC2 instance image id.Default is false.",
+                    "type": "boolean"
+                  },
+                  "az": {
+                    "description": "The availability zone; for example, \"us-east-1a\". Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceID": {
+                    "description": "The EC2 instance ID.Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceType": {
+                    "description": "The EC2 instance type.Default is false.",
+                    "type": "boolean"
+                  },
+                  "hostName": {
+                    "description": "The hostname for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "imdsVersion": {
+                    "description": "Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2'.",
+                    "enum": [
+                      "v1",
+                      "v2"
+                    ],
+                    "type": "string"
+                  },
+                  "privateIP": {
+                    "description": "The EC2 instance private ip.Default is false.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "vpcID": {
+                    "description": "The VPC ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "customPlugin": {
+                "description": "CustomPlugin defines a Custom plugin configuration.",
+                "properties": {
+                  "config": {
+                    "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+                    "type": "string"
+                  },
+                  "yamlConfig": {
+                    "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "grep": {
+                "description": "Grep defines Grep Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Exclude records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Keep records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kubernetes": {
+                "description": "Kubernetes defines Kubernetes Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "annotations": {
+                    "description": "Include Kubernetes resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "bufferSize": {
+                    "description": "Set the buffer size for HTTP client when reading responses from Kubernetes API server.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "cacheUseDockerId": {
+                    "description": "When enabled, metadata will be fetched from K8s when docker_id is changed.",
+                    "type": "boolean"
+                  },
+                  "dnsRetries": {
+                    "description": "DNS lookup retries N times until the network start working",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dnsWaitTime": {
+                    "description": "DNS lookup interval between network status checks",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dummyMeta": {
+                    "description": "If set, use dummy-meta data (for test/dev purposes)",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingExclude": {
+                    "description": "Allow Kubernetes Pods to exclude their logs from the log processor\n(read more about it in Kubernetes Annotations section).",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingParser": {
+                    "description": "Allow Kubernetes Pods to suggest a pre-defined Parser\n(read more about it in Kubernetes Annotations section)",
+                    "type": "boolean"
+                  },
+                  "keepLog": {
+                    "description": "When Keep_Log is disabled, the log field is removed\nfrom the incoming message once it has been successfully merged\n(Merge_Log must be enabled as well).",
+                    "type": "boolean"
+                  },
+                  "kubeCAFile": {
+                    "description": "CA certificate file",
+                    "type": "string"
+                  },
+                  "kubeCAPath": {
+                    "description": "Absolute path to scan for certificate files",
+                    "type": "string"
+                  },
+                  "kubeMetaCacheTTL": {
+                    "description": "configurable TTL for K8s cached metadata. By default, it is set to 0\nwhich means TTL for cache entries is disabled and cache entries are evicted at random\nwhen capacity is reached. In order to enable this option, you should set the number to a time interval.\nFor example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted.",
+                    "type": "string"
+                  },
+                  "kubeMetaNamespaceCacheTTL": {
+                    "description": "Configurable TTL for K8s cached namespace metadata.\nBy default, it is set to 900 which means a 15min TTL for namespace cache entries.\nSetting this to 0 will mean entries are evicted at random once the cache is full.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "kubeMetaPreloadCacheDir": {
+                    "description": "If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory,\nnamed as namespace-pod.meta",
+                    "type": "string"
+                  },
+                  "kubeTagPrefix": {
+                    "description": "When the source records comes from Tail input plugin,\nthis option allows to specify what's the prefix used in Tail configuration.",
+                    "type": "string"
+                  },
+                  "kubeTokenCommand": {
+                    "description": "Command to get Kubernetes authorization token.\nBy default, it will be NULL and we will use token file to get token.",
+                    "type": "string"
+                  },
+                  "kubeTokenFile": {
+                    "description": "Token file",
+                    "type": "string"
+                  },
+                  "kubeTokenTTL": {
+                    "description": "configurable 'time to live' for the K8s token. By default, it is set to 600 seconds.\nAfter this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.",
+                    "type": "string"
+                  },
+                  "kubeURL": {
+                    "description": "API Server end-point",
+                    "type": "string"
+                  },
+                  "kubeletHost": {
+                    "description": "kubelet host using for HTTP request, this only works when Use_Kubelet set to On.",
+                    "type": "string"
+                  },
+                  "kubeletPort": {
+                    "description": "kubelet port using for HTTP request, this only works when useKubelet is set to On.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "description": "Include Kubernetes resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "mergeLog": {
+                    "description": "When enabled, it checks if the log field content is a JSON string map,\nif so, it append the map fields as part of the log structure.",
+                    "type": "boolean"
+                  },
+                  "mergeLogKey": {
+                    "description": "When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message\nand make a structured representation of it at the same level of the log field in the map.\nNow if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.",
+                    "type": "string"
+                  },
+                  "mergeLogTrim": {
+                    "description": "When Merge_Log is enabled, trim (remove possible \\n or \\r) field values.",
+                    "type": "boolean"
+                  },
+                  "mergeParser": {
+                    "description": "Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.",
+                    "type": "string"
+                  },
+                  "namespaceAnnotations": {
+                    "description": "Include Kubernetes namespace resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceLabels": {
+                    "description": "Include Kubernetes namespace resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceMetadataOnly": {
+                    "description": "Include Kubernetes namespace metadata only and no pod metadata.\nIf this is set, the values of Labels and Annotations are ignored.",
+                    "type": "boolean"
+                  },
+                  "regexParser": {
+                    "description": "Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.\nThe parser must be registered in a parsers file (refer to parser filter-kube-test as an example).",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tlsDebug": {
+                    "description": "Debug level between 0 (nothing) and 4 (every detail).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tlsVerify": {
+                    "description": "When enabled, turns on certificate validation when connecting to the Kubernetes API server.",
+                    "type": "boolean"
+                  },
+                  "useJournal": {
+                    "description": "When enabled, the filter reads logs coming in Journald format.",
+                    "type": "boolean"
+                  },
+                  "useKubelet": {
+                    "description": "This is an optional feature flag to get metadata information from kubelet\ninstead of calling Kube Server API to enhance the log.\nThis could mitigate the Kube API heavy traffic issue for large cluster.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logToMetrics": {
+                "description": "LogToMetrics defines a Log to Metrics Filter configuration.",
+                "properties": {
+                  "addLabel": {
+                    "description": "Add a custom label NAME and set the value to the value of KEY",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "bucket": {
+                    "description": "Defines a bucket for histogram",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "discardLogs": {
+                    "description": "Flag that defines if logs should be discarded after processing. This applies\nfor all logs, no matter if they have emitted metrics or not.",
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "description": "set a buffer limit to restrict memory usage of metrics emitter",
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "Name of the emitter (advanced users)",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Optional filter for records in which the content of KEY does not matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "kubernetesMode": {
+                    "description": "If enabled, it will automatically put pod_id, pod_name, namespace_name, docker_id and container_name\ninto the metric as labels. This option is intended to be used in combination with the kubernetes filter plugin.",
+                    "type": "boolean"
+                  },
+                  "labelField": {
+                    "description": "Includes a record field as label dimension in the metric.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "metricDescription": {
+                    "description": "Sets a help text for the metric.",
+                    "type": "string"
+                  },
+                  "metricMode": {
+                    "description": "Defines the mode for the metric. Valid values are [counter, gauge or histogram]",
+                    "type": "string"
+                  },
+                  "metricName": {
+                    "description": "Sets the name of the metric.",
+                    "type": "string"
+                  },
+                  "metricNamespace": {
+                    "description": "Namespace of the metric",
+                    "type": "string"
+                  },
+                  "metricSubsystem": {
+                    "description": "Sets a sub-system for the metric.",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Optional filter for records in which the content of KEY matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Defines the tag for the generated metrics record",
+                    "type": "string"
+                  },
+                  "valueField": {
+                    "description": "Specify the record field that holds a numerical value",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "lua": {
+                "description": "Lua defines Lua Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "call": {
+                    "description": "Lua function name that will be triggered to do filtering.\nIt's assumed that the function is declared inside the Script defined above.",
+                    "type": "string"
+                  },
+                  "code": {
+                    "description": "Inline LUA code instead of loading from a path via script.",
+                    "type": "string"
+                  },
+                  "protectedMode": {
+                    "description": "If enabled, Lua script will be executed in protected mode.\nIt prevents to crash when invalid Lua script is executed. Default is true.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "script": {
+                    "description": "Path to the Lua script that will be used.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "timeAsTable": {
+                    "description": "By default when the Lua script is invoked, the record timestamp is passed as a\nFloating number which might lead to loss precision when the data is converted back.\nIf you desire timestamp precision enabling this option will pass the timestamp as\na Lua table with keys sec for seconds since epoch and nsec for nanoseconds.",
+                    "type": "boolean"
+                  },
+                  "typeArrayKey": {
+                    "description": "If these keys are matched, the fields are handled as array. If more than\none key, delimit by space. It is useful the array can be empty.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "typeIntKey": {
+                    "description": "If these keys are matched, the fields are converted to integer.\nIf more than one key, delimit by space.\nNote that starting from Fluent Bit v1.6 integer data types are preserved\nand not converted to double as in previous versions.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "call"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "modify": {
+                "description": "Modify defines Modify Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "description": "All conditions have to be true for the rules to be applied.",
+                    "items": {
+                      "description": "The plugin supports the following conditions",
+                      "properties": {
+                        "aKeyMatches": {
+                          "description": "Is true if a key matches regex KEY",
+                          "type": "string"
+                        },
+                        "keyDoesNotExist": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY does not exist",
+                          "type": "object"
+                        },
+                        "keyExists": {
+                          "description": "Is true if KEY exists",
+                          "type": "string"
+                        },
+                        "keyValueDoesNotEqual": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is not VALUE",
+                          "type": "object"
+                        },
+                        "keyValueDoesNotMatch": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value does not match VALUE",
+                          "type": "object"
+                        },
+                        "keyValueEquals": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is VALUE",
+                          "type": "object"
+                        },
+                        "keyValueMatches": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value matches VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysDoNotHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that do not match VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that match VALUE",
+                          "type": "object"
+                        },
+                        "noKeyMatches": {
+                          "description": "Is true if no key matches regex KEY",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Rules are applied in the order they appear,\nwith each rule operating on the result of the previous rule.",
+                    "items": {
+                      "description": "The plugin supports the following rules",
+                      "properties": {
+                        "add": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE if KEY does not exist",
+                          "type": "object"
+                        },
+                        "copy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "hardCopy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists.\nIf COPIED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "hardRename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists.\nIf RENAMED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "remove": {
+                          "description": "Remove a key/value pair with key KEY if it exists",
+                          "type": "string"
+                        },
+                        "removeRegex": {
+                          "description": "Remove all key/value pairs with key matching regexp KEY",
+                          "type": "string"
+                        },
+                        "removeWildcard": {
+                          "description": "Remove all key/value pairs with key matching wildcard KEY",
+                          "type": "string"
+                        },
+                        "rename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "set": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "multiline": {
+                "description": "Multiline defines a Multiline configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "buffer": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "default": 10,
+                    "description": "Set a limit on the amount of memory in MB the emitter can consume if the outputs provide backpressure. The default for this limit is 10M. The pipeline will pause once the buffer exceeds the value of this setting. For example, if the value is set to 10MB then the pipeline will pause if the buffer exceeds 10M. The pipeline will remain paused until the output drains the buffer below the 10M limit.",
+                    "type": "integer"
+                  },
+                  "emitterName": {
+                    "description": "Name for the emitter input instance which re-emits the completed records at the beginning of the pipeline.",
+                    "type": "string"
+                  },
+                  "emitterType": {
+                    "default": "memory",
+                    "description": "The storage type for the emitter input instance. This option supports the values memory (default) and filesystem.",
+                    "enum": [
+                      "memory",
+                      "filesystem"
+                    ],
+                    "type": "string"
+                  },
+                  "flushMs": {
+                    "default": 2000,
+                    "type": "integer"
+                  },
+                  "keyContent": {
+                    "description": "Key name that holds the content to process.\nNote that a Multiline Parser definition can already specify the key_content to use, but this option allows to overwrite that value for the purpose of the filter.",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "enum": [
+                      "parser",
+                      "partial_message"
+                    ],
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify one or multiple Multiline Parsing definitions to apply to the content.\nYou can specify multiple multiline parsers to detect different formats by separating them with a comma.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parser"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nest": {
+                "description": "Nest defines Nest Filter configuration.",
+                "properties": {
+                  "addPrefix": {
+                    "description": "Prefix affected keys with this string",
+                    "type": "string"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "nestUnder": {
+                    "description": "Nest records matching the Wildcard under this key",
+                    "type": "string"
+                  },
+                  "nestedUnder": {
+                    "description": "Lift records nested under the Nested_under key",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "Select the operation nest or lift",
+                    "enum": [
+                      "nest",
+                      "lift"
+                    ],
+                    "type": "string"
+                  },
+                  "removePrefix": {
+                    "description": "Remove prefix from affected keys if it matches this string",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wildcard": {
+                    "description": "Nest records which field matches the wildcard",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "parser": {
+                "description": "Parser defines Parser Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "keyName": {
+                    "description": "Specify field name in record to parse.",
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify the parser name to interpret the field.\nMultiple Parser entries are allowed (split by comma).",
+                    "type": "string"
+                  },
+                  "preserveKey": {
+                    "description": "Keep original Key_Name field in the parsed result.\nIf false, the field will be removed.",
+                    "type": "boolean"
+                  },
+                  "reserveData": {
+                    "description": "Keep all other original fields in the parsed result.\nIf false, all other original fields will be removed.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "unescapeKey": {
+                    "description": "If the key is a escaped string (e.g: stringify JSON), unescape the string before to apply the parser.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "recordModifier": {
+                "description": "RecordModifier defines Record Modifier Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "allowlistKeys": {
+                    "description": "If the key is not matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "records": {
+                    "description": "Append fields. This parameter needs key and value pair.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "removeKeys": {
+                    "description": "If the key is matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "uuidKeys": {
+                    "description": "If set, the plugin appends uuid to each record. The value assigned becomes the key in the map.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "whitelistKeys": {
+                    "description": "An alias of allowlistKeys for backwards compatibility.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rewriteTag": {
+                "description": "RewriteTag defines a RewriteTag configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "emitterMemBufLimit": {
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "When the filter emits a record under the new Tag, there is an internal emitter\nplugin that takes care of the job. Since this emitter expose metrics as any other\ncomponent of the pipeline, you can use this property to configure an optional name for it.",
+                    "type": "string"
+                  },
+                  "emitterStorageType": {
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Defines the matching criteria and the format of the Tag for the matching record.\nThe Rule format have four components: KEY REGEX NEW_TAG KEEP.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "throttle": {
+                "description": "Throttle defines a Throttle configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "interval": {
+                    "description": "Interval is the time interval expressed in \"sleep\" format. e.g. 3s, 1.5m, 0.5h, etc.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "printStatus": {
+                    "description": "PrintStatus represents whether to print status messages with current rate and the limits to information logs.",
+                    "type": "boolean"
+                  },
+                  "rate": {
+                    "description": "Rate is the amount of messages for the time.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "window": {
+                    "description": "Window is the amount of intervals to calculate average over.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "wasm": {
+                "description": "Wasm defines a Wasm configuration.",
+                "properties": {
+                  "accessiblePaths": {
+                    "description": "Specify the whitelist of paths to be able to access paths from WASM programs.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "eventFormat": {
+                    "description": "Define event format to interact with Wasm programs: msgpack or json. Default: json",
+                    "type": "string"
+                  },
+                  "functionName": {
+                    "description": "Wasm function name that will be triggered to do filtering. It's assumed that the function is built inside the Wasm program specified above.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wasmHeapSize": {
+                    "description": "Size of the heap size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "wasmPath": {
+                    "description": "Path to the built Wasm program that will be used. This can be a relative path against the main configuration file.",
+                    "type": "string"
+                  },
+                  "wasmStackSize": {
+                    "description": "Size of the stack size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "logLevel": {
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case-sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/clusterfluentbitconfig_v1alpha2.json
+++ b/fluentbit.fluent.io/clusterfluentbitconfig_v1alpha2.json
@@ -1,0 +1,423 @@
+{
+  "description": "ClusterFluentBitConfig is the Schema for the cluster-level fluentbitconfigs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluentBitConfigSpec defines the desired state of ClusterFluentBitConfig",
+      "properties": {
+        "configFileFormat": {
+          "description": "ConfigFileFormat defines the format of the config file, default is \"classic\",\navailable options are \"classic\" and \"yaml\"",
+          "enum": [
+            "classic",
+            "yaml"
+          ],
+          "type": "string"
+        },
+        "filterSelector": {
+          "description": "Select filter plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "inputSelector": {
+          "description": "Select input plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "multilineParserSelector": {
+          "description": "Select multiline parser plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "namespace": {
+          "description": "If namespace is defined, then the configmap and secret for fluent-bit is in this namespace.\nIf it is not defined, it is in the namespace of the fluentd-operator",
+          "type": "string"
+        },
+        "outputSelector": {
+          "description": "Select output plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "parserSelector": {
+          "description": "Select parser plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "service": {
+          "description": "Service defines the global behaviour of the Fluent Bit engine.",
+          "properties": {
+            "daemon": {
+              "description": "If true go to background on start",
+              "type": "boolean"
+            },
+            "emitterMemBufLimit": {
+              "type": "string"
+            },
+            "emitterName": {
+              "description": "Per-namespace re-emitter configuration",
+              "type": "string"
+            },
+            "emitterStorageType": {
+              "type": "string"
+            },
+            "flushSeconds": {
+              "description": "Interval to flush output",
+              "format": "int64",
+              "type": "integer"
+            },
+            "graceSeconds": {
+              "description": "Wait time on exit",
+              "format": "int64",
+              "type": "integer"
+            },
+            "hcErrorsCount": {
+              "description": "the error count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for output error: [2022/02/16 10:44:10] [ warn] [engine] failed to flush chunk '1-1645008245.491540684.flb', retry in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3 (out_id=3)",
+              "format": "int64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "hcPeriod": {
+              "description": "The time period by second to count the error and retry failure data point",
+              "format": "int64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "hcRetryFailureCount": {
+              "description": "the retry failure count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for retry failure: [2022/02/16 20:11:36] [ warn] [engine] chunk '1-1645042288.260516436.flb' cannot be retried: task_id=0, input=tcp.3 > output=cloudwatch_logs.1",
+              "format": "int64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "healthCheck": {
+              "description": "enable Health check feature at http://127.0.0.1:2020/api/v1/health Note: Enabling this will not automatically configure kubernetes to use fluentbit's healthcheck endpoint",
+              "type": "boolean"
+            },
+            "hotReload": {
+              "description": "If true enable reloading via HTTP",
+              "type": "boolean"
+            },
+            "httpListen": {
+              "description": "Address to listen",
+              "pattern": "^\\d{1,3}.\\d{1,3}.\\d{1,3}.\\d{1,3}$",
+              "type": "string"
+            },
+            "httpPort": {
+              "description": "Port to listen",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "httpServer": {
+              "description": "If true enable statistics HTTP server",
+              "type": "boolean"
+            },
+            "logFile": {
+              "description": "File to log diagnostic output",
+              "type": "string"
+            },
+            "logLevel": {
+              "description": "Diagnostic level (error/warning/info/debug/trace)",
+              "enum": [
+                "off",
+                "error",
+                "warning",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "type": "string"
+            },
+            "parsersFile": {
+              "description": "Optional 'parsers' config file (can be multiple)",
+              "type": "string"
+            },
+            "parsersFiles": {
+              "description": "backward compatible",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "storage": {
+              "description": "Configure a global environment for the storage layer in Service. It is recommended to configure the volume and volumeMount separately for this storage. The hostPath type should be used for that Volume in Fluentbit daemon set.",
+              "properties": {
+                "backlogMemLimit": {
+                  "description": "This option configure a hint of maximum value of memory to use when processing these records",
+                  "type": "string"
+                },
+                "checksum": {
+                  "description": "Enable the data integrity check when writing and reading data from the filesystem",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "deleteIrrecoverableChunks": {
+                  "description": "When enabled, irrecoverable chunks will be deleted during runtime, and any other irrecoverable chunk located in the configured storage path directory will be deleted when Fluent-Bit starts.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "maxChunksUp": {
+                  "description": "If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "metrics": {
+                  "description": "If http_server option has been enabled in the Service section, this option registers a new endpoint where internal metrics of the storage layer can be consumed",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Select an optional location in the file system to store streams and chunks of data/",
+                  "type": "string"
+                },
+                "sync": {
+                  "description": "Configure the synchronization mode used to store the data into the file system",
+                  "enum": [
+                    "normal",
+                    "full"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/clusterinput_v1alpha2.json
+++ b/fluentbit.fluent.io/clusterinput_v1alpha2.json
@@ -1,0 +1,957 @@
+{
+  "description": "ClusterInput is the Schema for the inputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "InputSpec defines the desired state of ClusterInput",
+      "properties": {
+        "alias": {
+          "description": "A user friendly alias name for this input plugin.\nUsed in metrics for distinction of each configured input.",
+          "type": "string"
+        },
+        "collectd": {
+          "description": "Collectd defines the Collectd input plugin configuration",
+          "properties": {
+            "listen": {
+              "description": "Set the address to listen to, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "Set the port to listen to, default: 25826",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "typesDB": {
+              "description": "Set the data specification file,default: /usr/share/collectd/types.db",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customPlugin": {
+          "description": "CustomPlugin defines Custom Input configuration.",
+          "properties": {
+            "config": {
+              "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+              "type": "string"
+            },
+            "yamlConfig": {
+              "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dummy": {
+          "description": "Dummy defines Dummy Input configuration.",
+          "properties": {
+            "dummy": {
+              "description": "Dummy JSON record.",
+              "type": "string"
+            },
+            "rate": {
+              "description": "Events number generated per second.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Sample events to generate.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "execWasi": {
+          "description": "ExecWasi defines the exec wasi input plugin configuration",
+          "properties": {
+            "accessiblePaths": {
+              "description": "Specify the whitelist of paths to be able to access paths from WASM programs.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "bufSize": {
+              "description": "Size of the buffer (check unit sizes for allowed values)",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "intervalNSec": {
+              "description": "Polling interval (nanoseconds).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "intervalSec": {
+              "description": "Polling interval (seconds).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "parser": {
+              "description": "Specify the name of a parser to interpret the entry as a structured message.",
+              "type": "string"
+            },
+            "threaded": {
+              "description": "Indicates whether to run this input in its own thread. Default: false.",
+              "type": "boolean"
+            },
+            "wasiPath": {
+              "description": "The place of a WASM program file.",
+              "type": "string"
+            },
+            "wasmHeapSize": {
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "wasmStackSize": {
+              "description": "Size of the stack size of Wasm execution. Review unit sizes for allowed values.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "fluentBitMetrics": {
+          "description": "FluentBitMetrics defines Fluent Bit Metrics Input configuration.",
+          "properties": {
+            "scrapeInterval": {
+              "description": "The rate at which metrics are collected from the host operating system. default is 2 seconds.",
+              "type": "string"
+            },
+            "scrapeOnStart": {
+              "description": "Scrape metrics upon start, useful to avoid waiting for 'scrape_interval' for the first round of metrics.",
+              "type": "boolean"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forward": {
+          "description": "Forward defines forward  input plugin configuration",
+          "properties": {
+            "bufferMaxSize": {
+              "description": "Specify maximum buffer memory size used to recieve a forward message.\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferchunkSize": {
+              "description": "Set the initial buffer size to store incoming data.\nThis value is used too to increase buffer size as required.\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "Listener network interface.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port for forward plugin instance.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tag": {
+              "description": "in_forward uses the tag value for incoming logs. If not set it uses tag from incoming log.",
+              "type": "string"
+            },
+            "tagPrefix": {
+              "description": "Adds the prefix to incoming event's tag",
+              "type": "string"
+            },
+            "threaded": {
+              "description": "Threaded mechanism allows input plugin to run in a separate thread which helps to desaturate the main pipeline.",
+              "type": "string"
+            },
+            "unixPath": {
+              "description": "Specify the path to unix socket to recieve a forward message. If set, Listen and port are ignnored.",
+              "type": "string"
+            },
+            "unixPerm": {
+              "description": "Set the permission of unix socket file.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "http": {
+          "description": "HTTP defines the HTTP input plugin configuration",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "This sets the chunk size for incoming incoming JSON messages.\nThese chunks are then stored/managed in the space available by buffer_max_size,default 512K.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Specify the maximum buffer size in KB to receive a JSON message,default 4M.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "The address to listen on,default 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port for Fluent Bit to listen on,default 9880",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "successfulHeader": {
+              "description": "Add an HTTP header key/value pair on success. Multiple headers can be set. Example: X-Custom custom-answer.",
+              "type": "string"
+            },
+            "successfulResponseCode": {
+              "description": "It allows to set successful response code. 200, 201 and 204 are supported,default 201.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tagKey": {
+              "description": "Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubernetesEvents": {
+          "description": "KubernetesEvents defines the KubernetesEvents input plugin configuration",
+          "properties": {
+            "db": {
+              "description": "Set a database file to keep track of recorded Kubernetes events",
+              "type": "string"
+            },
+            "dbSync": {
+              "description": "Set a database sync method. values: extra, full, normal and off",
+              "type": "string"
+            },
+            "intervalNsec": {
+              "description": "Set the polling interval for each channel (sub seconds: nanoseconds).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "intervalSec": {
+              "description": "Set the polling interval for each channel.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "kubeCAFile": {
+              "description": "CA certificate file",
+              "type": "string"
+            },
+            "kubeCAPath": {
+              "description": "Absolute path to scan for certificate files",
+              "type": "string"
+            },
+            "kubeNamespace": {
+              "description": "Kubernetes namespace to query events from. Gets events from all namespaces by default",
+              "type": "string"
+            },
+            "kubeRequestLimit": {
+              "description": "kubernetes limit parameter for events query, no limit applied when set to 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "kubeRetentionTime": {
+              "description": "Kubernetes retention time for events.",
+              "type": "string"
+            },
+            "kubeTokenFile": {
+              "description": "Token file",
+              "type": "string"
+            },
+            "kubeTokenTTL": {
+              "description": "configurable 'time to live' for the K8s token. By default, it is set to 600 seconds.\nAfter this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.",
+              "type": "string"
+            },
+            "kubeURL": {
+              "description": "API Server end-point",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin.",
+              "type": "string"
+            },
+            "tlsDebug": {
+              "description": "Debug level between 0 (nothing) and 4 (every detail).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tlsVerify": {
+              "description": "When enabled, turns on certificate validation when connecting to the Kubernetes API server.",
+              "type": "boolean"
+            },
+            "tlsVhost": {
+              "description": "Set optional TLS virtual host.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "mqtt": {
+          "description": "MQTT defines the MQTT input plugin configuration",
+          "properties": {
+            "listen": {
+              "description": "Listener network interface, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port where listening for connections, default: 1883",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nginx": {
+          "description": "Nginx defines the Nginx input plugin configuration",
+          "properties": {
+            "host": {
+              "description": "Name of the target host or IP address to check, default: localhost",
+              "type": "string"
+            },
+            "nginxPlus": {
+              "description": "Turn on NGINX plus mode,default: true",
+              "type": "boolean"
+            },
+            "port": {
+              "description": "Port of the target nginx service to connect to, default: 80",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "statusURL": {
+              "description": "The URL of the Stub Status Handler,default: /status",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeExporterMetrics": {
+          "description": "NodeExporterMetrics defines Node Exporter Metrics Input configuration.",
+          "properties": {
+            "path": {
+              "properties": {
+                "procfs": {
+                  "description": "The mount point used to collect process information and metrics.",
+                  "type": "string"
+                },
+                "sysfs": {
+                  "description": "The path in the filesystem used to collect system metrics.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scrapeInterval": {
+              "description": "The rate at which metrics are collected from the host operating system, default is 5 seconds.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "openTelemetry": {
+          "description": "OpenTelemetry defines the OpenTelemetry input plugin configuration",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size(default 512K).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Specify the maximum buffer size in KB to receive a JSON message(default 4M).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "The address to listen on,default 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port for Fluent Bit to listen on.default 4318.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "rawTraces": {
+              "description": "Route trace data as a log message(default false).",
+              "type": "boolean"
+            },
+            "successfulResponseCode": {
+              "description": "It allows to set successful response code. 200, 201 and 204 are supported(default 201).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tag": {
+              "description": "opentelemetry uses the tag value for incoming metrics.",
+              "type": "string"
+            },
+            "tagFromURI": {
+              "description": "If true, tag will be created from uri. e.g. v1_metrics from /v1/metrics",
+              "type": "boolean"
+            },
+            "tagKey": {
+              "description": "Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processors": {
+          "description": "Processors defines the processors configuration",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "prometheusScrapeMetrics": {
+          "description": "PrometheusScrapeMetrics  defines Prometheus Scrape Metrics Input configuration.",
+          "properties": {
+            "host": {
+              "description": "The host of the prometheus metric endpoint that you want to scrape",
+              "type": "string"
+            },
+            "metricsPath": {
+              "description": "The metrics URI endpoint, that must start with a forward slash, deflaut: /metrics",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port of the promethes metric endpoint that you want to scrape",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "scrapeInterval": {
+              "description": "The interval to scrape metrics, default: 10s",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "statsd": {
+          "description": "StatsD defines the StatsD input plugin configuration",
+          "properties": {
+            "listen": {
+              "description": "Listener network interface, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "UDP port where listening for connections, default: 8125",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syslog": {
+          "description": "Syslog defines the Syslog input plugin configuration",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "By default the buffer to store the incoming Syslog messages, do not allocate the maximum memory allowed, instead it allocate memory when is required.\nThe rounds of allocations are set by Buffer_Chunk_Size. If not set, Buffer_Chunk_Size is equal to 32000 bytes (32KB).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Specify the maximum buffer size to receive a Syslog message. If not set, the default size will be the value of Buffer_Chunk_Size.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "If Mode is set to tcp or udp, specify the network interface to bind, default: 0.0.0.0",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Defines transport protocol mode: unix_udp (UDP over Unix socket), unix_tcp (TCP over Unix socket), tcp or udp",
+              "enum": [
+                "unix_udp",
+                "unix_tcp",
+                "tcp",
+                "udp"
+              ],
+              "type": "string"
+            },
+            "parser": {
+              "description": "Specify an alternative parser for the message. If Mode is set to tcp or udp then the default parser is syslog-rfc5424 otherwise syslog-rfc3164-local is used.\nIf your syslog messages have fractional seconds set this Parser value to syslog-rfc5424 instead.",
+              "type": "string"
+            },
+            "path": {
+              "description": "If Mode is set to unix_tcp or unix_udp, set the absolute path to the Unix socket file.",
+              "type": "string"
+            },
+            "port": {
+              "description": "If Mode is set to tcp or udp, specify the TCP port to listen for incoming connections.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "receiveBufferSize": {
+              "description": "Specify the maximum socket receive buffer size. If not set, the default value is OS-dependant,\nbut generally too low to accept thousands of syslog messages per second without loss on udp or unix_udp sockets. Note that on Linux the value is capped by sysctl net.core.rmem_max.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "sourceAddressKey": {
+              "description": "Specify the key where the source address will be injected.",
+              "type": "string"
+            },
+            "unixPerm": {
+              "description": "If Mode is set to unix_tcp or unix_udp, set the permission of the Unix socket file, default: 0644",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "systemd": {
+          "description": "Systemd defines Systemd Input configuration.",
+          "properties": {
+            "db": {
+              "description": "Specify the database file to keep track of monitored files and offsets.",
+              "type": "string"
+            },
+            "dbSync": {
+              "description": "Set a default synchronization (I/O) method. values: Extra, Full, Normal, Off.\nThis flag affects how the internal SQLite engine do synchronization to disk,\nfor more details about each option please refer to this section.\nnote: this option was introduced on Fluent Bit v1.4.6.",
+              "enum": [
+                "Extra",
+                "Full",
+                "Normal",
+                "Off"
+              ],
+              "type": "string"
+            },
+            "maxEntries": {
+              "description": "When Fluent Bit starts, the Journal might have a high number of logs in the queue.\nIn order to avoid delays and reduce memory usage, this option allows to specify the maximum number of log entries that can be processed per round.\nOnce the limit is reached, Fluent Bit will continue processing the remaining log entries once Journald performs the notification.",
+              "type": "integer"
+            },
+            "maxFields": {
+              "description": "Set a maximum number of fields (keys) allowed per record.",
+              "type": "integer"
+            },
+            "path": {
+              "description": "Optional path to the Systemd journal directory,\nif not set, the plugin will use default paths to read local-only logs.",
+              "type": "string"
+            },
+            "pauseOnChunksOverlimit": {
+              "description": "Specifies if the input plugin should be paused (stop ingesting new data) when the storage.max_chunks_up value is reached.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "readFromTail": {
+              "description": "Start reading new entries. Skip entries already stored in Journald.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "storageType": {
+              "description": "Specify the buffering mechanism to use. It can be memory or filesystem",
+              "enum": [
+                "filesystem",
+                "memory"
+              ],
+              "type": "string"
+            },
+            "stripUnderscores": {
+              "description": "Remove the leading underscore of the Journald field (key). For example the Journald field _PID becomes the key PID.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "systemdFilter": {
+              "description": "Allows to perform a query over logs that contains a specific Journald key/value pairs, e.g: _SYSTEMD_UNIT=UNIT.\nThe Systemd_Filter option can be specified multiple times in the input section to apply multiple filters as required.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "systemdFilterType": {
+              "description": "Define the filter type when Systemd_Filter is specified multiple times. Allowed values are And and Or.\nWith And a record is matched only when all of the Systemd_Filter have a match.\nWith Or a record is matched when any of the Systemd_Filter has a match.",
+              "enum": [
+                "And",
+                "Or"
+              ],
+              "type": "string"
+            },
+            "tag": {
+              "description": "The tag is used to route messages but on Systemd plugin there is an extra functionality:\nif the tag includes a star/wildcard, it will be expanded with the Systemd Unit file (e.g: host.* => host.UNIT_NAME).",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tail": {
+          "description": "Tail defines Tail Input configuration.",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "Set the initial buffer size to read files data.\nThis value is used too to increase buffer size.\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Set the limit of the buffer size per monitored file.\nWhen a buffer needs to be increased (e.g: very long lines),\nthis value is used to restrict how much the memory buffer can grow.\nIf reading a file exceed this limit, the file is removed from the monitored file list\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "db": {
+              "description": "Specify the database file to keep track of monitored files and offsets.",
+              "type": "string"
+            },
+            "dbSync": {
+              "description": "Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off.",
+              "enum": [
+                "Extra",
+                "Full",
+                "Normal",
+                "Off"
+              ],
+              "type": "string"
+            },
+            "disableInotifyWatcher": {
+              "description": "DisableInotifyWatcher will disable inotify and use the file stat watcher instead.",
+              "type": "boolean"
+            },
+            "dockerMode": {
+              "description": "If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above.\nThis mode cannot be used at the same time as Multiline.",
+              "type": "boolean"
+            },
+            "dockerModeFlushSeconds": {
+              "description": "Wait period time in seconds to flush queued unfinished split lines.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "dockerModeParser": {
+              "description": "Specify an optional parser for the first line of the docker multiline mode. The parser name to be specified must be registered in the parsers.conf file.",
+              "type": "string"
+            },
+            "excludePath": {
+              "description": "Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria,\ne.g: exclude_path=*.gz,*.zip",
+              "type": "string"
+            },
+            "ignoredOlder": {
+              "description": "Ignores records which are older than this time in seconds.\nSupports m,h,d (minutes, hours, days) syntax.\nDefault behavior is to read all records from specified files.\nOnly available when a Parser is specificied and it can parse the time of a record.",
+              "pattern": "^\\d+(m|h|d)?$",
+              "type": "string"
+            },
+            "key": {
+              "description": "When a message is unstructured (no parser applied), it's appended as a string under the key name log.\nThis option allows to define an alternative name for that key.",
+              "type": "string"
+            },
+            "memBufLimit": {
+              "description": "Set a limit of memory that Tail plugin can use when appending data to the Engine.\nIf the limit is reach, it will be paused; when the data is flushed it resumes.",
+              "type": "string"
+            },
+            "multiline": {
+              "description": "If enabled, the plugin will try to discover multiline messages\nand use the proper parsers to compose the outgoing messages.\nNote that when this option is enabled the Parser option is not used.",
+              "type": "boolean"
+            },
+            "multilineFlushSeconds": {
+              "description": "Wait period time in seconds to process queued multiline messages",
+              "format": "int64",
+              "type": "integer"
+            },
+            "multilineParser": {
+              "description": "This will help to reassembly multiline messages originally split by Docker or CRI\nSpecify one or Multiline Parser definition to apply to the content.",
+              "type": "string"
+            },
+            "parser": {
+              "description": "Specify the name of a parser to interpret the entry as a structured message.",
+              "type": "string"
+            },
+            "parserFirstline": {
+              "description": "Name of the parser that matchs the beginning of a multiline message.\nNote that the regular expression defined in the parser must include a group name (named capture)",
+              "type": "string"
+            },
+            "parserN": {
+              "description": "Optional-extra parser to interpret and structure multiline entries.\nThis option can be used to define multiple parsers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "path": {
+              "description": "Pattern specifying a specific log files or multiple ones through the use of common wildcards.",
+              "type": "string"
+            },
+            "pathKey": {
+              "description": "If enabled, it appends the name of the monitored file as part of the record.\nThe value assigned becomes the key in the map.",
+              "type": "string"
+            },
+            "pauseOnChunksOverlimit": {
+              "description": "Specifies if the input plugin should be paused (stop ingesting new data) when the storage.max_chunks_up value is reached.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "readFromHead": {
+              "description": "For new discovered files on start (without a database offset/position),\nread the content from the head of the file, not tail.",
+              "type": "boolean"
+            },
+            "refreshIntervalSeconds": {
+              "description": "The interval of refreshing the list of watched files in seconds.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rotateWaitSeconds": {
+              "description": "Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "skipLongLines": {
+              "description": "When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size),\nthe default behavior is to stop monitoring that file.\nSkip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines\nand continue processing other lines that fits into the buffer size.",
+              "type": "boolean"
+            },
+            "storageType": {
+              "description": "Specify the buffering mechanism to use. It can be memory or filesystem",
+              "enum": [
+                "filesystem",
+                "memory"
+              ],
+              "type": "string"
+            },
+            "tag": {
+              "description": "Set a tag (with regex-extract fields) that will be placed on lines read.\nE.g. kube.<namespace_name>.<pod_name>.<container_name>",
+              "type": "string"
+            },
+            "tagRegex": {
+              "description": "Set a regex to exctract fields from the file",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tcp": {
+          "description": "TCP defines the TCP input plugin configuration",
+          "properties": {
+            "bufferSize": {
+              "description": "Specify the maximum buffer size in KB to receive a JSON message. If not set, the default size will be the value of Chunk_Size.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "chunkSize": {
+              "description": "By default the buffer to store the incoming JSON messages, do not allocate the maximum memory allowed, instead it allocate memory when is required.\nThe rounds of allocations are set by Chunk_Size in KB. If not set, Chunk_Size is equal to 32 (32KB).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "format": {
+              "description": "Specify the expected payload format. It support the options json and none.\nWhen using json, it expects JSON maps, when is set to none, it will split every record using the defined Separator (option below).",
+              "type": "string"
+            },
+            "listen": {
+              "description": "Listener network interface,default 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port where listening for connections,default 5170",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "separator": {
+              "description": "When the expected Format is set to none, Fluent Bit needs a separator string to split the records. By default it uses the breakline character (LF or 0x10).",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "udp": {
+          "description": "UDP defines the UDP input plugin configuration",
+          "properties": {
+            "bufferSize": {
+              "description": "BufferSize Specify the maximum buffer size in KB to receive a JSON message.\nIf not set, the default size will be the value of Chunk_Size.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "chunkSize": {
+              "description": "By default the buffer to store the incoming JSON messages, do not allocate the maximum memory allowed,\ninstead it allocate memory when is required.\nThe rounds of allocations are set by Chunk_Size in KB. If not set, Chunk_Size is equal to 32 (32KB).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "format": {
+              "description": "Format Specify the expected payload format. It support the options json and none.\nWhen using json, it expects JSON maps, when is set to none,\nit will split every record using the defined Separator (option below).",
+              "type": "string"
+            },
+            "listen": {
+              "description": "Listen Listener network interface, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port Specify the UDP port where listening for connections, default: 5170",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "separator": {
+              "description": "Separator When the expected Format is set to none, Fluent Bit needs a separator string to split the records. By default it uses the breakline character (LF or 0x10).",
+              "type": "string"
+            },
+            "sourceAddressKey": {
+              "description": "SourceAddressKey Specify the key where the source address will be injected.",
+              "type": "string"
+            },
+            "threaded": {
+              "description": "Threaded mechanism allows input plugin to run in a separate thread which helps to desaturate the main pipeline.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/clustermultilineparser_v1alpha2.json
+++ b/fluentbit.fluent.io/clustermultilineparser_v1alpha2.json
@@ -1,0 +1,68 @@
+{
+  "description": "ClusterMultilineParser is the Schema for the cluster-level multiline parser API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "flushTimeout": {
+          "default": 5000,
+          "description": "Timeout in milliseconds to flush a non-terminated multiline buffer. Default is set to 5 seconds.",
+          "type": "integer"
+        },
+        "keyContent": {
+          "description": "For an incoming structured message, specify the key that contains the data that should be processed by the regular expression and possibly concatenated.",
+          "type": "string"
+        },
+        "parser": {
+          "description": "Name of a pre-defined parser that must be applied to the incoming content before applying the regex rule. If no parser is defined, it's assumed that's a raw text and not a structured message.",
+          "type": "string"
+        },
+        "rules": {
+          "description": "Configure a rule to match a multiline pattern. The rule has a specific format described below. Multiple rules can be defined.",
+          "items": {
+            "properties": {
+              "next": {
+                "type": "string"
+              },
+              "regex": {
+                "type": "string"
+              },
+              "start": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "next",
+              "regex",
+              "start"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "type": {
+          "default": "regex",
+          "description": "Set the multiline mode, for now, we support the type regex.",
+          "enum": [
+            "regex"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/clusteroutput_v1alpha2.json
+++ b/fluentbit.fluent.io/clusteroutput_v1alpha2.json
@@ -1,0 +1,4769 @@
+{
+  "description": "ClusterOutput is the Schema for the cluster-level outputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OutputSpec defines the desired state of ClusterOutput",
+      "properties": {
+        "alias": {
+          "description": "A user friendly alias name for this output plugin.\nUsed in metrics for distinction of each configured output.",
+          "type": "string"
+        },
+        "azureBlob": {
+          "description": "AzureBlob defines AzureBlob Output Configuration",
+          "properties": {
+            "accountName": {
+              "description": "Azure Storage account name",
+              "type": "string"
+            },
+            "autoCreateContainer": {
+              "description": "Creates container if ContainerName is not set.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "blobType": {
+              "description": "Specify the desired blob type. Must be `appendblob` or `blockblob`",
+              "enum": [
+                "appendblob",
+                "blockblob"
+              ],
+              "type": "string"
+            },
+            "containerName": {
+              "description": "Name of the container that will contain the blobs",
+              "type": "string"
+            },
+            "emulatorMode": {
+              "description": "Optional toggle to use an Azure emulator",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "HTTP Service of the endpoint (if using EmulatorMode)",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Optional path to store the blobs.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the Azure Storage Shared Key to authenticate against the storage account",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Enable/Disable TLS Encryption. Azure services require TLS to be enabled.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "accountName",
+            "containerName",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azureLogAnalytics": {
+          "description": "AzureLogAnalytics defines AzureLogAnalytics Output Configuration",
+          "properties": {
+            "customerID": {
+              "description": "Customer ID or Workspace ID",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logType": {
+              "description": "Name of the event type.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the primary or the secondary client authentication key",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeGenerated": {
+              "description": "If set, overrides the timeKey value with the `time-generated-field` HTTP header value.",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Specify the name of the key where the timestamp is stored.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "customerID",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudWatch": {
+          "description": "CloudWatch defines CloudWatch Output Configuration",
+          "properties": {
+            "autoCreateGroup": {
+              "description": "Automatically create the log group. Defaults to False.",
+              "type": "boolean"
+            },
+            "autoRetryRequests": {
+              "description": "Automatically retry failed requests to CloudWatch once. Defaults to True.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Custom endpoint for CloudWatch logs API",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API.",
+              "type": "string"
+            },
+            "logFormat": {
+              "description": "Optional parameter to tell CloudWatch the format of the data",
+              "type": "string"
+            },
+            "logGroupName": {
+              "description": "Name of Cloudwatch Log Group to send log records to",
+              "type": "string"
+            },
+            "logGroupTemplate": {
+              "description": "Template for Log Group name, overrides LogGroupName if set.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "If set, only the value of the key will be sent to CloudWatch",
+              "type": "string"
+            },
+            "logRetentionDays": {
+              "description": "Number of days logs are retained for",
+              "enum": [
+                1,
+                3,
+                5,
+                7,
+                14,
+                30,
+                60,
+                90,
+                120,
+                150,
+                180,
+                365,
+                400,
+                545,
+                731,
+                1827,
+                3653
+              ],
+              "format": "int32",
+              "type": "integer"
+            },
+            "logStreamName": {
+              "description": "The name of the CloudWatch Log Stream to send log records to",
+              "type": "string"
+            },
+            "logStreamPrefix": {
+              "description": "Prefix for the Log Stream name. Not compatible with LogStreamName setting",
+              "type": "string"
+            },
+            "logStreamTemplate": {
+              "description": "Template for Log Stream name. Overrides LogStreamPrefix and LogStreamName if set.",
+              "type": "string"
+            },
+            "metricDimensions": {
+              "description": "Optional lists of lists for dimension keys to be added to all metrics. Use comma separated strings\nfor one list of dimensions and semicolon separated strings for list of lists dimensions.",
+              "type": "string"
+            },
+            "metricNamespace": {
+              "description": "Optional string to represent the CloudWatch namespace.",
+              "type": "string"
+            },
+            "region": {
+              "description": "AWS Region",
+              "type": "string"
+            },
+            "roleArn": {
+              "description": "Role ARN to use for cross-account access",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom STS endpoint for the AWS STS API",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customPlugin": {
+          "description": "CustomPlugin defines Custom Output configuration.",
+          "properties": {
+            "config": {
+              "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+              "type": "string"
+            },
+            "yamlConfig": {
+              "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "datadog": {
+          "description": "DataDog defines DataDog Output configuration.",
+          "properties": {
+            "apikey": {
+              "description": "Your Datadog API key.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "compress": {
+              "description": "Compress  the payload in GZIP format.\nDatadog supports and recommends setting this to gzip.",
+              "type": "string"
+            },
+            "dd_message_key": {
+              "description": "By default, the plugin searches for the key 'log' and remap the value to the key 'message'. If the property is set, the plugin will search the property name key.",
+              "type": "string"
+            },
+            "dd_service": {
+              "description": "The human readable name for your service generating the logs.",
+              "type": "string"
+            },
+            "dd_source": {
+              "description": "A human readable name for the underlying technology of your service.",
+              "type": "string"
+            },
+            "dd_tags": {
+              "description": "The tags you want to assign to your logs in Datadog.",
+              "type": "string"
+            },
+            "host": {
+              "description": "Host is the Datadog server where you are sending your logs.",
+              "type": "string"
+            },
+            "include_tag_key": {
+              "description": "If enabled, a tag is appended to output. The key name is used tag_key property.",
+              "type": "boolean"
+            },
+            "json_date_key": {
+              "description": "Date key name for output.",
+              "type": "string"
+            },
+            "provider": {
+              "description": "To activate the remapping, specify configuration flag provider.",
+              "type": "string"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy.",
+              "type": "string"
+            },
+            "tag_key": {
+              "description": "The key name of tag. If include_tag_key is false, This property is ignored.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "TLS controls whether to use end-to-end security communications security protocol.\nDatadog recommends setting this to on.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "es": {
+          "description": "Elasticsearch defines Elasticsearch Output configuration.",
+          "properties": {
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsAuthSecret": {
+              "description": "AWSAuthSecret Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon ES cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the Elasticsearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "cloudAuth": {
+              "description": "Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "type": "string"
+            },
+            "cloudAuthSecret": {
+              "description": "CloudAuthSecret Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cloudID": {
+              "description": "If you are using Elastic's Elasticsearch Service you can specify the cloud_id of the cluster running.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying ES.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Elasticsearch instance",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for Elastic X-Pack access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Elasticsearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve Elasticsearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "Newer versions of Elasticsearch allows setting up filters called pipelines.\nThis option allows defining which pipeline the database should use.\nFor performance reasons is strongly suggested parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target Elasticsearch instance",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "string"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "file": {
+          "description": "File defines File Output configuration.",
+          "properties": {
+            "delimiter": {
+              "description": "The character to separate each pair. Applicable only if format is csv or ltsv.",
+              "type": "string"
+            },
+            "file": {
+              "description": "Set file name to store the records. If not set, the file name will be the tag associated with the records.",
+              "type": "string"
+            },
+            "format": {
+              "description": "The format of the file content. See also Format section. Default: out_file.",
+              "enum": [
+                "out_file",
+                "plain",
+                "csv",
+                "ltsv",
+                "template"
+              ],
+              "type": "string"
+            },
+            "labelDelimiter": {
+              "description": "The character to separate each pair. Applicable only if format is ltsv.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory.",
+              "type": "string"
+            },
+            "template": {
+              "description": "The format string. Applicable only if format is template.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "firehose": {
+          "description": "Firehose defines Firehose Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues.",
+              "type": "boolean"
+            },
+            "dataKeys": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited.",
+              "type": "string"
+            },
+            "deliveryStream": {
+              "description": "The name of the Kinesis Firehose Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis Firehose API.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Firehose. If you specify a key name with this option, then only the value of that key will be sent to Firehose. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Firehose.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom endpoint for the STS API; used to assume your custom role provided with role_arn.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default, the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, %Y-%m-%dT%H *string This option is used with time_key. You can also use %L for milliseconds and %f for microseconds. If you are using ECS FireLens, make sure you are running Amazon ECS Container Agent v1.42.0 or later, otherwise the timestamps associated with your container logs will only have second precision.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "deliveryStream",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forward": {
+          "description": "Forward defines Forward Output configuration.",
+          "properties": {
+            "emptySharedKey": {
+              "description": "Use this option to connect to Fluentd with a zero-length secret.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "password": {
+              "description": "Specify the password corresponding to the username.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "requireAckResponse": {
+              "description": "Send \"chunk\"-option and wait for \"ack\" response from server.\nEnables at-least-once and receiving server can control rate of traffic.\n(Requires Fluentd v0.14.0+ server)",
+              "type": "boolean"
+            },
+            "selfHostname": {
+              "description": "Default value of the auto-generated certificate common name (CN).",
+              "type": "string"
+            },
+            "sendOptions": {
+              "description": "Always send options (with \"size\"=count of messages)",
+              "type": "boolean"
+            },
+            "sharedKey": {
+              "description": "A key string known by the remote Fluentd used for authorization.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Overwrite the tag as we transmit. This allows the receiving pipeline start\nfresh, or to attribute source.",
+              "type": "string"
+            },
+            "timeAsInteger": {
+              "description": "Set timestamps in integer format, it enable compatibility mode for Fluentd v0.12 series.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "username": {
+              "description": "Specify the username to present to a Fluentd server that enables user_auth.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gelf": {
+          "description": "Gelf defines GELF Output configuration.",
+          "properties": {
+            "compress": {
+              "description": "If transport protocol is udp, it defines if UDP packets should be compressed.",
+              "type": "boolean"
+            },
+            "fullMessageKey": {
+              "description": "FullMessageKey is the key to use as the long message that can i.e. contain a backtrace.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Graylog server.",
+              "type": "string"
+            },
+            "hostKey": {
+              "description": "HostKey is the key which its value is used as the name of the host, source or application that sent this message.",
+              "type": "string"
+            },
+            "levelKey": {
+              "description": "LevelKey is the key to be used as the log level.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "The protocol to use (tls, tcp or udp).",
+              "enum": [
+                "tls",
+                "tcp",
+                "udp"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "packetSize": {
+              "description": "If transport protocol is udp, it sets the size of packets to be sent.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "port": {
+              "description": "The port that the target Graylog server is listening on.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "shortMessageKey": {
+              "description": "ShortMessageKey is the key to use as the short message.",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "TimestampKey is the key which its value is used as the timestamp of the message.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "http": {
+          "description": "HTTP defines HTTP Output configuration.",
+          "properties": {
+            "allowDuplicatedHeaders": {
+              "description": "Specify if duplicated headers are allowed.\nIf a duplicated header is found, the latest key/value set is preserved.",
+              "type": "boolean"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "type": "string"
+            },
+            "format": {
+              "description": "Specify the data format to be used in the HTTP request body, by default it uses msgpack.\nOther supported formats are json, json_stream and json_lines and gelf.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_stream",
+                "json_lines",
+                "gelf"
+              ],
+              "type": "string"
+            },
+            "gelfFullMessageKey": {
+              "description": "Specify the key to use for the full message in gelf format",
+              "type": "string"
+            },
+            "gelfHostKey": {
+              "description": "Specify the key to use for the host in gelf format",
+              "type": "string"
+            },
+            "gelfLevelKey": {
+              "description": "Specify the key to use for the level in gelf format",
+              "type": "string"
+            },
+            "gelfShortMessageKey": {
+              "description": "Specify the key to use as the short message in gelf format",
+              "type": "string"
+            },
+            "gelfTimestampKey": {
+              "description": "Specify the key to use for timestamp in gelf format",
+              "type": "string"
+            },
+            "headerTag": {
+              "description": "Specify an optional HTTP header field for the original message tag.",
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Basic Auth Password. Requires HTTP_User to be set",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Server",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://host:port.\nNote that https is not supported yet.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "HTTP output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "influxDB": {
+          "description": "InfluxDB defines InfluxDB Output configuration.",
+          "properties": {
+            "autoTags": {
+              "description": "Automatically tag keys where value is string.",
+              "type": "boolean"
+            },
+            "bucket": {
+              "description": "InfluxDB bucket name where records will be inserted - if specified, database is ignored and v2 of API is used",
+              "type": "string"
+            },
+            "database": {
+              "description": "InfluxDB database name where records will be inserted.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target InfluxDB service.",
+              "format": "ipv6",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpToken": {
+              "description": "Authentication token used with InfluxDB v2 - if specified, both HTTPUser and HTTPPasswd are ignored",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username for HTTP Basic Authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "org": {
+              "description": "InfluxDB organization name where the bucket is (v2 only)",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target InfluxDB service.",
+              "format": "int32",
+              "maximum": 65536,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sequenceTag": {
+              "description": "The name of the tag whose value is incremented for the consecutive simultaneous events.",
+              "type": "string"
+            },
+            "tagKeys": {
+              "description": "List of keys that needs to be tagged",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tagListKey": {
+              "description": "Key of the string array optionally contained within each log record that contains tag keys for that record",
+              "type": "string"
+            },
+            "tagsListEnabled": {
+              "description": "Dynamically tag keys which are in the string array at Tags_List_Key key.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafka": {
+          "description": "Kafka defines Kafka Output configuration.",
+          "properties": {
+            "brokers": {
+              "description": "Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092.",
+              "type": "string"
+            },
+            "dynamicTopic": {
+              "description": "adds unknown topics (found in Topic_Key) to Topics. So in Topics only a default topic needs to be configured",
+              "type": "boolean"
+            },
+            "format": {
+              "description": "Specify data format, options available: json, msgpack.",
+              "type": "string"
+            },
+            "messageKey": {
+              "description": "Optional key to store the message",
+              "type": "string"
+            },
+            "messageKeyField": {
+              "description": "If set, the value of Message_Key_Field in the record will indicate the message key.\nIf not set nor found in the record, Message_Key will be used (if set).",
+              "type": "string"
+            },
+            "queueFullRetries": {
+              "description": "Fluent Bit queues data into rdkafka library,\nif for some reason the underlying library cannot flush the records the queue might fills up blocking new addition of records.\nThe queue_full_retries option set the number of local retries to enqueue the data.\nThe default value is 10 times, the interval between each retry is 1 second.\nSetting the queue_full_retries value to 0 set's an unlimited number of retries.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rdkafka": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "{property} can be any librdkafka properties",
+              "type": "object"
+            },
+            "timestampFormat": {
+              "description": "iso8601 or double",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "Set the key to store the record timestamp",
+              "type": "string"
+            },
+            "topicKey": {
+              "description": "If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use.\nE.g: if Topic_Key is router and the record is {\"key1\": 123, \"router\": \"route_2\"},\nFluent Bit will use topic route_2. Note that if the value of Topic_Key is not present in Topics,\nthen by default the first topic in the Topics list will indicate the topic to be used.",
+              "type": "string"
+            },
+            "topics": {
+              "description": "Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka.\nIf only one topic is set, that one will be used for all records.\nInstead if multiple topics exists, the one set in the record by Topic_Key will be used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kinesis": {
+          "description": "Kinesis defines Kinesis Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis API.",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Kinesis.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stream": {
+              "description": "The name of the Kinesis Streams Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond precision with '%3N' and supports nanosecond precision with '%9N' and '%L'; for example, adding '%3N' to support millisecond '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region",
+            "stream"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "description": "Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace, Defaults to the SERVICE section's Log_Level",
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "loki": {
+          "description": "Loki defines Loki Output configuration.",
+          "properties": {
+            "autoKubernetesLabels": {
+              "description": "If set to true, it will add all Kubernetes labels to the Stream labels.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "bearerToken": {
+              "description": "Set bearer token authentication token value.\nCan be used as alterntative to HTTP basic authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dropSingleKey": {
+              "description": "If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Loki hostname or IP address.",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User\nSet HTTP basic authentication password",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Set HTTP basic authentication user name.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "labelKeys": {
+              "description": "Optional list of record keys that will be placed as stream labels.\nThis configuration property is for records key only.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelMapPath": {
+              "description": "Specify the label map file path. The file defines how to extract labels from each record.",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs.\nIn addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "lineFormat": {
+              "description": "Format to use when flattening the record to a log line. Valid values are json or key_value.\nIf set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON.\nIf set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.",
+              "enum": [
+                "json",
+                "key_value"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "Loki TCP port",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "removeKeys": {
+              "description": "Optional list of keys to remove.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tenantID": {
+              "description": "Tenant ID used by default to push logs to Loki.\nIf omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tenantIDKey": {
+              "description": "Specify the name of the key from the original record that contains the Tenant ID.\nThe value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify a custom HTTP URI. It must start with forward slash.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        },
+        "null": {
+          "description": "Null defines Null Output configuration.",
+          "type": "object"
+        },
+        "opensearch": {
+          "description": "OpenSearch defines OpenSearch Output configuration.",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the OpenSearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "compress": {
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying OpenSearch.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "OpenSearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve OpenSearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "OpenSearch allows to setup filters called pipelines.\nThis option allows to define which pipeline the database should use.\nFor performance reasons is strongly suggested to do parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `9200`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "boolean"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "opentelemetry": {
+          "description": "OpenTelemetry defines OpenTelemetry Output configuration.",
+          "properties": {
+            "addLabel": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields.",
+              "type": "object"
+            },
+            "header": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log.",
+              "type": "boolean"
+            },
+            "logsBodyKeyAttributes": {
+              "description": "If true, remaining unmatched keys are added as attributes.",
+              "type": "boolean"
+            },
+            "logsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for logs, e.g: /v1/logs",
+              "type": "string"
+            },
+            "metricsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for metrics, e.g: /v1/metrics",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `80`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT. Note that HTTPS is not currently supported.\nIt is recommended not to set this and to configure the HTTP proxy environment variables instead as they support both HTTP and HTTPS.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tracesUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for traces, e.g: /v1/traces",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processors": {
+          "description": "Processors defines the processors configuration",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "prometheusExporter": {
+          "description": "PrometheusExporter_types defines Prometheus exporter configuration to expose metrics from Fluent Bit.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "This is the port Fluent Bit will bind to when hosting prometheus metrics.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "prometheusRemoteWrite": {
+          "description": "PrometheusRemoteWrite_types defines Prometheus Remote Write configuration.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 127.0.0.1",
+              "type": "string"
+            },
+            "httpPasswd": {
+              "description": "Basic Auth Password.\nRequires HTTP_user to be se",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log,default: false",
+              "type": "boolean"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Serveri, default:80",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something ,default: /",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0,default : 2",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "retry_limit": {
+          "description": "RetryLimit represents configuration for the scheduler which can be set independently on each output section.\nThis option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.",
+          "type": "string"
+        },
+        "s3": {
+          "description": "S3 defines S3 Output configuration.",
+          "properties": {
+            "AutoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once.",
+              "type": "boolean"
+            },
+            "Bucket": {
+              "description": "S3 Bucket name",
+              "type": "string"
+            },
+            "CannedAcl": {
+              "description": "Predefined Canned ACL Policy for S3 objects.",
+              "type": "string"
+            },
+            "Compression": {
+              "description": "Compression type for S3 objects.",
+              "type": "string"
+            },
+            "ContentType": {
+              "description": "A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header.",
+              "type": "string"
+            },
+            "Endpoint": {
+              "description": "Custom endpoint for the S3 API.",
+              "type": "string"
+            },
+            "ExternalId": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "JsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681)",
+              "type": "string"
+            },
+            "JsonDateKey": {
+              "description": "Specify the name of the time key in the output record. To disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "LogKey": {
+              "description": "By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3.",
+              "type": "string"
+            },
+            "PreserveDataOrdering": {
+              "description": "Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads.",
+              "type": "boolean"
+            },
+            "Profile": {
+              "description": "Option to specify an AWS Profile for credentials.",
+              "type": "string"
+            },
+            "Region": {
+              "description": "The AWS region of your S3 bucket",
+              "type": "string"
+            },
+            "RetryLimit": {
+              "description": "Integer value to set the maximum number of retries allowed.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "RoleArn": {
+              "description": "ARN of an IAM role to assume",
+              "type": "string"
+            },
+            "S3KeyFormat": {
+              "description": "Format string for keys in S3.",
+              "type": "string"
+            },
+            "S3KeyFormatTagDelimiters": {
+              "description": "A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option.",
+              "type": "string"
+            },
+            "SendContentMd5": {
+              "description": "Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled.",
+              "type": "boolean"
+            },
+            "StaticFilePath": {
+              "description": "Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true.",
+              "type": "boolean"
+            },
+            "StorageClass": {
+              "description": "Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class.",
+              "type": "string"
+            },
+            "StoreDir": {
+              "description": "Directory to locally buffer data before sending.",
+              "type": "string"
+            },
+            "StoreDirLimitSize": {
+              "description": "The size of the limitation for disk usage in S3.",
+              "type": "string"
+            },
+            "StsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "TotalFileSize": {
+              "description": "Specifies the size of files in S3. Minimum size is 1M. With use_put_object On the maximum size is 1G. With multipart upload mode, the maximum size is 50G.",
+              "type": "string"
+            },
+            "UploadChunkSize": {
+              "description": "The size of each 'part' for multipart uploads. Max: 50M",
+              "type": "string"
+            },
+            "UploadTimeout": {
+              "description": "Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour.",
+              "type": "string"
+            },
+            "UsePutObject": {
+              "description": "Use the S3 PutObject API, instead of the multipart upload API.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "Bucket",
+            "Region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "splunk": {
+          "description": "Splunk defines Splunk Output Configuration",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value `2` is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "channel": {
+              "description": "Specify X-Splunk-Request-Channel Header for the HTTP Event Collector interface.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. The only available option is gzip.",
+              "type": "string"
+            },
+            "eventFields": {
+              "description": "Set event fields for the record. This option is an array and the format is \"key_name\nrecord_accessor_pattern\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "eventHost": {
+              "description": "Specify the key name that contains the host value. This option allows a record accessors pattern.",
+              "type": "string"
+            },
+            "eventIndex": {
+              "description": "The name of the index by which the event data is to be indexed.",
+              "type": "string"
+            },
+            "eventIndexKey": {
+              "description": "Set a record key that will populate the index field. If the key is found, it will have precedence\nover the value set in event_index.",
+              "type": "string"
+            },
+            "eventKey": {
+              "description": "Specify the key name that will be used to send a single value as part of the record.",
+              "type": "string"
+            },
+            "eventSource": {
+              "description": "Set the source value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetype": {
+              "description": "Set the sourcetype value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetypeKey": {
+              "description": "Set a record key that will populate 'sourcetype'. If the key is found, it will have precedence\nover the value set in event_sourcetype.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpBufferSize": {
+              "description": "Buffer size used to receive Splunk HTTP responses: Default `2M`",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "httpDebugBadRequest": {
+              "description": "If the HTTP server response code is 400 (bad request) and this flag is enabled, it will print the full HTTP request\nand response to the stdout interface. This feature is available for debugging purposes.",
+              "type": "boolean"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target Splunk instance, default `8088`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "splunkSendRaw": {
+              "description": "When enabled, the record keys and values are set in the top level of the map instead of under the event key. Refer to\nthe Sending Raw Events section from the docs more details to make this option work properly.",
+              "type": "boolean"
+            },
+            "splunkToken": {
+              "description": "Specify the Authentication Token for the HTTP Event Collector interface.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stackdriver": {
+          "description": "Stackdriver defines Stackdriver Output Configuration",
+          "properties": {
+            "autoformatStackdriverTrace": {
+              "description": "Rewrite the trace field to be formatted for use with GCP Cloud Trace",
+              "type": "boolean"
+            },
+            "customK8sRegex": {
+              "description": "A custom regex to extract fields from the local_resource_id of the logs",
+              "type": "string"
+            },
+            "exportToProjectID": {
+              "description": "The GCP Project that should receive the logs",
+              "type": "string"
+            },
+            "googleServiceCredentials": {
+              "description": "Path to GCP Credentials JSON file",
+              "type": "string"
+            },
+            "job": {
+              "description": "Identifier for a grouping of tasks. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "k8sClusterLocation": {
+              "description": "Location of the cluster that contains the pods/nodes. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "k8sClusterName": {
+              "description": "Name of the cluster that the pod is running in. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Optional list of comma separated of strings for key/value pairs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelsKey": {
+              "description": "Used by Stackdriver to find related labels and extract them to LogEntry Labels",
+              "type": "string"
+            },
+            "location": {
+              "description": "GCP/AWS region to store data. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "logNameKey": {
+              "description": "The value of this field is set as the logName field in Stackdriver",
+              "type": "string"
+            },
+            "metadataServer": {
+              "description": "Metadata Server Prefix",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace identifier. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "nodeID": {
+              "description": "Node identifier within the namespace. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Set resource types of data",
+              "type": "string"
+            },
+            "resourceLabels": {
+              "description": "Optional list of comma seperated strings. Setting these fields overrides the Stackdriver monitored resource API values",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "serviceAccountEmail": {
+              "description": "Email associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountSecret": {
+              "description": "Private Key associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "severityKey": {
+              "description": "Specify the key that contains the severity information for the logs",
+              "type": "string"
+            },
+            "tagPrefix": {
+              "description": "Used to validate the tags of logs that when the Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "taskID": {
+              "description": "Identifier for a task within a namespace. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Number of dedicated threads for the Stackdriver Output Plugin",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stdout": {
+          "description": "Stdout defines Stdout Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.",
+              "enum": [
+                "double",
+                "iso8601",
+                "epoch"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the date field in output.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syslog": {
+          "description": "Syslog defines Syslog Output configuration.",
+          "properties": {
+            "host": {
+              "description": "Host domain or IP address of the remote Syslog server.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode of the desired transport type, the available options are tcp, tls and udp.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP or UDP port of the remote Syslog server.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "syslogAppnameKey": {
+              "description": "Key name from the original record that contains the application name that generated the message.",
+              "type": "string"
+            },
+            "syslogFacilityKey": {
+              "description": "Key from the original record that contains the Syslog facility number.",
+              "type": "string"
+            },
+            "syslogFormat": {
+              "description": "Syslog protocol format to use, the available options are rfc3164 and rfc5424.",
+              "type": "string"
+            },
+            "syslogHostnameKey": {
+              "description": "Key name from the original record that contains the hostname that generated the message.",
+              "type": "string"
+            },
+            "syslogMaxSize": {
+              "description": "Maximum size allowed per message, in bytes.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "syslogMessageIDKey": {
+              "description": "Key name from the original record that contains the Message ID associated to the message.",
+              "type": "string"
+            },
+            "syslogMessageKey": {
+              "description": "Key key name that contains the message to deliver.",
+              "type": "string"
+            },
+            "syslogProcessIDKey": {
+              "description": "Key name from the original record that contains the Process ID that generated the message.",
+              "type": "string"
+            },
+            "syslogSDKey": {
+              "description": "Key name from the original record that contains the Structured Data (SD) content.",
+              "type": "string"
+            },
+            "syslogSeverityKey": {
+              "description": "Key from the original record that contains the Syslog severity number.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Syslog output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tcp": {
+          "description": "TCP defines TCP Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "enum": [
+                "double",
+                "epoch",
+                "iso8601"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "TSpecify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/clusterparser_v1alpha2.json
+++ b/fluentbit.fluent.io/clusterparser_v1alpha2.json
@@ -1,0 +1,116 @@
+{
+  "description": "ClusterParser is the Schema for the cluster-level parsers API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ParserSpec defines the desired state of ClusterParser",
+      "properties": {
+        "decoders": {
+          "description": "Decoders are a built-in feature available through the Parsers file, each Parser definition can optionally set one or multiple decoders.\nThere are two type of decoders type: Decode_Field and Decode_Field_As.",
+          "items": {
+            "properties": {
+              "decodeField": {
+                "description": "If the content can be decoded in a structured message,\nappend that structure message (keys and values) to the original log message.",
+                "type": "string"
+              },
+              "decodeFieldAs": {
+                "description": "Any content decoded (unstructured or structured) will be replaced in the same key/value,\nno extra keys are added.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "json": {
+          "description": "JSON defines json parser configuration.",
+          "properties": {
+            "timeFormat": {
+              "description": "Time_Format, eg. %Y-%m-%dT%H:%M:%S %z",
+              "type": "string"
+            },
+            "timeKeep": {
+              "description": "Time_Keep",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Time_Key",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logfmt": {
+          "description": "Logfmt defines logfmt parser configuration.",
+          "type": "object"
+        },
+        "ltsv": {
+          "description": "LTSV defines ltsv parser configuration.",
+          "properties": {
+            "timeFormat": {
+              "description": "Time_Format, eg. %Y-%m-%dT%H:%M:%S %z",
+              "type": "string"
+            },
+            "timeKeep": {
+              "description": "Time_Keep",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Time_Key",
+              "type": "string"
+            },
+            "types": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "regex": {
+          "description": "Regex defines regex parser configuration.",
+          "properties": {
+            "regex": {
+              "type": "string"
+            },
+            "timeFormat": {
+              "description": "Time_Format, eg. %Y-%m-%dT%H:%M:%S %z",
+              "type": "string"
+            },
+            "timeKeep": {
+              "description": "Time_Keep",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Time_Key",
+              "type": "string"
+            },
+            "timeOffset": {
+              "description": "Time_Offset, eg. +0200",
+              "type": "string"
+            },
+            "types": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/collector_v1alpha2.json
+++ b/fluentbit.fluent.io/collector_v1alpha2.json
@@ -1,0 +1,3138 @@
+{
+  "description": "Collector is the Schema for the fluentbits API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "CollectorSpec defines the desired state of FluentBit",
+      "properties": {
+        "affinity": {
+          "description": "Pod's scheduling constraints.",
+          "properties": {
+            "nodeAffinity": {
+              "description": "Describes node affinity scheduling rules for the pod.",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                    "properties": {
+                      "preference": {
+                        "description": "A node selector term, associated with the corresponding weight.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                      "items": {
+                        "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAffinity": {
+              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAntiAffinity": {
+              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to each Fluentbit pod.",
+          "type": "object"
+        },
+        "args": {
+          "description": "Fluent Bit Watcher command line arguments.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "bufferPath": {
+          "description": "The path where buffer chunks are stored.",
+          "type": "string"
+        },
+        "disableService": {
+          "description": "By default will build the related service according to the globalinputs definition.",
+          "type": "boolean"
+        },
+        "fluentBitConfigName": {
+          "description": "Fluentbitconfig object associated with this Fluentbit",
+          "type": "string"
+        },
+        "hostNetwork": {
+          "description": "Host networking is requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+          "type": "boolean"
+        },
+        "image": {
+          "description": "Fluent Bit image.",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Fluent Bit image pull policy.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "Fluent Bit image pull secret",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "NodeSelector",
+          "type": "object"
+        },
+        "ports": {
+          "description": "Ports represents the pod's ports.",
+          "items": {
+            "description": "ContainerPort represents a network port in a single container.",
+            "properties": {
+              "containerPort": {
+                "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "hostIP": {
+                "description": "What host IP to bind the external port to.",
+                "type": "string"
+              },
+              "hostPort": {
+                "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "name": {
+                "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                "type": "string"
+              },
+              "protocol": {
+                "default": "TCP",
+                "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                "type": "string"
+              }
+            },
+            "required": [
+              "containerPort"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "priorityClassName": {
+          "description": "PriorityClassName represents the pod's priority class.",
+          "type": "string"
+        },
+        "pvc": {
+          "description": "PVC definition",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "metadata": {
+              "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+              "properties": {
+                "accessModes": {
+                  "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "dataSource": {
+                  "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                  "properties": {
+                    "apiGroup": {
+                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is the type of resource being referenced",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of resource being referenced",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "dataSourceRef": {
+                  "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                  "properties": {
+                    "apiGroup": {
+                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind is the type of resource being referenced",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of resource being referenced",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "resources": {
+                  "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "selector": {
+                  "description": "selector is a label query over volumes to consider for binding.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "storageClassName": {
+                  "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                  "type": "string"
+                },
+                "volumeAttributesClassName": {
+                  "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                  "type": "string"
+                },
+                "volumeMode": {
+                  "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                  "type": "string"
+                },
+                "volumeName": {
+                  "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "description": "status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+              "properties": {
+                "accessModes": {
+                  "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "allocatedResourceStatuses": {
+                  "additionalProperties": {
+                    "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
+                    "type": "string"
+                  },
+                  "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "allocatedResources": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+                  "type": "object"
+                },
+                "capacity": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "description": "capacity represents the actual resources of the underlying volume.",
+                  "type": "object"
+                },
+                "conditions": {
+                  "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
+                  "items": {
+                    "description": "PersistentVolumeClaimCondition contains details about state of pvc",
+                    "properties": {
+                      "lastProbeTime": {
+                        "description": "lastProbeTime is the time we probed the condition.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "message": {
+                        "description": "message is the human-readable message indicating details about last transition.",
+                        "type": "string"
+                      },
+                      "reason": {
+                        "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "status",
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "type"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "currentVolumeAttributesClassName": {
+                  "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim\nThis is an alpha field and requires enabling VolumeAttributesClass feature.",
+                  "type": "string"
+                },
+                "modifyVolumeStatus": {
+                  "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.\nThis is an alpha field and requires enabling VolumeAttributesClass feature.",
+                  "properties": {
+                    "status": {
+                      "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
+                      "type": "string"
+                    },
+                    "targetVolumeAttributesClassName": {
+                      "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "phase": {
+                  "description": "phase represents the current phase of PersistentVolumeClaim.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rbacRules": {
+          "description": "RBACRules represents additional rbac rules which will be applied to the fluent-bit clusterrole.",
+          "items": {
+            "description": "PolicyRule holds information that describes a policy rule, but does not contain information\nabout who the rule applies to or which namespace the rule applies to.",
+            "properties": {
+              "apiGroups": {
+                "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of\nthe enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "nonResourceURLs": {
+                "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path\nSince non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.\nRules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resourceNames": {
+                "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resources": {
+                "description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "verbs": {
+                "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              }
+            },
+            "required": [
+              "verbs"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Compute Resources required by container.",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName represents the container runtime configuration.",
+          "type": "string"
+        },
+        "schedulerName": {
+          "description": "SchedulerName represents the desired scheduler for the Fluentbit collector pods",
+          "type": "string"
+        },
+        "secrets": {
+          "description": "The Secrets are mounted into /fluent-bit/secrets/<secret-name>.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "securityContext": {
+          "description": "SecurityContext holds pod-level security attributes and common container settings.",
+          "properties": {
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fsGroup": {
+              "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "supplementalGroups": {
+              "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container. Note that group memberships\ndefined in the container image for the uid of the container process are still effective,\neven if they are not included in this list.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "sysctls": {
+              "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "description": "Sysctl defines a kernel parameter to be set",
+                "properties": {
+                  "name": {
+                    "description": "Name of a property to set",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value of a property to set",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "service": {
+          "description": "Service represents configurations on the fluent-bit service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to add to each Fluentbit service.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to add to each FluentBit service",
+              "type": "object"
+            },
+            "name": {
+              "description": "Name is the name of the FluentBit service.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccountAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the Fluentbit service account",
+          "type": "object"
+        },
+        "tolerations": {
+          "description": "Tolerations",
+          "items": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "List of volumes that can be mounted by containers belonging to the pod.",
+          "items": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+            "properties": {
+              "awsElasticBlockStore": {
+                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureDisk": {
+                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                "properties": {
+                  "cachingMode": {
+                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                    "type": "string"
+                  },
+                  "diskName": {
+                    "description": "diskName is the Name of the data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "diskURI": {
+                    "description": "diskURI is the URI of data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "diskName",
+                  "diskURI"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureFile": {
+                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                "properties": {
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                    "type": "string"
+                  },
+                  "shareName": {
+                    "description": "shareName is the azure share Name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secretName",
+                  "shareName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cephfs": {
+                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                "properties": {
+                  "monitors": {
+                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "path": {
+                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretFile": {
+                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cinder": {
+                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeID": {
+                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "configMap represents a configMap that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "csi": {
+                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "downwardAPI": {
+                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "Items is a list of downward API volume file",
+                    "items": {
+                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                      "properties": {
+                        "fieldRef": {
+                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                          "type": "string"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "emptyDir": {
+                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ephemeral": {
+                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                "properties": {
+                  "volumeClaimTemplate": {
+                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\n\nRequired, must not be nil.",
+                    "properties": {
+                      "metadata": {
+                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                        "properties": {
+                          "accessModes": {
+                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "dataSource": {
+                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "dataSourceRef": {
+                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "selector": {
+                            "description": "selector is a label query over volumes to consider for binding.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "storageClassName": {
+                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "fc": {
+                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun is Optional: FC target lun number",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "targetWWNs": {
+                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "wwids": {
+                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flexVolume": {
+                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the driver to use for this volume.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                    "type": "string"
+                  },
+                  "options": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "options is Optional: this field holds extra command options if any.",
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flocker": {
+                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                "properties": {
+                  "datasetName": {
+                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                    "type": "string"
+                  },
+                  "datasetUUID": {
+                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gcePersistentDisk": {
+                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "pdName": {
+                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "pdName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gitRepo": {
+                "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                "properties": {
+                  "directory": {
+                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                    "type": "string"
+                  },
+                  "repository": {
+                    "description": "repository is the URL",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "revision is the commit hash for the specified revision.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repository"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "glusterfs": {
+                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                "properties": {
+                  "endpoints": {
+                    "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "endpoints",
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "hostPath": {
+                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.",
+                "properties": {
+                  "path": {
+                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "iscsi": {
+                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                "properties": {
+                  "chapAuthDiscovery": {
+                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "chapAuthSession": {
+                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "initiatorName": {
+                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                    "type": "string"
+                  },
+                  "iqn": {
+                    "description": "iqn is the target iSCSI Qualified Name.",
+                    "type": "string"
+                  },
+                  "iscsiInterface": {
+                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun represents iSCSI Target Lun number.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "portals": {
+                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "targetPortal": {
+                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "iqn",
+                  "lun",
+                  "targetPortal"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "nfs": {
+                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                "properties": {
+                  "path": {
+                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "boolean"
+                  },
+                  "server": {
+                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "server"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "persistentVolumeClaim": {
+                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "photonPersistentDisk": {
+                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "pdID": {
+                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pdID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "portworxVolume": {
+                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID uniquely identifies a Portworx volume",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "projected": {
+                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "quobyte": {
+                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                "properties": {
+                  "group": {
+                    "description": "group to map volume access to\nDefault is no group",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "registry": {
+                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                    "type": "string"
+                  },
+                  "tenant": {
+                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "user to map volume access to\nDefaults to serivceaccount user",
+                    "type": "string"
+                  },
+                  "volume": {
+                    "description": "volume is a string that references an already created Quobyte volume by name.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "registry",
+                  "volume"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rbd": {
+                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "image": {
+                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "keyring": {
+                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "monitors": {
+                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "pool": {
+                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "image",
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scaleIO": {
+                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                    "type": "string"
+                  },
+                  "gateway": {
+                    "description": "gateway is the host address of the ScaleIO API Gateway.",
+                    "type": "string"
+                  },
+                  "protectionDomain": {
+                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "sslEnabled": {
+                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                    "type": "boolean"
+                  },
+                  "storageMode": {
+                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                    "type": "string"
+                  },
+                  "storagePool": {
+                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                    "type": "string"
+                  },
+                  "system": {
+                    "description": "system is the name of the storage system as configured in ScaleIO.",
+                    "type": "string"
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "gateway",
+                  "secretRef",
+                  "system"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "secret": {
+                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "storageos": {
+                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                    "type": "string"
+                  },
+                  "volumeNamespace": {
+                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "vsphereVolume": {
+                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "storagePolicyID": {
+                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                    "type": "string"
+                  },
+                  "storagePolicyName": {
+                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                    "type": "string"
+                  },
+                  "volumePath": {
+                    "description": "volumePath is the path that identifies vSphere volume vmdk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumePath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumesMounts": {
+          "description": "Pod volumes to mount into the container's filesystem.",
+          "items": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+              "mountPath": {
+                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                "type": "string"
+              },
+              "mountPropagation": {
+                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                "type": "string"
+              },
+              "name": {
+                "description": "This must match the Name of a Volume.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                "type": "string"
+              },
+              "subPathExpr": {
+                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mountPath",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "CollectorStatus defines the observed state of FluentBit",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/filter_v1alpha2.json
+++ b/fluentbit.fluent.io/filter_v1alpha2.json
@@ -1,0 +1,935 @@
+{
+  "description": "Filter is the Schema for namespace level filter API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FilterSpec defines the desired state of ClusterFilter",
+      "properties": {
+        "filters": {
+          "description": "A set of filter plugins in order.",
+          "items": {
+            "properties": {
+              "aws": {
+                "description": "Aws defines a Aws configuration.",
+                "properties": {
+                  "accountID": {
+                    "description": "The account ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "amiID": {
+                    "description": "The EC2 instance image id.Default is false.",
+                    "type": "boolean"
+                  },
+                  "az": {
+                    "description": "The availability zone; for example, \"us-east-1a\". Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceID": {
+                    "description": "The EC2 instance ID.Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceType": {
+                    "description": "The EC2 instance type.Default is false.",
+                    "type": "boolean"
+                  },
+                  "hostName": {
+                    "description": "The hostname for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "imdsVersion": {
+                    "description": "Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2'.",
+                    "enum": [
+                      "v1",
+                      "v2"
+                    ],
+                    "type": "string"
+                  },
+                  "privateIP": {
+                    "description": "The EC2 instance private ip.Default is false.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "vpcID": {
+                    "description": "The VPC ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "customPlugin": {
+                "description": "CustomPlugin defines a Custom plugin configuration.",
+                "properties": {
+                  "config": {
+                    "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+                    "type": "string"
+                  },
+                  "yamlConfig": {
+                    "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "grep": {
+                "description": "Grep defines Grep Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Exclude records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Keep records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kubernetes": {
+                "description": "Kubernetes defines Kubernetes Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "annotations": {
+                    "description": "Include Kubernetes resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "bufferSize": {
+                    "description": "Set the buffer size for HTTP client when reading responses from Kubernetes API server.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "cacheUseDockerId": {
+                    "description": "When enabled, metadata will be fetched from K8s when docker_id is changed.",
+                    "type": "boolean"
+                  },
+                  "dnsRetries": {
+                    "description": "DNS lookup retries N times until the network start working",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dnsWaitTime": {
+                    "description": "DNS lookup interval between network status checks",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dummyMeta": {
+                    "description": "If set, use dummy-meta data (for test/dev purposes)",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingExclude": {
+                    "description": "Allow Kubernetes Pods to exclude their logs from the log processor\n(read more about it in Kubernetes Annotations section).",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingParser": {
+                    "description": "Allow Kubernetes Pods to suggest a pre-defined Parser\n(read more about it in Kubernetes Annotations section)",
+                    "type": "boolean"
+                  },
+                  "keepLog": {
+                    "description": "When Keep_Log is disabled, the log field is removed\nfrom the incoming message once it has been successfully merged\n(Merge_Log must be enabled as well).",
+                    "type": "boolean"
+                  },
+                  "kubeCAFile": {
+                    "description": "CA certificate file",
+                    "type": "string"
+                  },
+                  "kubeCAPath": {
+                    "description": "Absolute path to scan for certificate files",
+                    "type": "string"
+                  },
+                  "kubeMetaCacheTTL": {
+                    "description": "configurable TTL for K8s cached metadata. By default, it is set to 0\nwhich means TTL for cache entries is disabled and cache entries are evicted at random\nwhen capacity is reached. In order to enable this option, you should set the number to a time interval.\nFor example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted.",
+                    "type": "string"
+                  },
+                  "kubeMetaNamespaceCacheTTL": {
+                    "description": "Configurable TTL for K8s cached namespace metadata.\nBy default, it is set to 900 which means a 15min TTL for namespace cache entries.\nSetting this to 0 will mean entries are evicted at random once the cache is full.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "kubeMetaPreloadCacheDir": {
+                    "description": "If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory,\nnamed as namespace-pod.meta",
+                    "type": "string"
+                  },
+                  "kubeTagPrefix": {
+                    "description": "When the source records comes from Tail input plugin,\nthis option allows to specify what's the prefix used in Tail configuration.",
+                    "type": "string"
+                  },
+                  "kubeTokenCommand": {
+                    "description": "Command to get Kubernetes authorization token.\nBy default, it will be NULL and we will use token file to get token.",
+                    "type": "string"
+                  },
+                  "kubeTokenFile": {
+                    "description": "Token file",
+                    "type": "string"
+                  },
+                  "kubeTokenTTL": {
+                    "description": "configurable 'time to live' for the K8s token. By default, it is set to 600 seconds.\nAfter this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.",
+                    "type": "string"
+                  },
+                  "kubeURL": {
+                    "description": "API Server end-point",
+                    "type": "string"
+                  },
+                  "kubeletHost": {
+                    "description": "kubelet host using for HTTP request, this only works when Use_Kubelet set to On.",
+                    "type": "string"
+                  },
+                  "kubeletPort": {
+                    "description": "kubelet port using for HTTP request, this only works when useKubelet is set to On.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "description": "Include Kubernetes resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "mergeLog": {
+                    "description": "When enabled, it checks if the log field content is a JSON string map,\nif so, it append the map fields as part of the log structure.",
+                    "type": "boolean"
+                  },
+                  "mergeLogKey": {
+                    "description": "When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message\nand make a structured representation of it at the same level of the log field in the map.\nNow if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.",
+                    "type": "string"
+                  },
+                  "mergeLogTrim": {
+                    "description": "When Merge_Log is enabled, trim (remove possible \\n or \\r) field values.",
+                    "type": "boolean"
+                  },
+                  "mergeParser": {
+                    "description": "Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.",
+                    "type": "string"
+                  },
+                  "namespaceAnnotations": {
+                    "description": "Include Kubernetes namespace resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceLabels": {
+                    "description": "Include Kubernetes namespace resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceMetadataOnly": {
+                    "description": "Include Kubernetes namespace metadata only and no pod metadata.\nIf this is set, the values of Labels and Annotations are ignored.",
+                    "type": "boolean"
+                  },
+                  "regexParser": {
+                    "description": "Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.\nThe parser must be registered in a parsers file (refer to parser filter-kube-test as an example).",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tlsDebug": {
+                    "description": "Debug level between 0 (nothing) and 4 (every detail).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tlsVerify": {
+                    "description": "When enabled, turns on certificate validation when connecting to the Kubernetes API server.",
+                    "type": "boolean"
+                  },
+                  "useJournal": {
+                    "description": "When enabled, the filter reads logs coming in Journald format.",
+                    "type": "boolean"
+                  },
+                  "useKubelet": {
+                    "description": "This is an optional feature flag to get metadata information from kubelet\ninstead of calling Kube Server API to enhance the log.\nThis could mitigate the Kube API heavy traffic issue for large cluster.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logToMetrics": {
+                "description": "LogToMetrics defines a Log to Metrics Filter configuration.",
+                "properties": {
+                  "addLabel": {
+                    "description": "Add a custom label NAME and set the value to the value of KEY",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "bucket": {
+                    "description": "Defines a bucket for histogram",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "discardLogs": {
+                    "description": "Flag that defines if logs should be discarded after processing. This applies\nfor all logs, no matter if they have emitted metrics or not.",
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "description": "set a buffer limit to restrict memory usage of metrics emitter",
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "Name of the emitter (advanced users)",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Optional filter for records in which the content of KEY does not matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "kubernetesMode": {
+                    "description": "If enabled, it will automatically put pod_id, pod_name, namespace_name, docker_id and container_name\ninto the metric as labels. This option is intended to be used in combination with the kubernetes filter plugin.",
+                    "type": "boolean"
+                  },
+                  "labelField": {
+                    "description": "Includes a record field as label dimension in the metric.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "metricDescription": {
+                    "description": "Sets a help text for the metric.",
+                    "type": "string"
+                  },
+                  "metricMode": {
+                    "description": "Defines the mode for the metric. Valid values are [counter, gauge or histogram]",
+                    "type": "string"
+                  },
+                  "metricName": {
+                    "description": "Sets the name of the metric.",
+                    "type": "string"
+                  },
+                  "metricNamespace": {
+                    "description": "Namespace of the metric",
+                    "type": "string"
+                  },
+                  "metricSubsystem": {
+                    "description": "Sets a sub-system for the metric.",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Optional filter for records in which the content of KEY matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Defines the tag for the generated metrics record",
+                    "type": "string"
+                  },
+                  "valueField": {
+                    "description": "Specify the record field that holds a numerical value",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "lua": {
+                "description": "Lua defines Lua Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "call": {
+                    "description": "Lua function name that will be triggered to do filtering.\nIt's assumed that the function is declared inside the Script defined above.",
+                    "type": "string"
+                  },
+                  "code": {
+                    "description": "Inline LUA code instead of loading from a path via script.",
+                    "type": "string"
+                  },
+                  "protectedMode": {
+                    "description": "If enabled, Lua script will be executed in protected mode.\nIt prevents to crash when invalid Lua script is executed. Default is true.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "script": {
+                    "description": "Path to the Lua script that will be used.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "timeAsTable": {
+                    "description": "By default when the Lua script is invoked, the record timestamp is passed as a\nFloating number which might lead to loss precision when the data is converted back.\nIf you desire timestamp precision enabling this option will pass the timestamp as\na Lua table with keys sec for seconds since epoch and nsec for nanoseconds.",
+                    "type": "boolean"
+                  },
+                  "typeArrayKey": {
+                    "description": "If these keys are matched, the fields are handled as array. If more than\none key, delimit by space. It is useful the array can be empty.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "typeIntKey": {
+                    "description": "If these keys are matched, the fields are converted to integer.\nIf more than one key, delimit by space.\nNote that starting from Fluent Bit v1.6 integer data types are preserved\nand not converted to double as in previous versions.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "call"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "modify": {
+                "description": "Modify defines Modify Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "description": "All conditions have to be true for the rules to be applied.",
+                    "items": {
+                      "description": "The plugin supports the following conditions",
+                      "properties": {
+                        "aKeyMatches": {
+                          "description": "Is true if a key matches regex KEY",
+                          "type": "string"
+                        },
+                        "keyDoesNotExist": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY does not exist",
+                          "type": "object"
+                        },
+                        "keyExists": {
+                          "description": "Is true if KEY exists",
+                          "type": "string"
+                        },
+                        "keyValueDoesNotEqual": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is not VALUE",
+                          "type": "object"
+                        },
+                        "keyValueDoesNotMatch": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value does not match VALUE",
+                          "type": "object"
+                        },
+                        "keyValueEquals": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is VALUE",
+                          "type": "object"
+                        },
+                        "keyValueMatches": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value matches VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysDoNotHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that do not match VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that match VALUE",
+                          "type": "object"
+                        },
+                        "noKeyMatches": {
+                          "description": "Is true if no key matches regex KEY",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Rules are applied in the order they appear,\nwith each rule operating on the result of the previous rule.",
+                    "items": {
+                      "description": "The plugin supports the following rules",
+                      "properties": {
+                        "add": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE if KEY does not exist",
+                          "type": "object"
+                        },
+                        "copy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "hardCopy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists.\nIf COPIED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "hardRename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists.\nIf RENAMED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "remove": {
+                          "description": "Remove a key/value pair with key KEY if it exists",
+                          "type": "string"
+                        },
+                        "removeRegex": {
+                          "description": "Remove all key/value pairs with key matching regexp KEY",
+                          "type": "string"
+                        },
+                        "removeWildcard": {
+                          "description": "Remove all key/value pairs with key matching wildcard KEY",
+                          "type": "string"
+                        },
+                        "rename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "set": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "multiline": {
+                "description": "Multiline defines a Multiline configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "buffer": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "default": 10,
+                    "description": "Set a limit on the amount of memory in MB the emitter can consume if the outputs provide backpressure. The default for this limit is 10M. The pipeline will pause once the buffer exceeds the value of this setting. For example, if the value is set to 10MB then the pipeline will pause if the buffer exceeds 10M. The pipeline will remain paused until the output drains the buffer below the 10M limit.",
+                    "type": "integer"
+                  },
+                  "emitterName": {
+                    "description": "Name for the emitter input instance which re-emits the completed records at the beginning of the pipeline.",
+                    "type": "string"
+                  },
+                  "emitterType": {
+                    "default": "memory",
+                    "description": "The storage type for the emitter input instance. This option supports the values memory (default) and filesystem.",
+                    "enum": [
+                      "memory",
+                      "filesystem"
+                    ],
+                    "type": "string"
+                  },
+                  "flushMs": {
+                    "default": 2000,
+                    "type": "integer"
+                  },
+                  "keyContent": {
+                    "description": "Key name that holds the content to process.\nNote that a Multiline Parser definition can already specify the key_content to use, but this option allows to overwrite that value for the purpose of the filter.",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "enum": [
+                      "parser",
+                      "partial_message"
+                    ],
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify one or multiple Multiline Parsing definitions to apply to the content.\nYou can specify multiple multiline parsers to detect different formats by separating them with a comma.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parser"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nest": {
+                "description": "Nest defines Nest Filter configuration.",
+                "properties": {
+                  "addPrefix": {
+                    "description": "Prefix affected keys with this string",
+                    "type": "string"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "nestUnder": {
+                    "description": "Nest records matching the Wildcard under this key",
+                    "type": "string"
+                  },
+                  "nestedUnder": {
+                    "description": "Lift records nested under the Nested_under key",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "Select the operation nest or lift",
+                    "enum": [
+                      "nest",
+                      "lift"
+                    ],
+                    "type": "string"
+                  },
+                  "removePrefix": {
+                    "description": "Remove prefix from affected keys if it matches this string",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wildcard": {
+                    "description": "Nest records which field matches the wildcard",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "parser": {
+                "description": "Parser defines Parser Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "keyName": {
+                    "description": "Specify field name in record to parse.",
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify the parser name to interpret the field.\nMultiple Parser entries are allowed (split by comma).",
+                    "type": "string"
+                  },
+                  "preserveKey": {
+                    "description": "Keep original Key_Name field in the parsed result.\nIf false, the field will be removed.",
+                    "type": "boolean"
+                  },
+                  "reserveData": {
+                    "description": "Keep all other original fields in the parsed result.\nIf false, all other original fields will be removed.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "unescapeKey": {
+                    "description": "If the key is a escaped string (e.g: stringify JSON), unescape the string before to apply the parser.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "recordModifier": {
+                "description": "RecordModifier defines Record Modifier Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "allowlistKeys": {
+                    "description": "If the key is not matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "records": {
+                    "description": "Append fields. This parameter needs key and value pair.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "removeKeys": {
+                    "description": "If the key is matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "uuidKeys": {
+                    "description": "If set, the plugin appends uuid to each record. The value assigned becomes the key in the map.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "whitelistKeys": {
+                    "description": "An alias of allowlistKeys for backwards compatibility.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rewriteTag": {
+                "description": "RewriteTag defines a RewriteTag configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "emitterMemBufLimit": {
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "When the filter emits a record under the new Tag, there is an internal emitter\nplugin that takes care of the job. Since this emitter expose metrics as any other\ncomponent of the pipeline, you can use this property to configure an optional name for it.",
+                    "type": "string"
+                  },
+                  "emitterStorageType": {
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Defines the matching criteria and the format of the Tag for the matching record.\nThe Rule format have four components: KEY REGEX NEW_TAG KEEP.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "throttle": {
+                "description": "Throttle defines a Throttle configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "interval": {
+                    "description": "Interval is the time interval expressed in \"sleep\" format. e.g. 3s, 1.5m, 0.5h, etc.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "printStatus": {
+                    "description": "PrintStatus represents whether to print status messages with current rate and the limits to information logs.",
+                    "type": "boolean"
+                  },
+                  "rate": {
+                    "description": "Rate is the amount of messages for the time.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "window": {
+                    "description": "Window is the amount of intervals to calculate average over.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "wasm": {
+                "description": "Wasm defines a Wasm configuration.",
+                "properties": {
+                  "accessiblePaths": {
+                    "description": "Specify the whitelist of paths to be able to access paths from WASM programs.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "eventFormat": {
+                    "description": "Define event format to interact with Wasm programs: msgpack or json. Default: json",
+                    "type": "string"
+                  },
+                  "functionName": {
+                    "description": "Wasm function name that will be triggered to do filtering. It's assumed that the function is built inside the Wasm program specified above.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wasmHeapSize": {
+                    "description": "Size of the heap size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "wasmPath": {
+                    "description": "Path to the built Wasm program that will be used. This can be a relative path against the main configuration file.",
+                    "type": "string"
+                  },
+                  "wasmStackSize": {
+                    "description": "Size of the stack size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "logLevel": {
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case-sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/fluentbit_v1alpha2.json
+++ b/fluentbit.fluent.io/fluentbit_v1alpha2.json
@@ -1,0 +1,6264 @@
+{
+  "description": "FluentBit is the Schema for the fluentbits API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluentBitSpec defines the desired state of FluentBit",
+      "properties": {
+        "affinity": {
+          "description": "Pod's scheduling constraints.",
+          "properties": {
+            "nodeAffinity": {
+              "description": "Describes node affinity scheduling rules for the pod.",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                    "properties": {
+                      "preference": {
+                        "description": "A node selector term, associated with the corresponding weight.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                      "items": {
+                        "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAffinity": {
+              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAntiAffinity": {
+              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to each Fluentbit pod.",
+          "type": "object"
+        },
+        "args": {
+          "description": "Fluent Bit Watcher command line arguments.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "description": "Fluent Bit Watcher command.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "containerLogRealPath": {
+          "description": "Container log path",
+          "type": "string"
+        },
+        "containerSecurityContext": {
+          "description": "ContainerSecurityContext holds container-level security attributes.",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "capabilities": {
+              "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "add": {
+                  "description": "Added capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "drop": {
+                  "description": "Removed capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "privileged": {
+              "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "procMount": {
+              "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "readOnlyRootFilesystem": {
+              "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "disableLogVolumes": {
+          "description": "DisableLogVolumes removes the hostPath mounts for varlibcontainers, varlogs and systemd.",
+          "type": "boolean"
+        },
+        "disableService": {
+          "description": "DisableService tells if the fluentbit service should be deployed.",
+          "type": "boolean"
+        },
+        "dnsPolicy": {
+          "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are\n'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.",
+          "type": "string"
+        },
+        "envVars": {
+          "description": "EnvVars represent environment variables that can be passed to fluentbit pods.",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "fluentBitConfigName": {
+          "description": "Fluentbitconfig object associated with this Fluentbit",
+          "type": "string"
+        },
+        "hostNetwork": {
+          "description": "Host networking is requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+          "type": "boolean"
+        },
+        "image": {
+          "description": "Fluent Bit image.",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Fluent Bit image pull policy.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "Fluent Bit image pull secret",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "initContainers": {
+          "description": "InitContainers represents the pod's init containers.",
+          "items": {
+            "description": "A single application container that you want to run within a pod.",
+            "properties": {
+              "args": {
+                "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "command": {
+                "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "env": {
+                "description": "List of environment variables to set in the container.\nCannot be updated.",
+                "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
+                          "properties": {
+                            "key": {
+                              "description": "The key to select.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "fieldRef": {
+                          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "envFrom": {
+                "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                "items": {
+                  "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                  "properties": {
+                    "configMapRef": {
+                      "description": "The ConfigMap to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the ConfigMap must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "prefix": {
+                      "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The Secret to select from",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "image": {
+                "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                "type": "string"
+              },
+              "lifecycle": {
+                "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
+                "properties": {
+                  "postStart": {
+                    "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies the action to take.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies the http request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "sleep": {
+                        "description": "Sleep represents the duration that the container should sleep before being terminated.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor the backward compatibility. There are no validation of this field and\nlifecycle hooks will fail in runtime when tcp handler is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "preStop": {
+                    "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                    "properties": {
+                      "exec": {
+                        "description": "Exec specifies the action to take.",
+                        "properties": {
+                          "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "description": "HTTPGet specifies the http request to perform.",
+                        "properties": {
+                          "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                            "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                              "properties": {
+                                "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "The header field value",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "path": {
+                            "description": "Path to access on the HTTP server.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "sleep": {
+                        "description": "Sleep represents the duration that the container should sleep before being terminated.",
+                        "properties": {
+                          "seconds": {
+                            "description": "Seconds is the number of seconds to sleep.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "seconds"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor the backward compatibility. There are no validation of this field and\nlifecycle hooks will fail in runtime when tcp handler is specified.",
+                        "properties": {
+                          "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "livenessProbe": {
+                "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies the action to take.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies an action involving a GRPC port.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies the http request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies an action involving a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                "type": "string"
+              },
+              "ports": {
+                "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                "items": {
+                  "description": "ContainerPort represents a network port in a single container.",
+                  "properties": {
+                    "containerPort": {
+                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "description": "What host IP to bind the external port to.",
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "readinessProbe": {
+                "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies the action to take.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies an action involving a GRPC port.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies the http request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies an action involving a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "resizePolicy": {
+                "description": "Resources resize policy for the container.",
+                "items": {
+                  "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                  "properties": {
+                    "resourceName": {
+                      "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                      "type": "string"
+                    },
+                    "restartPolicy": {
+                      "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "resourceName",
+                    "restartPolicy"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resources": {
+                "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                "properties": {
+                  "claims": {
+                    "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                    "items": {
+                      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                      "properties": {
+                        "name": {
+                          "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "restartPolicy": {
+                "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                "type": "string"
+              },
+              "securityContext": {
+                "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "appArmorProfile": {
+                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "capabilities": {
+                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "add": {
+                        "description": "Added capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "drop": {
+                        "description": "Removed capabilities",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "privileged": {
+                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "level": {
+                        "description": "Level is SELinux level label that applies to the container.",
+                        "type": "string"
+                      },
+                      "role": {
+                        "description": "Role is a SELinux role label that applies to the container.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Type is a SELinux type label that applies to the container.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User is a SELinux user label that applies to the container.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "seccompProfile": {
+                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "windowsOptions": {
+                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "startupProbe": {
+                "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies the action to take.",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies an action involving a GRPC port.",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies the http request to perform.",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies an action involving a TCP port.",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdin": {
+                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                "type": "string"
+              },
+              "tty": {
+                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "description": "volumeDevices is the list of block devices to be used by the container.",
+                "items": {
+                  "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                  "properties": {
+                    "devicePath": {
+                      "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "name must match the name of a persistentVolumeClaim in the pod",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "devicePath"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "volumeMounts": {
+                "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                "items": {
+                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                  "properties": {
+                    "mountPath": {
+                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "This must match the Name of a Volume.",
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "recursiveReadOnly": {
+                      "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                      "type": "string"
+                    },
+                    "subPath": {
+                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "mountPath"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "workingDir": {
+                "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "internalMountPropagation": {
+          "description": "MountPropagation option for internal mounts",
+          "enum": [
+            "None",
+            "HostToContainer",
+            "Bidirectional"
+          ],
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels to add to each FluentBit pod",
+          "type": "object"
+        },
+        "livenessProbe": {
+          "description": "LivenessProbe represents the pod's liveness probe.",
+          "properties": {
+            "exec": {
+              "description": "Exec specifies the action to take.",
+              "properties": {
+                "command": {
+                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "description": "GRPC specifies an action involving a GRPC port.",
+              "properties": {
+                "port": {
+                  "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "description": "HTTPGet specifies the http request to perform.",
+              "properties": {
+                "host": {
+                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                  "items": {
+                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                    "properties": {
+                      "name": {
+                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The header field value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "description": "Path to access on the HTTP server.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "description": "TCPSocket specifies an action involving a TCP port.",
+              "properties": {
+                "host": {
+                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metricsPort": {
+          "description": "MetricsPort is the port used by the metrics server. If this option is set, HttpPort from ClusterFluentBitConfig needs to match this value. Default is 2020.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "namespaceFluentBitCfgSelector": {
+          "description": "NamespacedFluentBitCfgSelector selects the namespace FluentBitConfig associated with this FluentBit",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "NodeSelector",
+          "type": "object"
+        },
+        "ports": {
+          "description": "Ports represents the pod's ports.",
+          "items": {
+            "description": "ContainerPort represents a network port in a single container.",
+            "properties": {
+              "containerPort": {
+                "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "hostIP": {
+                "description": "What host IP to bind the external port to.",
+                "type": "string"
+              },
+              "hostPort": {
+                "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "name": {
+                "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                "type": "string"
+              },
+              "protocol": {
+                "default": "TCP",
+                "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                "type": "string"
+              }
+            },
+            "required": [
+              "containerPort"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "positionDB": {
+          "description": "Storage for position db. You will use it if tail input is enabled.",
+          "properties": {
+            "awsElasticBlockStore": {
+              "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "partition": {
+                  "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "readOnly": {
+                  "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                  "type": "boolean"
+                },
+                "volumeID": {
+                  "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumeID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "azureDisk": {
+              "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+              "properties": {
+                "cachingMode": {
+                  "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                  "type": "string"
+                },
+                "diskName": {
+                  "description": "diskName is the Name of the data disk in the blob storage",
+                  "type": "string"
+                },
+                "diskURI": {
+                  "description": "diskURI is the URI of data disk in the blob storage",
+                  "type": "string"
+                },
+                "fsType": {
+                  "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "diskName",
+                "diskURI"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "azureFile": {
+              "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+              "properties": {
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretName": {
+                  "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                  "type": "string"
+                },
+                "shareName": {
+                  "description": "shareName is the azure share Name",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretName",
+                "shareName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cephfs": {
+              "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+              "properties": {
+                "monitors": {
+                  "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "type": "boolean"
+                },
+                "secretFile": {
+                  "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "user": {
+                  "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "monitors"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cinder": {
+              "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "volumeID": {
+                  "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumeID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "configMap": {
+              "description": "configMap represents a configMap that should populate this volume",
+              "properties": {
+                "defaultMode": {
+                  "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "items": {
+                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                  "items": {
+                    "description": "Maps a string key to a path within a volume.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the key to project.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "name": {
+                  "default": "",
+                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                  "type": "string"
+                },
+                "optional": {
+                  "description": "optional specify whether the ConfigMap or its keys must be defined",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "csi": {
+              "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+              "properties": {
+                "driver": {
+                  "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                  "type": "string"
+                },
+                "fsType": {
+                  "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                  "type": "string"
+                },
+                "nodePublishSecretRef": {
+                  "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "readOnly": {
+                  "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                  "type": "boolean"
+                },
+                "volumeAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "driver"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "downwardAPI": {
+              "description": "downwardAPI represents downward API about the pod that should populate this volume",
+              "properties": {
+                "defaultMode": {
+                  "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "items": {
+                  "description": "Items is a list of downward API volume file",
+                  "items": {
+                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                    "properties": {
+                      "fieldRef": {
+                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "mode": {
+                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                        "type": "string"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "emptyDir": {
+              "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+              "properties": {
+                "medium": {
+                  "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                  "type": "string"
+                },
+                "sizeLimit": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ephemeral": {
+              "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+              "properties": {
+                "volumeClaimTemplate": {
+                  "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\n\nRequired, must not be nil.",
+                  "properties": {
+                    "metadata": {
+                      "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                      "properties": {
+                        "accessModes": {
+                          "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "dataSource": {
+                          "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "dataSourceRef": {
+                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "resources": {
+                          "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                          "properties": {
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "description": "selector is a label query over volumes to consider for binding.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "storageClassName": {
+                          "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                          "type": "string"
+                        },
+                        "volumeAttributesClassName": {
+                          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                          "type": "string"
+                        },
+                        "volumeMode": {
+                          "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                          "type": "string"
+                        },
+                        "volumeName": {
+                          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "spec"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fc": {
+              "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "lun": {
+                  "description": "lun is Optional: FC target lun number",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "readOnly": {
+                  "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "targetWWNs": {
+                  "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "wwids": {
+                  "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "flexVolume": {
+              "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+              "properties": {
+                "driver": {
+                  "description": "driver is the name of the driver to use for this volume.",
+                  "type": "string"
+                },
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                  "type": "string"
+                },
+                "options": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "options is Optional: this field holds extra command options if any.",
+                  "type": "object"
+                },
+                "readOnly": {
+                  "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "driver"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "flocker": {
+              "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+              "properties": {
+                "datasetName": {
+                  "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                  "type": "string"
+                },
+                "datasetUUID": {
+                  "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "gcePersistentDisk": {
+              "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "partition": {
+                  "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "pdName": {
+                  "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "pdName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "gitRepo": {
+              "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+              "properties": {
+                "directory": {
+                  "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                  "type": "string"
+                },
+                "repository": {
+                  "description": "repository is the URL",
+                  "type": "string"
+                },
+                "revision": {
+                  "description": "revision is the commit hash for the specified revision.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "repository"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "glusterfs": {
+              "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+              "properties": {
+                "endpoints": {
+                  "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "endpoints",
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "hostPath": {
+              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.",
+              "properties": {
+                "path": {
+                  "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iscsi": {
+              "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+              "properties": {
+                "chapAuthDiscovery": {
+                  "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                  "type": "boolean"
+                },
+                "chapAuthSession": {
+                  "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                  "type": "boolean"
+                },
+                "fsType": {
+                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "initiatorName": {
+                  "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                  "type": "string"
+                },
+                "iqn": {
+                  "description": "iqn is the target iSCSI Qualified Name.",
+                  "type": "string"
+                },
+                "iscsiInterface": {
+                  "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                  "type": "string"
+                },
+                "lun": {
+                  "description": "lun represents iSCSI Target Lun number.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "portals": {
+                  "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "targetPortal": {
+                  "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "iqn",
+                "lun",
+                "targetPortal"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nfs": {
+              "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+              "properties": {
+                "path": {
+                  "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                  "type": "boolean"
+                },
+                "server": {
+                  "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "server"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "persistentVolumeClaim": {
+              "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+              "properties": {
+                "claimName": {
+                  "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "claimName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "photonPersistentDisk": {
+              "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "pdID": {
+                  "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pdID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "portworxVolume": {
+              "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+              "properties": {
+                "fsType": {
+                  "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "volumeID": {
+                  "description": "volumeID uniquely identifies a Portworx volume",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumeID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "projected": {
+              "description": "projected items for all in one resources secrets, configmaps, and downward API",
+              "properties": {
+                "defaultMode": {
+                  "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sources": {
+                  "description": "sources is the list of volume projections",
+                  "items": {
+                    "description": "Projection that may be projected along with other supported volume types",
+                    "properties": {
+                      "clusterTrustBundle": {
+                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                            "type": "boolean"
+                          },
+                          "path": {
+                            "description": "Relative path from the volume root to write the bundle.",
+                            "type": "string"
+                          },
+                          "signerName": {
+                            "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "description": "configMap information about the configMap data to project",
+                        "properties": {
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "description": "downwardAPI information about the downwardAPI data to project",
+                        "properties": {
+                          "items": {
+                            "description": "Items is a list of DownwardAPIVolume file",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "secret information about the secret data to project",
+                        "properties": {
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountToken": {
+                        "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                        "properties": {
+                          "audience": {
+                            "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                            "type": "string"
+                          },
+                          "expirationSeconds": {
+                            "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "path": {
+                            "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "quobyte": {
+              "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+              "properties": {
+                "group": {
+                  "description": "group to map volume access to\nDefault is no group",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                  "type": "boolean"
+                },
+                "registry": {
+                  "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                  "type": "string"
+                },
+                "tenant": {
+                  "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "user to map volume access to\nDefaults to serivceaccount user",
+                  "type": "string"
+                },
+                "volume": {
+                  "description": "volume is a string that references an already created Quobyte volume by name.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "registry",
+                "volume"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rbd": {
+              "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "image": {
+                  "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "keyring": {
+                  "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "monitors": {
+                  "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "pool": {
+                  "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "user": {
+                  "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "image",
+                "monitors"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scaleIO": {
+              "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                  "type": "string"
+                },
+                "gateway": {
+                  "description": "gateway is the host address of the ScaleIO API Gateway.",
+                  "type": "string"
+                },
+                "protectionDomain": {
+                  "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "sslEnabled": {
+                  "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                  "type": "boolean"
+                },
+                "storageMode": {
+                  "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                  "type": "string"
+                },
+                "storagePool": {
+                  "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                  "type": "string"
+                },
+                "system": {
+                  "description": "system is the name of the storage system as configured in ScaleIO.",
+                  "type": "string"
+                },
+                "volumeName": {
+                  "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gateway",
+                "secretRef",
+                "system"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secret": {
+              "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+              "properties": {
+                "defaultMode": {
+                  "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "items": {
+                  "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                  "items": {
+                    "description": "Maps a string key to a path within a volume.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the key to project.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "optional": {
+                  "description": "optional field specify whether the Secret or its keys must be defined",
+                  "type": "boolean"
+                },
+                "secretName": {
+                  "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "storageos": {
+              "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "volumeName": {
+                  "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                  "type": "string"
+                },
+                "volumeNamespace": {
+                  "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "vsphereVolume": {
+              "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "storagePolicyID": {
+                  "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                  "type": "string"
+                },
+                "storagePolicyName": {
+                  "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                  "type": "string"
+                },
+                "volumePath": {
+                  "description": "volumePath is the path that identifies vSphere volume vmdk",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumePath"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "priorityClassName": {
+          "description": "PriorityClassName represents the pod's priority class.",
+          "type": "string"
+        },
+        "rbacRules": {
+          "description": "RBACRules represents additional rbac rules which will be applied to the fluent-bit clusterrole.",
+          "items": {
+            "description": "PolicyRule holds information that describes a policy rule, but does not contain information\nabout who the rule applies to or which namespace the rule applies to.",
+            "properties": {
+              "apiGroups": {
+                "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of\nthe enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "nonResourceURLs": {
+                "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path\nSince non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.\nRules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resourceNames": {
+                "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resources": {
+                "description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "verbs": {
+                "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              }
+            },
+            "required": [
+              "verbs"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "readinessProbe": {
+          "description": "ReadinessProbe represents the pod's readiness probe.",
+          "properties": {
+            "exec": {
+              "description": "Exec specifies the action to take.",
+              "properties": {
+                "command": {
+                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "description": "GRPC specifies an action involving a GRPC port.",
+              "properties": {
+                "port": {
+                  "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "description": "HTTPGet specifies the http request to perform.",
+              "properties": {
+                "host": {
+                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                  "items": {
+                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                    "properties": {
+                      "name": {
+                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The header field value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "description": "Path to access on the HTTP server.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "description": "TCPSocket specifies an action involving a TCP port.",
+              "properties": {
+                "host": {
+                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Compute Resources required by container.",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName represents the container runtime configuration.",
+          "type": "string"
+        },
+        "schedulerName": {
+          "description": "SchedulerName represents the desired scheduler for fluent-bit pods.",
+          "type": "string"
+        },
+        "secrets": {
+          "description": "The Secrets are mounted into /fluent-bit/secrets/<secret-name>.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "securityContext": {
+          "description": "SecurityContext holds pod-level security attributes and common container settings.",
+          "properties": {
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fsGroup": {
+              "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "supplementalGroups": {
+              "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container. Note that group memberships\ndefined in the container image for the uid of the container process are still effective,\neven if they are not included in this list.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "sysctls": {
+              "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "description": "Sysctl defines a kernel parameter to be set",
+                "properties": {
+                  "name": {
+                    "description": "Name of a property to set",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value of a property to set",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "service": {
+          "description": "Service represents configurations on the fluent-bit service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to add to each Fluentbit service.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to add to each FluentBit service",
+              "type": "object"
+            },
+            "name": {
+              "description": "Name is the name of the FluentBit service.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccountAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the Fluentbit service account",
+          "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully. Value must be non-negative integer.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "tolerations": {
+          "description": "Tolerations",
+          "items": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "List of volumes that can be mounted by containers belonging to the pod.",
+          "items": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+            "properties": {
+              "awsElasticBlockStore": {
+                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureDisk": {
+                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                "properties": {
+                  "cachingMode": {
+                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                    "type": "string"
+                  },
+                  "diskName": {
+                    "description": "diskName is the Name of the data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "diskURI": {
+                    "description": "diskURI is the URI of data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "diskName",
+                  "diskURI"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureFile": {
+                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                "properties": {
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                    "type": "string"
+                  },
+                  "shareName": {
+                    "description": "shareName is the azure share Name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secretName",
+                  "shareName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cephfs": {
+                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                "properties": {
+                  "monitors": {
+                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "path": {
+                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretFile": {
+                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cinder": {
+                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeID": {
+                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "configMap represents a configMap that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "csi": {
+                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "downwardAPI": {
+                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "Items is a list of downward API volume file",
+                    "items": {
+                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                      "properties": {
+                        "fieldRef": {
+                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                          "type": "string"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "emptyDir": {
+                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ephemeral": {
+                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                "properties": {
+                  "volumeClaimTemplate": {
+                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\n\nRequired, must not be nil.",
+                    "properties": {
+                      "metadata": {
+                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                        "properties": {
+                          "accessModes": {
+                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "dataSource": {
+                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "dataSourceRef": {
+                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "selector": {
+                            "description": "selector is a label query over volumes to consider for binding.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "storageClassName": {
+                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "fc": {
+                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun is Optional: FC target lun number",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "targetWWNs": {
+                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "wwids": {
+                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flexVolume": {
+                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the driver to use for this volume.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                    "type": "string"
+                  },
+                  "options": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "options is Optional: this field holds extra command options if any.",
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flocker": {
+                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                "properties": {
+                  "datasetName": {
+                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                    "type": "string"
+                  },
+                  "datasetUUID": {
+                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gcePersistentDisk": {
+                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "pdName": {
+                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "pdName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gitRepo": {
+                "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                "properties": {
+                  "directory": {
+                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                    "type": "string"
+                  },
+                  "repository": {
+                    "description": "repository is the URL",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "revision is the commit hash for the specified revision.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repository"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "glusterfs": {
+                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                "properties": {
+                  "endpoints": {
+                    "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "endpoints",
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "hostPath": {
+                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.",
+                "properties": {
+                  "path": {
+                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "iscsi": {
+                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                "properties": {
+                  "chapAuthDiscovery": {
+                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "chapAuthSession": {
+                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "initiatorName": {
+                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                    "type": "string"
+                  },
+                  "iqn": {
+                    "description": "iqn is the target iSCSI Qualified Name.",
+                    "type": "string"
+                  },
+                  "iscsiInterface": {
+                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun represents iSCSI Target Lun number.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "portals": {
+                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "targetPortal": {
+                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "iqn",
+                  "lun",
+                  "targetPortal"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "nfs": {
+                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                "properties": {
+                  "path": {
+                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "boolean"
+                  },
+                  "server": {
+                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "server"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "persistentVolumeClaim": {
+                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "photonPersistentDisk": {
+                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "pdID": {
+                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pdID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "portworxVolume": {
+                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID uniquely identifies a Portworx volume",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "projected": {
+                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "quobyte": {
+                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                "properties": {
+                  "group": {
+                    "description": "group to map volume access to\nDefault is no group",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "registry": {
+                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                    "type": "string"
+                  },
+                  "tenant": {
+                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "user to map volume access to\nDefaults to serivceaccount user",
+                    "type": "string"
+                  },
+                  "volume": {
+                    "description": "volume is a string that references an already created Quobyte volume by name.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "registry",
+                  "volume"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rbd": {
+                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "image": {
+                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "keyring": {
+                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "monitors": {
+                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "pool": {
+                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "image",
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scaleIO": {
+                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                    "type": "string"
+                  },
+                  "gateway": {
+                    "description": "gateway is the host address of the ScaleIO API Gateway.",
+                    "type": "string"
+                  },
+                  "protectionDomain": {
+                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "sslEnabled": {
+                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                    "type": "boolean"
+                  },
+                  "storageMode": {
+                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                    "type": "string"
+                  },
+                  "storagePool": {
+                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                    "type": "string"
+                  },
+                  "system": {
+                    "description": "system is the name of the storage system as configured in ScaleIO.",
+                    "type": "string"
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "gateway",
+                  "secretRef",
+                  "system"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "secret": {
+                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "storageos": {
+                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                    "type": "string"
+                  },
+                  "volumeNamespace": {
+                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "vsphereVolume": {
+                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "storagePolicyID": {
+                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                    "type": "string"
+                  },
+                  "storagePolicyName": {
+                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                    "type": "string"
+                  },
+                  "volumePath": {
+                    "description": "volumePath is the path that identifies vSphere volume vmdk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumePath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumesMounts": {
+          "description": "Pod volumes to mount into the container's filesystem.",
+          "items": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+              "mountPath": {
+                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                "type": "string"
+              },
+              "mountPropagation": {
+                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                "type": "string"
+              },
+              "name": {
+                "description": "This must match the Name of a Volume.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                "type": "string"
+              },
+              "subPathExpr": {
+                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mountPath",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FluentBitStatus defines the observed state of FluentBit",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/fluentbitconfig_v1alpha2.json
+++ b/fluentbit.fluent.io/fluentbitconfig_v1alpha2.json
@@ -1,0 +1,458 @@
+{
+  "description": "FluentBitConfig is the Schema for the API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "NamespacedFluentBitCfgSpec defines the desired state of FluentBit",
+      "properties": {
+        "clusterMultilineParserSelector": {
+          "description": "Select cluster level multiline parser config",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "clusterParserSelector": {
+          "description": "Select cluster level parser config",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "filterSelector": {
+          "description": "Select filter plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "multilineParserSelector": {
+          "description": "Select multiline parser plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "outputSelector": {
+          "description": "Select output plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "parserSelector": {
+          "description": "Select parser plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "service": {
+          "description": "Service defines the global behaviour of the Fluent Bit engine.",
+          "properties": {
+            "daemon": {
+              "description": "If true go to background on start",
+              "type": "boolean"
+            },
+            "emitterMemBufLimit": {
+              "type": "string"
+            },
+            "emitterName": {
+              "description": "Per-namespace re-emitter configuration",
+              "type": "string"
+            },
+            "emitterStorageType": {
+              "type": "string"
+            },
+            "flushSeconds": {
+              "description": "Interval to flush output",
+              "format": "int64",
+              "type": "integer"
+            },
+            "graceSeconds": {
+              "description": "Wait time on exit",
+              "format": "int64",
+              "type": "integer"
+            },
+            "hcErrorsCount": {
+              "description": "the error count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for output error: [2022/02/16 10:44:10] [ warn] [engine] failed to flush chunk '1-1645008245.491540684.flb', retry in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3 (out_id=3)",
+              "format": "int64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "hcPeriod": {
+              "description": "The time period by second to count the error and retry failure data point",
+              "format": "int64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "hcRetryFailureCount": {
+              "description": "the retry failure count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for retry failure: [2022/02/16 20:11:36] [ warn] [engine] chunk '1-1645042288.260516436.flb' cannot be retried: task_id=0, input=tcp.3 > output=cloudwatch_logs.1",
+              "format": "int64",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "healthCheck": {
+              "description": "enable Health check feature at http://127.0.0.1:2020/api/v1/health Note: Enabling this will not automatically configure kubernetes to use fluentbit's healthcheck endpoint",
+              "type": "boolean"
+            },
+            "hotReload": {
+              "description": "If true enable reloading via HTTP",
+              "type": "boolean"
+            },
+            "httpListen": {
+              "description": "Address to listen",
+              "pattern": "^\\d{1,3}.\\d{1,3}.\\d{1,3}.\\d{1,3}$",
+              "type": "string"
+            },
+            "httpPort": {
+              "description": "Port to listen",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "httpServer": {
+              "description": "If true enable statistics HTTP server",
+              "type": "boolean"
+            },
+            "logFile": {
+              "description": "File to log diagnostic output",
+              "type": "string"
+            },
+            "logLevel": {
+              "description": "Diagnostic level (error/warning/info/debug/trace)",
+              "enum": [
+                "off",
+                "error",
+                "warning",
+                "info",
+                "debug",
+                "trace"
+              ],
+              "type": "string"
+            },
+            "parsersFile": {
+              "description": "Optional 'parsers' config file (can be multiple)",
+              "type": "string"
+            },
+            "parsersFiles": {
+              "description": "backward compatible",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "storage": {
+              "description": "Configure a global environment for the storage layer in Service. It is recommended to configure the volume and volumeMount separately for this storage. The hostPath type should be used for that Volume in Fluentbit daemon set.",
+              "properties": {
+                "backlogMemLimit": {
+                  "description": "This option configure a hint of maximum value of memory to use when processing these records",
+                  "type": "string"
+                },
+                "checksum": {
+                  "description": "Enable the data integrity check when writing and reading data from the filesystem",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "deleteIrrecoverableChunks": {
+                  "description": "When enabled, irrecoverable chunks will be deleted during runtime, and any other irrecoverable chunk located in the configured storage path directory will be deleted when Fluent-Bit starts.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "maxChunksUp": {
+                  "description": "If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "metrics": {
+                  "description": "If http_server option has been enabled in the Service section, this option registers a new endpoint where internal metrics of the storage layer can be consumed",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "description": "Select an optional location in the file system to store streams and chunks of data/",
+                  "type": "string"
+                },
+                "sync": {
+                  "description": "Configure the synchronization mode used to store the data into the file system",
+                  "enum": [
+                    "normal",
+                    "full"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/multilineparser_v1alpha2.json
+++ b/fluentbit.fluent.io/multilineparser_v1alpha2.json
@@ -1,0 +1,68 @@
+{
+  "description": "MultilineParser is the Schema of namespace-level multiline parser API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "flushTimeout": {
+          "default": 5000,
+          "description": "Timeout in milliseconds to flush a non-terminated multiline buffer. Default is set to 5 seconds.",
+          "type": "integer"
+        },
+        "keyContent": {
+          "description": "For an incoming structured message, specify the key that contains the data that should be processed by the regular expression and possibly concatenated.",
+          "type": "string"
+        },
+        "parser": {
+          "description": "Name of a pre-defined parser that must be applied to the incoming content before applying the regex rule. If no parser is defined, it's assumed that's a raw text and not a structured message.",
+          "type": "string"
+        },
+        "rules": {
+          "description": "Configure a rule to match a multiline pattern. The rule has a specific format described below. Multiple rules can be defined.",
+          "items": {
+            "properties": {
+              "next": {
+                "type": "string"
+              },
+              "regex": {
+                "type": "string"
+              },
+              "start": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "next",
+              "regex",
+              "start"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "type": {
+          "default": "regex",
+          "description": "Set the multiline mode, for now, we support the type regex.",
+          "enum": [
+            "regex"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/output_v1alpha2.json
+++ b/fluentbit.fluent.io/output_v1alpha2.json
@@ -1,0 +1,4769 @@
+{
+  "description": "Output is the schema for namespace level output API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OutputSpec defines the desired state of ClusterOutput",
+      "properties": {
+        "alias": {
+          "description": "A user friendly alias name for this output plugin.\nUsed in metrics for distinction of each configured output.",
+          "type": "string"
+        },
+        "azureBlob": {
+          "description": "AzureBlob defines AzureBlob Output Configuration",
+          "properties": {
+            "accountName": {
+              "description": "Azure Storage account name",
+              "type": "string"
+            },
+            "autoCreateContainer": {
+              "description": "Creates container if ContainerName is not set.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "blobType": {
+              "description": "Specify the desired blob type. Must be `appendblob` or `blockblob`",
+              "enum": [
+                "appendblob",
+                "blockblob"
+              ],
+              "type": "string"
+            },
+            "containerName": {
+              "description": "Name of the container that will contain the blobs",
+              "type": "string"
+            },
+            "emulatorMode": {
+              "description": "Optional toggle to use an Azure emulator",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "HTTP Service of the endpoint (if using EmulatorMode)",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Optional path to store the blobs.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the Azure Storage Shared Key to authenticate against the storage account",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Enable/Disable TLS Encryption. Azure services require TLS to be enabled.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "accountName",
+            "containerName",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azureLogAnalytics": {
+          "description": "AzureLogAnalytics defines AzureLogAnalytics Output Configuration",
+          "properties": {
+            "customerID": {
+              "description": "Customer ID or Workspace ID",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logType": {
+              "description": "Name of the event type.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the primary or the secondary client authentication key",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeGenerated": {
+              "description": "If set, overrides the timeKey value with the `time-generated-field` HTTP header value.",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Specify the name of the key where the timestamp is stored.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "customerID",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudWatch": {
+          "description": "CloudWatch defines CloudWatch Output Configuration",
+          "properties": {
+            "autoCreateGroup": {
+              "description": "Automatically create the log group. Defaults to False.",
+              "type": "boolean"
+            },
+            "autoRetryRequests": {
+              "description": "Automatically retry failed requests to CloudWatch once. Defaults to True.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Custom endpoint for CloudWatch logs API",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API.",
+              "type": "string"
+            },
+            "logFormat": {
+              "description": "Optional parameter to tell CloudWatch the format of the data",
+              "type": "string"
+            },
+            "logGroupName": {
+              "description": "Name of Cloudwatch Log Group to send log records to",
+              "type": "string"
+            },
+            "logGroupTemplate": {
+              "description": "Template for Log Group name, overrides LogGroupName if set.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "If set, only the value of the key will be sent to CloudWatch",
+              "type": "string"
+            },
+            "logRetentionDays": {
+              "description": "Number of days logs are retained for",
+              "enum": [
+                1,
+                3,
+                5,
+                7,
+                14,
+                30,
+                60,
+                90,
+                120,
+                150,
+                180,
+                365,
+                400,
+                545,
+                731,
+                1827,
+                3653
+              ],
+              "format": "int32",
+              "type": "integer"
+            },
+            "logStreamName": {
+              "description": "The name of the CloudWatch Log Stream to send log records to",
+              "type": "string"
+            },
+            "logStreamPrefix": {
+              "description": "Prefix for the Log Stream name. Not compatible with LogStreamName setting",
+              "type": "string"
+            },
+            "logStreamTemplate": {
+              "description": "Template for Log Stream name. Overrides LogStreamPrefix and LogStreamName if set.",
+              "type": "string"
+            },
+            "metricDimensions": {
+              "description": "Optional lists of lists for dimension keys to be added to all metrics. Use comma separated strings\nfor one list of dimensions and semicolon separated strings for list of lists dimensions.",
+              "type": "string"
+            },
+            "metricNamespace": {
+              "description": "Optional string to represent the CloudWatch namespace.",
+              "type": "string"
+            },
+            "region": {
+              "description": "AWS Region",
+              "type": "string"
+            },
+            "roleArn": {
+              "description": "Role ARN to use for cross-account access",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom STS endpoint for the AWS STS API",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customPlugin": {
+          "description": "CustomPlugin defines Custom Output configuration.",
+          "properties": {
+            "config": {
+              "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+              "type": "string"
+            },
+            "yamlConfig": {
+              "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "datadog": {
+          "description": "DataDog defines DataDog Output configuration.",
+          "properties": {
+            "apikey": {
+              "description": "Your Datadog API key.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "compress": {
+              "description": "Compress  the payload in GZIP format.\nDatadog supports and recommends setting this to gzip.",
+              "type": "string"
+            },
+            "dd_message_key": {
+              "description": "By default, the plugin searches for the key 'log' and remap the value to the key 'message'. If the property is set, the plugin will search the property name key.",
+              "type": "string"
+            },
+            "dd_service": {
+              "description": "The human readable name for your service generating the logs.",
+              "type": "string"
+            },
+            "dd_source": {
+              "description": "A human readable name for the underlying technology of your service.",
+              "type": "string"
+            },
+            "dd_tags": {
+              "description": "The tags you want to assign to your logs in Datadog.",
+              "type": "string"
+            },
+            "host": {
+              "description": "Host is the Datadog server where you are sending your logs.",
+              "type": "string"
+            },
+            "include_tag_key": {
+              "description": "If enabled, a tag is appended to output. The key name is used tag_key property.",
+              "type": "boolean"
+            },
+            "json_date_key": {
+              "description": "Date key name for output.",
+              "type": "string"
+            },
+            "provider": {
+              "description": "To activate the remapping, specify configuration flag provider.",
+              "type": "string"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy.",
+              "type": "string"
+            },
+            "tag_key": {
+              "description": "The key name of tag. If include_tag_key is false, This property is ignored.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "TLS controls whether to use end-to-end security communications security protocol.\nDatadog recommends setting this to on.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "es": {
+          "description": "Elasticsearch defines Elasticsearch Output configuration.",
+          "properties": {
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsAuthSecret": {
+              "description": "AWSAuthSecret Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon ES cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the Elasticsearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "cloudAuth": {
+              "description": "Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "type": "string"
+            },
+            "cloudAuthSecret": {
+              "description": "CloudAuthSecret Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cloudID": {
+              "description": "If you are using Elastic's Elasticsearch Service you can specify the cloud_id of the cluster running.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying ES.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Elasticsearch instance",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for Elastic X-Pack access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Elasticsearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve Elasticsearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "Newer versions of Elasticsearch allows setting up filters called pipelines.\nThis option allows defining which pipeline the database should use.\nFor performance reasons is strongly suggested parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target Elasticsearch instance",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "string"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "file": {
+          "description": "File defines File Output configuration.",
+          "properties": {
+            "delimiter": {
+              "description": "The character to separate each pair. Applicable only if format is csv or ltsv.",
+              "type": "string"
+            },
+            "file": {
+              "description": "Set file name to store the records. If not set, the file name will be the tag associated with the records.",
+              "type": "string"
+            },
+            "format": {
+              "description": "The format of the file content. See also Format section. Default: out_file.",
+              "enum": [
+                "out_file",
+                "plain",
+                "csv",
+                "ltsv",
+                "template"
+              ],
+              "type": "string"
+            },
+            "labelDelimiter": {
+              "description": "The character to separate each pair. Applicable only if format is ltsv.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory.",
+              "type": "string"
+            },
+            "template": {
+              "description": "The format string. Applicable only if format is template.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "firehose": {
+          "description": "Firehose defines Firehose Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues.",
+              "type": "boolean"
+            },
+            "dataKeys": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited.",
+              "type": "string"
+            },
+            "deliveryStream": {
+              "description": "The name of the Kinesis Firehose Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis Firehose API.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Firehose. If you specify a key name with this option, then only the value of that key will be sent to Firehose. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Firehose.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom endpoint for the STS API; used to assume your custom role provided with role_arn.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default, the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, %Y-%m-%dT%H *string This option is used with time_key. You can also use %L for milliseconds and %f for microseconds. If you are using ECS FireLens, make sure you are running Amazon ECS Container Agent v1.42.0 or later, otherwise the timestamps associated with your container logs will only have second precision.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "deliveryStream",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forward": {
+          "description": "Forward defines Forward Output configuration.",
+          "properties": {
+            "emptySharedKey": {
+              "description": "Use this option to connect to Fluentd with a zero-length secret.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "password": {
+              "description": "Specify the password corresponding to the username.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "requireAckResponse": {
+              "description": "Send \"chunk\"-option and wait for \"ack\" response from server.\nEnables at-least-once and receiving server can control rate of traffic.\n(Requires Fluentd v0.14.0+ server)",
+              "type": "boolean"
+            },
+            "selfHostname": {
+              "description": "Default value of the auto-generated certificate common name (CN).",
+              "type": "string"
+            },
+            "sendOptions": {
+              "description": "Always send options (with \"size\"=count of messages)",
+              "type": "boolean"
+            },
+            "sharedKey": {
+              "description": "A key string known by the remote Fluentd used for authorization.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Overwrite the tag as we transmit. This allows the receiving pipeline start\nfresh, or to attribute source.",
+              "type": "string"
+            },
+            "timeAsInteger": {
+              "description": "Set timestamps in integer format, it enable compatibility mode for Fluentd v0.12 series.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "username": {
+              "description": "Specify the username to present to a Fluentd server that enables user_auth.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gelf": {
+          "description": "Gelf defines GELF Output configuration.",
+          "properties": {
+            "compress": {
+              "description": "If transport protocol is udp, it defines if UDP packets should be compressed.",
+              "type": "boolean"
+            },
+            "fullMessageKey": {
+              "description": "FullMessageKey is the key to use as the long message that can i.e. contain a backtrace.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Graylog server.",
+              "type": "string"
+            },
+            "hostKey": {
+              "description": "HostKey is the key which its value is used as the name of the host, source or application that sent this message.",
+              "type": "string"
+            },
+            "levelKey": {
+              "description": "LevelKey is the key to be used as the log level.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "The protocol to use (tls, tcp or udp).",
+              "enum": [
+                "tls",
+                "tcp",
+                "udp"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "packetSize": {
+              "description": "If transport protocol is udp, it sets the size of packets to be sent.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "port": {
+              "description": "The port that the target Graylog server is listening on.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "shortMessageKey": {
+              "description": "ShortMessageKey is the key to use as the short message.",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "TimestampKey is the key which its value is used as the timestamp of the message.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "http": {
+          "description": "HTTP defines HTTP Output configuration.",
+          "properties": {
+            "allowDuplicatedHeaders": {
+              "description": "Specify if duplicated headers are allowed.\nIf a duplicated header is found, the latest key/value set is preserved.",
+              "type": "boolean"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "type": "string"
+            },
+            "format": {
+              "description": "Specify the data format to be used in the HTTP request body, by default it uses msgpack.\nOther supported formats are json, json_stream and json_lines and gelf.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_stream",
+                "json_lines",
+                "gelf"
+              ],
+              "type": "string"
+            },
+            "gelfFullMessageKey": {
+              "description": "Specify the key to use for the full message in gelf format",
+              "type": "string"
+            },
+            "gelfHostKey": {
+              "description": "Specify the key to use for the host in gelf format",
+              "type": "string"
+            },
+            "gelfLevelKey": {
+              "description": "Specify the key to use for the level in gelf format",
+              "type": "string"
+            },
+            "gelfShortMessageKey": {
+              "description": "Specify the key to use as the short message in gelf format",
+              "type": "string"
+            },
+            "gelfTimestampKey": {
+              "description": "Specify the key to use for timestamp in gelf format",
+              "type": "string"
+            },
+            "headerTag": {
+              "description": "Specify an optional HTTP header field for the original message tag.",
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Basic Auth Password. Requires HTTP_User to be set",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Server",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://host:port.\nNote that https is not supported yet.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "HTTP output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "influxDB": {
+          "description": "InfluxDB defines InfluxDB Output configuration.",
+          "properties": {
+            "autoTags": {
+              "description": "Automatically tag keys where value is string.",
+              "type": "boolean"
+            },
+            "bucket": {
+              "description": "InfluxDB bucket name where records will be inserted - if specified, database is ignored and v2 of API is used",
+              "type": "string"
+            },
+            "database": {
+              "description": "InfluxDB database name where records will be inserted.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target InfluxDB service.",
+              "format": "ipv6",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpToken": {
+              "description": "Authentication token used with InfluxDB v2 - if specified, both HTTPUser and HTTPPasswd are ignored",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username for HTTP Basic Authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "org": {
+              "description": "InfluxDB organization name where the bucket is (v2 only)",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target InfluxDB service.",
+              "format": "int32",
+              "maximum": 65536,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sequenceTag": {
+              "description": "The name of the tag whose value is incremented for the consecutive simultaneous events.",
+              "type": "string"
+            },
+            "tagKeys": {
+              "description": "List of keys that needs to be tagged",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tagListKey": {
+              "description": "Key of the string array optionally contained within each log record that contains tag keys for that record",
+              "type": "string"
+            },
+            "tagsListEnabled": {
+              "description": "Dynamically tag keys which are in the string array at Tags_List_Key key.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafka": {
+          "description": "Kafka defines Kafka Output configuration.",
+          "properties": {
+            "brokers": {
+              "description": "Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092.",
+              "type": "string"
+            },
+            "dynamicTopic": {
+              "description": "adds unknown topics (found in Topic_Key) to Topics. So in Topics only a default topic needs to be configured",
+              "type": "boolean"
+            },
+            "format": {
+              "description": "Specify data format, options available: json, msgpack.",
+              "type": "string"
+            },
+            "messageKey": {
+              "description": "Optional key to store the message",
+              "type": "string"
+            },
+            "messageKeyField": {
+              "description": "If set, the value of Message_Key_Field in the record will indicate the message key.\nIf not set nor found in the record, Message_Key will be used (if set).",
+              "type": "string"
+            },
+            "queueFullRetries": {
+              "description": "Fluent Bit queues data into rdkafka library,\nif for some reason the underlying library cannot flush the records the queue might fills up blocking new addition of records.\nThe queue_full_retries option set the number of local retries to enqueue the data.\nThe default value is 10 times, the interval between each retry is 1 second.\nSetting the queue_full_retries value to 0 set's an unlimited number of retries.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rdkafka": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "{property} can be any librdkafka properties",
+              "type": "object"
+            },
+            "timestampFormat": {
+              "description": "iso8601 or double",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "Set the key to store the record timestamp",
+              "type": "string"
+            },
+            "topicKey": {
+              "description": "If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use.\nE.g: if Topic_Key is router and the record is {\"key1\": 123, \"router\": \"route_2\"},\nFluent Bit will use topic route_2. Note that if the value of Topic_Key is not present in Topics,\nthen by default the first topic in the Topics list will indicate the topic to be used.",
+              "type": "string"
+            },
+            "topics": {
+              "description": "Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka.\nIf only one topic is set, that one will be used for all records.\nInstead if multiple topics exists, the one set in the record by Topic_Key will be used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kinesis": {
+          "description": "Kinesis defines Kinesis Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis API.",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Kinesis.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stream": {
+              "description": "The name of the Kinesis Streams Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond precision with '%3N' and supports nanosecond precision with '%9N' and '%L'; for example, adding '%3N' to support millisecond '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region",
+            "stream"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "description": "Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace, Defaults to the SERVICE section's Log_Level",
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "loki": {
+          "description": "Loki defines Loki Output configuration.",
+          "properties": {
+            "autoKubernetesLabels": {
+              "description": "If set to true, it will add all Kubernetes labels to the Stream labels.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "bearerToken": {
+              "description": "Set bearer token authentication token value.\nCan be used as alterntative to HTTP basic authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dropSingleKey": {
+              "description": "If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Loki hostname or IP address.",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User\nSet HTTP basic authentication password",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Set HTTP basic authentication user name.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "labelKeys": {
+              "description": "Optional list of record keys that will be placed as stream labels.\nThis configuration property is for records key only.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelMapPath": {
+              "description": "Specify the label map file path. The file defines how to extract labels from each record.",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs.\nIn addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "lineFormat": {
+              "description": "Format to use when flattening the record to a log line. Valid values are json or key_value.\nIf set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON.\nIf set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.",
+              "enum": [
+                "json",
+                "key_value"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "Loki TCP port",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "removeKeys": {
+              "description": "Optional list of keys to remove.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tenantID": {
+              "description": "Tenant ID used by default to push logs to Loki.\nIf omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tenantIDKey": {
+              "description": "Specify the name of the key from the original record that contains the Tenant ID.\nThe value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify a custom HTTP URI. It must start with forward slash.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        },
+        "null": {
+          "description": "Null defines Null Output configuration.",
+          "type": "object"
+        },
+        "opensearch": {
+          "description": "OpenSearch defines OpenSearch Output configuration.",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the OpenSearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "compress": {
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying OpenSearch.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "OpenSearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve OpenSearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "OpenSearch allows to setup filters called pipelines.\nThis option allows to define which pipeline the database should use.\nFor performance reasons is strongly suggested to do parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `9200`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "boolean"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "opentelemetry": {
+          "description": "OpenTelemetry defines OpenTelemetry Output configuration.",
+          "properties": {
+            "addLabel": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields.",
+              "type": "object"
+            },
+            "header": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log.",
+              "type": "boolean"
+            },
+            "logsBodyKeyAttributes": {
+              "description": "If true, remaining unmatched keys are added as attributes.",
+              "type": "boolean"
+            },
+            "logsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for logs, e.g: /v1/logs",
+              "type": "string"
+            },
+            "metricsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for metrics, e.g: /v1/metrics",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `80`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT. Note that HTTPS is not currently supported.\nIt is recommended not to set this and to configure the HTTP proxy environment variables instead as they support both HTTP and HTTPS.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tracesUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for traces, e.g: /v1/traces",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processors": {
+          "description": "Processors defines the processors configuration",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "prometheusExporter": {
+          "description": "PrometheusExporter_types defines Prometheus exporter configuration to expose metrics from Fluent Bit.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "This is the port Fluent Bit will bind to when hosting prometheus metrics.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "prometheusRemoteWrite": {
+          "description": "PrometheusRemoteWrite_types defines Prometheus Remote Write configuration.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 127.0.0.1",
+              "type": "string"
+            },
+            "httpPasswd": {
+              "description": "Basic Auth Password.\nRequires HTTP_user to be se",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log,default: false",
+              "type": "boolean"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Serveri, default:80",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something ,default: /",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0,default : 2",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "retry_limit": {
+          "description": "RetryLimit represents configuration for the scheduler which can be set independently on each output section.\nThis option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.",
+          "type": "string"
+        },
+        "s3": {
+          "description": "S3 defines S3 Output configuration.",
+          "properties": {
+            "AutoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once.",
+              "type": "boolean"
+            },
+            "Bucket": {
+              "description": "S3 Bucket name",
+              "type": "string"
+            },
+            "CannedAcl": {
+              "description": "Predefined Canned ACL Policy for S3 objects.",
+              "type": "string"
+            },
+            "Compression": {
+              "description": "Compression type for S3 objects.",
+              "type": "string"
+            },
+            "ContentType": {
+              "description": "A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header.",
+              "type": "string"
+            },
+            "Endpoint": {
+              "description": "Custom endpoint for the S3 API.",
+              "type": "string"
+            },
+            "ExternalId": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "JsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681)",
+              "type": "string"
+            },
+            "JsonDateKey": {
+              "description": "Specify the name of the time key in the output record. To disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "LogKey": {
+              "description": "By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3.",
+              "type": "string"
+            },
+            "PreserveDataOrdering": {
+              "description": "Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads.",
+              "type": "boolean"
+            },
+            "Profile": {
+              "description": "Option to specify an AWS Profile for credentials.",
+              "type": "string"
+            },
+            "Region": {
+              "description": "The AWS region of your S3 bucket",
+              "type": "string"
+            },
+            "RetryLimit": {
+              "description": "Integer value to set the maximum number of retries allowed.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "RoleArn": {
+              "description": "ARN of an IAM role to assume",
+              "type": "string"
+            },
+            "S3KeyFormat": {
+              "description": "Format string for keys in S3.",
+              "type": "string"
+            },
+            "S3KeyFormatTagDelimiters": {
+              "description": "A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option.",
+              "type": "string"
+            },
+            "SendContentMd5": {
+              "description": "Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled.",
+              "type": "boolean"
+            },
+            "StaticFilePath": {
+              "description": "Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true.",
+              "type": "boolean"
+            },
+            "StorageClass": {
+              "description": "Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class.",
+              "type": "string"
+            },
+            "StoreDir": {
+              "description": "Directory to locally buffer data before sending.",
+              "type": "string"
+            },
+            "StoreDirLimitSize": {
+              "description": "The size of the limitation for disk usage in S3.",
+              "type": "string"
+            },
+            "StsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "TotalFileSize": {
+              "description": "Specifies the size of files in S3. Minimum size is 1M. With use_put_object On the maximum size is 1G. With multipart upload mode, the maximum size is 50G.",
+              "type": "string"
+            },
+            "UploadChunkSize": {
+              "description": "The size of each 'part' for multipart uploads. Max: 50M",
+              "type": "string"
+            },
+            "UploadTimeout": {
+              "description": "Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour.",
+              "type": "string"
+            },
+            "UsePutObject": {
+              "description": "Use the S3 PutObject API, instead of the multipart upload API.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "Bucket",
+            "Region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "splunk": {
+          "description": "Splunk defines Splunk Output Configuration",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value `2` is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "channel": {
+              "description": "Specify X-Splunk-Request-Channel Header for the HTTP Event Collector interface.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. The only available option is gzip.",
+              "type": "string"
+            },
+            "eventFields": {
+              "description": "Set event fields for the record. This option is an array and the format is \"key_name\nrecord_accessor_pattern\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "eventHost": {
+              "description": "Specify the key name that contains the host value. This option allows a record accessors pattern.",
+              "type": "string"
+            },
+            "eventIndex": {
+              "description": "The name of the index by which the event data is to be indexed.",
+              "type": "string"
+            },
+            "eventIndexKey": {
+              "description": "Set a record key that will populate the index field. If the key is found, it will have precedence\nover the value set in event_index.",
+              "type": "string"
+            },
+            "eventKey": {
+              "description": "Specify the key name that will be used to send a single value as part of the record.",
+              "type": "string"
+            },
+            "eventSource": {
+              "description": "Set the source value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetype": {
+              "description": "Set the sourcetype value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetypeKey": {
+              "description": "Set a record key that will populate 'sourcetype'. If the key is found, it will have precedence\nover the value set in event_sourcetype.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpBufferSize": {
+              "description": "Buffer size used to receive Splunk HTTP responses: Default `2M`",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "httpDebugBadRequest": {
+              "description": "If the HTTP server response code is 400 (bad request) and this flag is enabled, it will print the full HTTP request\nand response to the stdout interface. This feature is available for debugging purposes.",
+              "type": "boolean"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target Splunk instance, default `8088`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "splunkSendRaw": {
+              "description": "When enabled, the record keys and values are set in the top level of the map instead of under the event key. Refer to\nthe Sending Raw Events section from the docs more details to make this option work properly.",
+              "type": "boolean"
+            },
+            "splunkToken": {
+              "description": "Specify the Authentication Token for the HTTP Event Collector interface.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stackdriver": {
+          "description": "Stackdriver defines Stackdriver Output Configuration",
+          "properties": {
+            "autoformatStackdriverTrace": {
+              "description": "Rewrite the trace field to be formatted for use with GCP Cloud Trace",
+              "type": "boolean"
+            },
+            "customK8sRegex": {
+              "description": "A custom regex to extract fields from the local_resource_id of the logs",
+              "type": "string"
+            },
+            "exportToProjectID": {
+              "description": "The GCP Project that should receive the logs",
+              "type": "string"
+            },
+            "googleServiceCredentials": {
+              "description": "Path to GCP Credentials JSON file",
+              "type": "string"
+            },
+            "job": {
+              "description": "Identifier for a grouping of tasks. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "k8sClusterLocation": {
+              "description": "Location of the cluster that contains the pods/nodes. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "k8sClusterName": {
+              "description": "Name of the cluster that the pod is running in. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Optional list of comma separated of strings for key/value pairs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelsKey": {
+              "description": "Used by Stackdriver to find related labels and extract them to LogEntry Labels",
+              "type": "string"
+            },
+            "location": {
+              "description": "GCP/AWS region to store data. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "logNameKey": {
+              "description": "The value of this field is set as the logName field in Stackdriver",
+              "type": "string"
+            },
+            "metadataServer": {
+              "description": "Metadata Server Prefix",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace identifier. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "nodeID": {
+              "description": "Node identifier within the namespace. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Set resource types of data",
+              "type": "string"
+            },
+            "resourceLabels": {
+              "description": "Optional list of comma seperated strings. Setting these fields overrides the Stackdriver monitored resource API values",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "serviceAccountEmail": {
+              "description": "Email associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountSecret": {
+              "description": "Private Key associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "severityKey": {
+              "description": "Specify the key that contains the severity information for the logs",
+              "type": "string"
+            },
+            "tagPrefix": {
+              "description": "Used to validate the tags of logs that when the Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "taskID": {
+              "description": "Identifier for a task within a namespace. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Number of dedicated threads for the Stackdriver Output Plugin",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stdout": {
+          "description": "Stdout defines Stdout Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.",
+              "enum": [
+                "double",
+                "iso8601",
+                "epoch"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the date field in output.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syslog": {
+          "description": "Syslog defines Syslog Output configuration.",
+          "properties": {
+            "host": {
+              "description": "Host domain or IP address of the remote Syslog server.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode of the desired transport type, the available options are tcp, tls and udp.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP or UDP port of the remote Syslog server.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "syslogAppnameKey": {
+              "description": "Key name from the original record that contains the application name that generated the message.",
+              "type": "string"
+            },
+            "syslogFacilityKey": {
+              "description": "Key from the original record that contains the Syslog facility number.",
+              "type": "string"
+            },
+            "syslogFormat": {
+              "description": "Syslog protocol format to use, the available options are rfc3164 and rfc5424.",
+              "type": "string"
+            },
+            "syslogHostnameKey": {
+              "description": "Key name from the original record that contains the hostname that generated the message.",
+              "type": "string"
+            },
+            "syslogMaxSize": {
+              "description": "Maximum size allowed per message, in bytes.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "syslogMessageIDKey": {
+              "description": "Key name from the original record that contains the Message ID associated to the message.",
+              "type": "string"
+            },
+            "syslogMessageKey": {
+              "description": "Key key name that contains the message to deliver.",
+              "type": "string"
+            },
+            "syslogProcessIDKey": {
+              "description": "Key name from the original record that contains the Process ID that generated the message.",
+              "type": "string"
+            },
+            "syslogSDKey": {
+              "description": "Key name from the original record that contains the Structured Data (SD) content.",
+              "type": "string"
+            },
+            "syslogSeverityKey": {
+              "description": "Key from the original record that contains the Syslog severity number.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Syslog output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tcp": {
+          "description": "TCP defines TCP Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "enum": [
+                "double",
+                "epoch",
+                "iso8601"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "TSpecify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentbit.fluent.io/parser_v1alpha2.json
+++ b/fluentbit.fluent.io/parser_v1alpha2.json
@@ -1,0 +1,116 @@
+{
+  "description": "Parser is the Schema for namespace level parser API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ParserSpec defines the desired state of ClusterParser",
+      "properties": {
+        "decoders": {
+          "description": "Decoders are a built-in feature available through the Parsers file, each Parser definition can optionally set one or multiple decoders.\nThere are two type of decoders type: Decode_Field and Decode_Field_As.",
+          "items": {
+            "properties": {
+              "decodeField": {
+                "description": "If the content can be decoded in a structured message,\nappend that structure message (keys and values) to the original log message.",
+                "type": "string"
+              },
+              "decodeFieldAs": {
+                "description": "Any content decoded (unstructured or structured) will be replaced in the same key/value,\nno extra keys are added.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "json": {
+          "description": "JSON defines json parser configuration.",
+          "properties": {
+            "timeFormat": {
+              "description": "Time_Format, eg. %Y-%m-%dT%H:%M:%S %z",
+              "type": "string"
+            },
+            "timeKeep": {
+              "description": "Time_Keep",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Time_Key",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logfmt": {
+          "description": "Logfmt defines logfmt parser configuration.",
+          "type": "object"
+        },
+        "ltsv": {
+          "description": "LTSV defines ltsv parser configuration.",
+          "properties": {
+            "timeFormat": {
+              "description": "Time_Format, eg. %Y-%m-%dT%H:%M:%S %z",
+              "type": "string"
+            },
+            "timeKeep": {
+              "description": "Time_Keep",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Time_Key",
+              "type": "string"
+            },
+            "types": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "regex": {
+          "description": "Regex defines regex parser configuration.",
+          "properties": {
+            "regex": {
+              "type": "string"
+            },
+            "timeFormat": {
+              "description": "Time_Format, eg. %Y-%m-%dT%H:%M:%S %z",
+              "type": "string"
+            },
+            "timeKeep": {
+              "description": "Time_Keep",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Time_Key",
+              "type": "string"
+            },
+            "timeOffset": {
+              "description": "Time_Offset, eg. +0200",
+              "type": "string"
+            },
+            "types": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusterfilter_v1alpha1.json
+++ b/fluentd.fluent.io/clusterfilter_v1alpha1.json
@@ -1,0 +1,561 @@
+{
+  "description": "ClusterFilter is the Schema for the clusterfilters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterFilterSpec defines the desired state of ClusterFilter",
+      "properties": {
+        "filters": {
+          "items": {
+            "description": "Filter defines all available filter plugins and their parameters.",
+            "properties": {
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "grep": {
+                "description": "The filter_grep filter plugin",
+                "properties": {
+                  "and": {
+                    "items": {
+                      "description": "And defines the parameters for the \"and\" plugin",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude defines the parameters for the exclude plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "regexp": {
+                          "description": "Regexp defines the parameters for the regexp plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "exclude": {
+                    "items": {
+                      "description": "Exclude defines the parameters for the exclude plugin",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "or": {
+                    "items": {
+                      "description": "Or defines the parameters for the \"or\" plugin",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude defines the parameters for the exclude plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "regexp": {
+                          "description": "Regexp defines the parameters for the regexp plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "regexp": {
+                    "items": {
+                      "description": "Regexp defines the parameters for the regexp plugin",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "parser": {
+                "description": "The filter_parser filter plugin",
+                "properties": {
+                  "emitInvalidRecordToError": {
+                    "description": "Emits invalid record to @ERROR label. Invalid cases are: key does not exist;the format is not matched;an unexpected error.\nIf you want to ignore these errors, set false.",
+                    "type": "boolean"
+                  },
+                  "hashValueField": {
+                    "description": "Stores the parsed values as a hash value in a field.",
+                    "type": "string"
+                  },
+                  "injectKeyPrefix": {
+                    "description": "Stores the parsed values with the specified key name prefix.",
+                    "type": "string"
+                  },
+                  "keyName": {
+                    "description": "Specifies the field name in the record to parse. Required parameter.\ni.e: If set keyName to log, {\"key\":\"value\",\"log\":\"{\\\"time\\\":1622473200,\\\"user\\\":1}\"} => {\"user\":1}",
+                    "type": "string"
+                  },
+                  "parse": {
+                    "description": "Parse defines various parameters for the parse plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "removeKeyNameField": {
+                    "description": "Removes key_name field when parsing is succeeded.",
+                    "type": "boolean"
+                  },
+                  "replaceInvalidSequence": {
+                    "description": "If true, invalid string is replaced with safe characters and re-parse it.",
+                    "type": "boolean"
+                  },
+                  "reserveData": {
+                    "description": "Keeps the original key-value pair in the parsed result. Default is false.\ni.e: If set keyName to log, reverseData to true,\n{\"key\":\"value\",\"log\":\"{\\\"user\\\":1,\\\"num\\\":2}\"} => {\"key\":\"value\",\"log\":\"{\\\"user\\\":1,\\\"num\\\":2}\",\"user\":1,\"num\":2}",
+                    "type": "boolean"
+                  },
+                  "reserveTime": {
+                    "description": "Keeps the original event time in the parsed result. Default is false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "keyName",
+                  "parse"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "recordTransformer": {
+                "description": "The filter_record_transformer filter plugin",
+                "properties": {
+                  "autoTypecast": {
+                    "description": "Automatically casts the field types. Default is false.\nThis option is effective only for field values comprised of a single placeholder.",
+                    "type": "boolean"
+                  },
+                  "enableRuby": {
+                    "description": "When set to true, the full Ruby syntax is enabled in the ${...} expression. The default value is false.\ni.e: jsonized_record ${record.to_json}",
+                    "type": "boolean"
+                  },
+                  "keepKeys": {
+                    "description": "A list of keys to keep. Only relevant if renew_record is set to true.",
+                    "type": "string"
+                  },
+                  "records": {
+                    "items": {
+                      "description": "The parameters inside <record> directives are considered to be new key-value pairs",
+                      "properties": {
+                        "key": {
+                          "description": "New field can be defined as key",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "The value must from Record properties.\nSee https://docs.fluentd.org/filter/record_transformer#less-than-record-greater-than-directive",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "removeKeys": {
+                    "description": "A list of keys to delete. Supports nested field via record_accessor syntax since v1.1.0.",
+                    "type": "string"
+                  },
+                  "renewRecord": {
+                    "description": "By default, the record transformer filter mutates the incoming data. However, if this parameter is set to true, it modifies a new empty hash instead.",
+                    "type": "boolean"
+                  },
+                  "renewTimeKey": {
+                    "description": "renew_time_key foo overwrites the time of events with a value of the record field foo if exists. The value of foo must be a Unix timestamp.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdout": {
+                "description": "The filter_stdout filter plugin",
+                "properties": {
+                  "format": {
+                    "description": "The format section",
+                    "properties": {
+                      "delimiter": {
+                        "description": "Delimiter for each field.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "newline": {
+                        "description": "Specify newline characters.",
+                        "enum": [
+                          "lf",
+                          "crlf"
+                        ],
+                        "type": "string"
+                      },
+                      "outputTag": {
+                        "description": "Output tag field if true.",
+                        "type": "boolean"
+                      },
+                      "outputTime": {
+                        "description": "Output time field if true.",
+                        "type": "boolean"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "out_file",
+                          "json",
+                          "ltsv",
+                          "csv",
+                          "msgpack",
+                          "hash",
+                          "single_value"
+                        ],
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "inject": {
+                    "description": "The inject section",
+                    "properties": {
+                      "hostname": {
+                        "description": "Hostname value",
+                        "type": "string"
+                      },
+                      "hostnameKey": {
+                        "description": "The field name to inject hostname",
+                        "type": "string"
+                      },
+                      "inline": {
+                        "description": "Time section",
+                        "properties": {
+                          "localtime": {
+                            "description": "If true, uses local time.",
+                            "type": "boolean"
+                          },
+                          "timeFormat": {
+                            "description": "Process value according to the specified format. This is available only when time_type is string",
+                            "type": "string"
+                          },
+                          "timeFormatFallbacks": {
+                            "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                            "type": "string"
+                          },
+                          "timeType": {
+                            "description": "parses/formats value according to this type, default is string",
+                            "enum": [
+                              "float",
+                              "unixtime",
+                              "string",
+                              "mixed"
+                            ],
+                            "type": "string"
+                          },
+                          "timezone": {
+                            "description": "Uses the specified timezone.",
+                            "type": "string"
+                          },
+                          "utc": {
+                            "description": "If true, uses UTC.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tagKey": {
+                        "description": "The field name to inject tag",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "The field name to inject time",
+                        "type": "string"
+                      },
+                      "workerIdKey": {
+                        "description": "The field name to inject worker_id",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "tag": {
+                "description": "Which tag to be matched.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterFilterStatus defines the observed state of ClusterFilter",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusterfilter_v1alpha2.json
+++ b/fluentd.fluent.io/clusterfilter_v1alpha2.json
@@ -1,0 +1,935 @@
+{
+  "description": "ClusterFilter defines a cluster-level Filter configuration.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Filter configuration.",
+      "properties": {
+        "filters": {
+          "description": "A set of filter plugins in order.",
+          "items": {
+            "properties": {
+              "aws": {
+                "description": "Aws defines a Aws configuration.",
+                "properties": {
+                  "accountID": {
+                    "description": "The account ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "amiID": {
+                    "description": "The EC2 instance image id.Default is false.",
+                    "type": "boolean"
+                  },
+                  "az": {
+                    "description": "The availability zone; for example, \"us-east-1a\". Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceID": {
+                    "description": "The EC2 instance ID.Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceType": {
+                    "description": "The EC2 instance type.Default is false.",
+                    "type": "boolean"
+                  },
+                  "hostName": {
+                    "description": "The hostname for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "imdsVersion": {
+                    "description": "Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2'.",
+                    "enum": [
+                      "v1",
+                      "v2"
+                    ],
+                    "type": "string"
+                  },
+                  "privateIP": {
+                    "description": "The EC2 instance private ip.Default is false.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "vpcID": {
+                    "description": "The VPC ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "customPlugin": {
+                "description": "CustomPlugin defines a Custom plugin configuration.",
+                "properties": {
+                  "config": {
+                    "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+                    "type": "string"
+                  },
+                  "yamlConfig": {
+                    "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "grep": {
+                "description": "Grep defines Grep Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Exclude records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Keep records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kubernetes": {
+                "description": "Kubernetes defines Kubernetes Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "annotations": {
+                    "description": "Include Kubernetes resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "bufferSize": {
+                    "description": "Set the buffer size for HTTP client when reading responses from Kubernetes API server.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "cacheUseDockerId": {
+                    "description": "When enabled, metadata will be fetched from K8s when docker_id is changed.",
+                    "type": "boolean"
+                  },
+                  "dnsRetries": {
+                    "description": "DNS lookup retries N times until the network start working",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dnsWaitTime": {
+                    "description": "DNS lookup interval between network status checks",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dummyMeta": {
+                    "description": "If set, use dummy-meta data (for test/dev purposes)",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingExclude": {
+                    "description": "Allow Kubernetes Pods to exclude their logs from the log processor\n(read more about it in Kubernetes Annotations section).",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingParser": {
+                    "description": "Allow Kubernetes Pods to suggest a pre-defined Parser\n(read more about it in Kubernetes Annotations section)",
+                    "type": "boolean"
+                  },
+                  "keepLog": {
+                    "description": "When Keep_Log is disabled, the log field is removed\nfrom the incoming message once it has been successfully merged\n(Merge_Log must be enabled as well).",
+                    "type": "boolean"
+                  },
+                  "kubeCAFile": {
+                    "description": "CA certificate file",
+                    "type": "string"
+                  },
+                  "kubeCAPath": {
+                    "description": "Absolute path to scan for certificate files",
+                    "type": "string"
+                  },
+                  "kubeMetaCacheTTL": {
+                    "description": "configurable TTL for K8s cached metadata. By default, it is set to 0\nwhich means TTL for cache entries is disabled and cache entries are evicted at random\nwhen capacity is reached. In order to enable this option, you should set the number to a time interval.\nFor example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted.",
+                    "type": "string"
+                  },
+                  "kubeMetaNamespaceCacheTTL": {
+                    "description": "Configurable TTL for K8s cached namespace metadata.\nBy default, it is set to 900 which means a 15min TTL for namespace cache entries.\nSetting this to 0 will mean entries are evicted at random once the cache is full.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "kubeMetaPreloadCacheDir": {
+                    "description": "If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory,\nnamed as namespace-pod.meta",
+                    "type": "string"
+                  },
+                  "kubeTagPrefix": {
+                    "description": "When the source records comes from Tail input plugin,\nthis option allows to specify what's the prefix used in Tail configuration.",
+                    "type": "string"
+                  },
+                  "kubeTokenCommand": {
+                    "description": "Command to get Kubernetes authorization token.\nBy default, it will be NULL and we will use token file to get token.",
+                    "type": "string"
+                  },
+                  "kubeTokenFile": {
+                    "description": "Token file",
+                    "type": "string"
+                  },
+                  "kubeTokenTTL": {
+                    "description": "configurable 'time to live' for the K8s token. By default, it is set to 600 seconds.\nAfter this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.",
+                    "type": "string"
+                  },
+                  "kubeURL": {
+                    "description": "API Server end-point",
+                    "type": "string"
+                  },
+                  "kubeletHost": {
+                    "description": "kubelet host using for HTTP request, this only works when Use_Kubelet set to On.",
+                    "type": "string"
+                  },
+                  "kubeletPort": {
+                    "description": "kubelet port using for HTTP request, this only works when useKubelet is set to On.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "description": "Include Kubernetes resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "mergeLog": {
+                    "description": "When enabled, it checks if the log field content is a JSON string map,\nif so, it append the map fields as part of the log structure.",
+                    "type": "boolean"
+                  },
+                  "mergeLogKey": {
+                    "description": "When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message\nand make a structured representation of it at the same level of the log field in the map.\nNow if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.",
+                    "type": "string"
+                  },
+                  "mergeLogTrim": {
+                    "description": "When Merge_Log is enabled, trim (remove possible \\n or \\r) field values.",
+                    "type": "boolean"
+                  },
+                  "mergeParser": {
+                    "description": "Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.",
+                    "type": "string"
+                  },
+                  "namespaceAnnotations": {
+                    "description": "Include Kubernetes namespace resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceLabels": {
+                    "description": "Include Kubernetes namespace resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceMetadataOnly": {
+                    "description": "Include Kubernetes namespace metadata only and no pod metadata.\nIf this is set, the values of Labels and Annotations are ignored.",
+                    "type": "boolean"
+                  },
+                  "regexParser": {
+                    "description": "Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.\nThe parser must be registered in a parsers file (refer to parser filter-kube-test as an example).",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tlsDebug": {
+                    "description": "Debug level between 0 (nothing) and 4 (every detail).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tlsVerify": {
+                    "description": "When enabled, turns on certificate validation when connecting to the Kubernetes API server.",
+                    "type": "boolean"
+                  },
+                  "useJournal": {
+                    "description": "When enabled, the filter reads logs coming in Journald format.",
+                    "type": "boolean"
+                  },
+                  "useKubelet": {
+                    "description": "This is an optional feature flag to get metadata information from kubelet\ninstead of calling Kube Server API to enhance the log.\nThis could mitigate the Kube API heavy traffic issue for large cluster.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logToMetrics": {
+                "description": "LogToMetrics defines a Log to Metrics Filter configuration.",
+                "properties": {
+                  "addLabel": {
+                    "description": "Add a custom label NAME and set the value to the value of KEY",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "bucket": {
+                    "description": "Defines a bucket for histogram",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "discardLogs": {
+                    "description": "Flag that defines if logs should be discarded after processing. This applies\nfor all logs, no matter if they have emitted metrics or not.",
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "description": "set a buffer limit to restrict memory usage of metrics emitter",
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "Name of the emitter (advanced users)",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Optional filter for records in which the content of KEY does not matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "kubernetesMode": {
+                    "description": "If enabled, it will automatically put pod_id, pod_name, namespace_name, docker_id and container_name\ninto the metric as labels. This option is intended to be used in combination with the kubernetes filter plugin.",
+                    "type": "boolean"
+                  },
+                  "labelField": {
+                    "description": "Includes a record field as label dimension in the metric.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "metricDescription": {
+                    "description": "Sets a help text for the metric.",
+                    "type": "string"
+                  },
+                  "metricMode": {
+                    "description": "Defines the mode for the metric. Valid values are [counter, gauge or histogram]",
+                    "type": "string"
+                  },
+                  "metricName": {
+                    "description": "Sets the name of the metric.",
+                    "type": "string"
+                  },
+                  "metricNamespace": {
+                    "description": "Namespace of the metric",
+                    "type": "string"
+                  },
+                  "metricSubsystem": {
+                    "description": "Sets a sub-system for the metric.",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Optional filter for records in which the content of KEY matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Defines the tag for the generated metrics record",
+                    "type": "string"
+                  },
+                  "valueField": {
+                    "description": "Specify the record field that holds a numerical value",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "lua": {
+                "description": "Lua defines Lua Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "call": {
+                    "description": "Lua function name that will be triggered to do filtering.\nIt's assumed that the function is declared inside the Script defined above.",
+                    "type": "string"
+                  },
+                  "code": {
+                    "description": "Inline LUA code instead of loading from a path via script.",
+                    "type": "string"
+                  },
+                  "protectedMode": {
+                    "description": "If enabled, Lua script will be executed in protected mode.\nIt prevents to crash when invalid Lua script is executed. Default is true.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "script": {
+                    "description": "Path to the Lua script that will be used.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "timeAsTable": {
+                    "description": "By default when the Lua script is invoked, the record timestamp is passed as a\nFloating number which might lead to loss precision when the data is converted back.\nIf you desire timestamp precision enabling this option will pass the timestamp as\na Lua table with keys sec for seconds since epoch and nsec for nanoseconds.",
+                    "type": "boolean"
+                  },
+                  "typeArrayKey": {
+                    "description": "If these keys are matched, the fields are handled as array. If more than\none key, delimit by space. It is useful the array can be empty.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "typeIntKey": {
+                    "description": "If these keys are matched, the fields are converted to integer.\nIf more than one key, delimit by space.\nNote that starting from Fluent Bit v1.6 integer data types are preserved\nand not converted to double as in previous versions.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "call"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "modify": {
+                "description": "Modify defines Modify Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "description": "All conditions have to be true for the rules to be applied.",
+                    "items": {
+                      "description": "The plugin supports the following conditions",
+                      "properties": {
+                        "aKeyMatches": {
+                          "description": "Is true if a key matches regex KEY",
+                          "type": "string"
+                        },
+                        "keyDoesNotExist": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY does not exist",
+                          "type": "object"
+                        },
+                        "keyExists": {
+                          "description": "Is true if KEY exists",
+                          "type": "string"
+                        },
+                        "keyValueDoesNotEqual": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is not VALUE",
+                          "type": "object"
+                        },
+                        "keyValueDoesNotMatch": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value does not match VALUE",
+                          "type": "object"
+                        },
+                        "keyValueEquals": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is VALUE",
+                          "type": "object"
+                        },
+                        "keyValueMatches": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value matches VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysDoNotHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that do not match VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that match VALUE",
+                          "type": "object"
+                        },
+                        "noKeyMatches": {
+                          "description": "Is true if no key matches regex KEY",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Rules are applied in the order they appear,\nwith each rule operating on the result of the previous rule.",
+                    "items": {
+                      "description": "The plugin supports the following rules",
+                      "properties": {
+                        "add": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE if KEY does not exist",
+                          "type": "object"
+                        },
+                        "copy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "hardCopy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists.\nIf COPIED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "hardRename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists.\nIf RENAMED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "remove": {
+                          "description": "Remove a key/value pair with key KEY if it exists",
+                          "type": "string"
+                        },
+                        "removeRegex": {
+                          "description": "Remove all key/value pairs with key matching regexp KEY",
+                          "type": "string"
+                        },
+                        "removeWildcard": {
+                          "description": "Remove all key/value pairs with key matching wildcard KEY",
+                          "type": "string"
+                        },
+                        "rename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "set": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "multiline": {
+                "description": "Multiline defines a Multiline configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "buffer": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "default": 10,
+                    "description": "Set a limit on the amount of memory in MB the emitter can consume if the outputs provide backpressure. The default for this limit is 10M. The pipeline will pause once the buffer exceeds the value of this setting. For example, if the value is set to 10MB then the pipeline will pause if the buffer exceeds 10M. The pipeline will remain paused until the output drains the buffer below the 10M limit.",
+                    "type": "integer"
+                  },
+                  "emitterName": {
+                    "description": "Name for the emitter input instance which re-emits the completed records at the beginning of the pipeline.",
+                    "type": "string"
+                  },
+                  "emitterType": {
+                    "default": "memory",
+                    "description": "The storage type for the emitter input instance. This option supports the values memory (default) and filesystem.",
+                    "enum": [
+                      "memory",
+                      "filesystem"
+                    ],
+                    "type": "string"
+                  },
+                  "flushMs": {
+                    "default": 2000,
+                    "type": "integer"
+                  },
+                  "keyContent": {
+                    "description": "Key name that holds the content to process.\nNote that a Multiline Parser definition can already specify the key_content to use, but this option allows to overwrite that value for the purpose of the filter.",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "enum": [
+                      "parser",
+                      "partial_message"
+                    ],
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify one or multiple Multiline Parsing definitions to apply to the content.\nYou can specify multiple multiline parsers to detect different formats by separating them with a comma.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parser"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nest": {
+                "description": "Nest defines Nest Filter configuration.",
+                "properties": {
+                  "addPrefix": {
+                    "description": "Prefix affected keys with this string",
+                    "type": "string"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "nestUnder": {
+                    "description": "Nest records matching the Wildcard under this key",
+                    "type": "string"
+                  },
+                  "nestedUnder": {
+                    "description": "Lift records nested under the Nested_under key",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "Select the operation nest or lift",
+                    "enum": [
+                      "nest",
+                      "lift"
+                    ],
+                    "type": "string"
+                  },
+                  "removePrefix": {
+                    "description": "Remove prefix from affected keys if it matches this string",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wildcard": {
+                    "description": "Nest records which field matches the wildcard",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "parser": {
+                "description": "Parser defines Parser Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "keyName": {
+                    "description": "Specify field name in record to parse.",
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify the parser name to interpret the field.\nMultiple Parser entries are allowed (split by comma).",
+                    "type": "string"
+                  },
+                  "preserveKey": {
+                    "description": "Keep original Key_Name field in the parsed result.\nIf false, the field will be removed.",
+                    "type": "boolean"
+                  },
+                  "reserveData": {
+                    "description": "Keep all other original fields in the parsed result.\nIf false, all other original fields will be removed.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "unescapeKey": {
+                    "description": "If the key is a escaped string (e.g: stringify JSON), unescape the string before to apply the parser.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "recordModifier": {
+                "description": "RecordModifier defines Record Modifier Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "allowlistKeys": {
+                    "description": "If the key is not matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "records": {
+                    "description": "Append fields. This parameter needs key and value pair.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "removeKeys": {
+                    "description": "If the key is matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "uuidKeys": {
+                    "description": "If set, the plugin appends uuid to each record. The value assigned becomes the key in the map.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "whitelistKeys": {
+                    "description": "An alias of allowlistKeys for backwards compatibility.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rewriteTag": {
+                "description": "RewriteTag defines a RewriteTag configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "emitterMemBufLimit": {
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "When the filter emits a record under the new Tag, there is an internal emitter\nplugin that takes care of the job. Since this emitter expose metrics as any other\ncomponent of the pipeline, you can use this property to configure an optional name for it.",
+                    "type": "string"
+                  },
+                  "emitterStorageType": {
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Defines the matching criteria and the format of the Tag for the matching record.\nThe Rule format have four components: KEY REGEX NEW_TAG KEEP.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "throttle": {
+                "description": "Throttle defines a Throttle configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "interval": {
+                    "description": "Interval is the time interval expressed in \"sleep\" format. e.g. 3s, 1.5m, 0.5h, etc.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "printStatus": {
+                    "description": "PrintStatus represents whether to print status messages with current rate and the limits to information logs.",
+                    "type": "boolean"
+                  },
+                  "rate": {
+                    "description": "Rate is the amount of messages for the time.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "window": {
+                    "description": "Window is the amount of intervals to calculate average over.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "wasm": {
+                "description": "Wasm defines a Wasm configuration.",
+                "properties": {
+                  "accessiblePaths": {
+                    "description": "Specify the whitelist of paths to be able to access paths from WASM programs.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "eventFormat": {
+                    "description": "Define event format to interact with Wasm programs: msgpack or json. Default: json",
+                    "type": "string"
+                  },
+                  "functionName": {
+                    "description": "Wasm function name that will be triggered to do filtering. It's assumed that the function is built inside the Wasm program specified above.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wasmHeapSize": {
+                    "description": "Size of the heap size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "wasmPath": {
+                    "description": "Path to the built Wasm program that will be used. This can be a relative path against the main configuration file.",
+                    "type": "string"
+                  },
+                  "wasmStackSize": {
+                    "description": "Size of the stack size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "logLevel": {
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case-sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusterfluentdconfig_v1alpha1.json
+++ b/fluentd.fluent.io/clusterfluentdconfig_v1alpha1.json
@@ -1,0 +1,220 @@
+{
+  "description": "ClusterFluentdConfig is the Schema for the clusterfluentdconfigs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterFluentdConfigSpec defines the desired state of ClusterFluentdConfig",
+      "properties": {
+        "clusterFilterSelector": {
+          "description": "Select cluster filter plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "clusterInputSelector": {
+          "description": "Select cluster input plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "clusterOutputSelector": {
+          "description": "Select cluster output plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "emit_mode": {
+          "description": "Emit mode. If batch, the plugin will emit events per labels matched. Enum: record, batch.\nwill make no effect if EnableFilterKubernetes is set false.",
+          "enum": [
+            "record",
+            "batch"
+          ],
+          "type": "string"
+        },
+        "stickyTags": {
+          "description": "Sticky tags will match only one record from an event stream. The same tag will be treated the same way.\nwill make no effect if EnableFilterKubernetes is set false.",
+          "type": "string"
+        },
+        "watchedConstainers": {
+          "description": "A set of container names. Ignored if left empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "watchedHosts": {
+          "description": "A set of hosts. Ignored if left empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "watchedLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Use this field to filter the logs, will make no effect if EnableFilterKubernetes is set false.",
+          "type": "object"
+        },
+        "watchedNamespaces": {
+          "description": "A set of namespaces. The whole namespaces would be watched if left empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterFluentdConfigStatus defines the observed state of ClusterFluentdConfig",
+      "properties": {
+        "messages": {
+          "description": "Messages defines the plugin errors which is selected by this fluentdconfig",
+          "type": "string"
+        },
+        "state": {
+          "description": "The state of this fluentd config",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusterinput_v1alpha1.json
+++ b/fluentd.fluent.io/clusterinput_v1alpha1.json
@@ -1,0 +1,998 @@
+{
+  "description": "ClusterInput is the Schema for the clusterinputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterInputSpec defines the desired state of ClusterInput",
+      "properties": {
+        "inputs": {
+          "items": {
+            "description": "Input defines all available input plugins and their parameters",
+            "properties": {
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "forward": {
+                "description": "in_forward plugin",
+                "properties": {
+                  "addTagPrefix": {
+                    "description": "Adds the prefix to the incoming event's tag.",
+                    "type": "string"
+                  },
+                  "bind": {
+                    "description": "The port to listen to, default is \"0.0.0.0\"",
+                    "type": "string"
+                  },
+                  "chunkSizeLimit": {
+                    "description": "The size limit of the received chunk. If the chunk size is larger than this value, the received chunk is dropped.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "chunkSizeWarnLimit": {
+                    "description": "The warning size limit of the received chunk. If the chunk size is larger than this value, a warning message will be sent.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "client": {
+                    "description": "The security section of client plugin",
+                    "properties": {
+                      "host": {
+                        "description": "The IP address or hostname of the client. This is exclusive with Network.",
+                        "type": "string"
+                      },
+                      "network": {
+                        "description": "The network address specification. This is exclusive with Host.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key per client.",
+                        "type": "string"
+                      },
+                      "users": {
+                        "description": "The array of usernames.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "denyKeepalive": {
+                    "description": "The connections will be disconnected right after receiving a message, if true.",
+                    "type": "boolean"
+                  },
+                  "lingerTimeout": {
+                    "description": "The timeout used to set the linger option.",
+                    "type": "integer"
+                  },
+                  "port": {
+                    "description": "The port to listen to, default is 24224.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "resolveHostname": {
+                    "description": "Tries to resolve hostname from IP addresses or not.",
+                    "type": "boolean"
+                  },
+                  "security": {
+                    "description": "The security section of forward plugin",
+                    "properties": {
+                      "allowAnonymousSource": {
+                        "description": "Allows the anonymous source. <client> sections are required, if disabled.",
+                        "type": "string"
+                      },
+                      "selfHostname": {
+                        "description": "The hostname.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key for authentication.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "Defines user section directly.",
+                        "properties": {
+                          "password": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "userAuth": {
+                        "description": "If true, user-based authentication is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "sendKeepalivePacket": {
+                    "description": "Enables the TCP keepalive for sockets.",
+                    "type": "boolean"
+                  },
+                  "skipInvalidEvent": {
+                    "description": "Skips the invalid incoming event.",
+                    "type": "boolean"
+                  },
+                  "sourceAddressKey": {
+                    "description": "The field name of the client's source address. If set, the client's address will be set to its key.",
+                    "type": "string"
+                  },
+                  "sourceHostnameKey": {
+                    "description": "The field name of the client's hostname. If set, the client's hostname will be set to its key.",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "in_forward uses incoming event's tag by default (See Protocol Section).\nIf the tag parameter is set, its value is used instead.",
+                    "type": "string"
+                  },
+                  "transport": {
+                    "description": "The transport section of forward plugin",
+                    "properties": {
+                      "caCertPath": {
+                        "description": "for Cert generated",
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "description": "for Cert signed by public CA",
+                        "type": "string"
+                      },
+                      "caPrivateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "caPrivateKeyPath": {
+                        "type": "string"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "certVerifier": {
+                        "description": "other parameters",
+                        "type": "string"
+                      },
+                      "ciphers": {
+                        "type": "string"
+                      },
+                      "clientCertAuth": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "privateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "privateKeyPath": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocal name of this plugin, i.e: tls",
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "The security section of user plugin",
+                    "properties": {
+                      "password": {
+                        "description": "Secret defines the key of a value.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "username": {
+                        "description": "Secret defines the key of a value.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "http": {
+                "description": "in_http plugin",
+                "properties": {
+                  "addHttpHeaders": {
+                    "description": "Adds HTTP_ prefix headers to the record.",
+                    "type": "boolean"
+                  },
+                  "addRemoteAddr": {
+                    "description": "Adds REMOTE_ADDR field to the record. The value of REMOTE_ADDR is the client's address.\ni.e: X-Forwarded-For: host1, host2",
+                    "type": "string"
+                  },
+                  "bind": {
+                    "description": "The port to listen to, default is \"0.0.0.0\"",
+                    "type": "string"
+                  },
+                  "bodySizeLimit": {
+                    "description": "The size limit of the POSTed element.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "corsAllOrigins": {
+                    "description": "Whitelist domains for CORS.",
+                    "type": "string"
+                  },
+                  "corsAllowCredentials": {
+                    "description": "Add Access-Control-Allow-Credentials header. It's needed when a request's credentials mode is include",
+                    "type": "string"
+                  },
+                  "keepaliveTimeout": {
+                    "description": "The timeout limit for keeping the connection alive.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "parse": {
+                    "description": "The parse section of http plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "description": "The port to listen to, default is 9880.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "respondsWithEmptyImg": {
+                    "description": "Responds with an empty GIF image of 1x1 pixel (rather than an empty string).",
+                    "type": "boolean"
+                  },
+                  "transport": {
+                    "description": "The transport section of http plugin",
+                    "properties": {
+                      "caCertPath": {
+                        "description": "for Cert generated",
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "description": "for Cert signed by public CA",
+                        "type": "string"
+                      },
+                      "caPrivateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "caPrivateKeyPath": {
+                        "type": "string"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "certVerifier": {
+                        "description": "other parameters",
+                        "type": "string"
+                      },
+                      "ciphers": {
+                        "type": "string"
+                      },
+                      "clientCertAuth": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "privateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "privateKeyPath": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocal name of this plugin, i.e: tls",
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "The @id parameter specifies a unique name for the configuration.",
+                "type": "string"
+              },
+              "label": {
+                "description": "The @label parameter is to route the input events to <label> sections.",
+                "type": "string"
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "monitorAgent": {
+                "description": "monitor_agent plugin",
+                "properties": {
+                  "bind": {
+                    "description": "The bind address to listen to.",
+                    "type": "string"
+                  },
+                  "emitInterval": {
+                    "description": "The interval time between event emits. This will be used when \"tag\" is configured.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "includeConfig": {
+                    "description": "You can set this option to false to remove the config field from the response.",
+                    "type": "boolean"
+                  },
+                  "includeRetry": {
+                    "description": "You can set this option to false to remove the retry field from the response.",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "The port to listen to.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "tag": {
+                    "description": "If you set this parameter, this plugin emits metrics as records.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "sample": {
+                "description": "in_sample plugin",
+                "properties": {
+                  "autoIncrementKey": {
+                    "description": "If specified, each generated event has an auto-incremented key field.",
+                    "type": "string"
+                  },
+                  "rate": {
+                    "description": "It configures how many events to generate per second.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "sample": {
+                    "description": "The sample data to be generated. It should be either an array of JSON hashes or a single JSON hash. If it is an array of JSON hashes, the hashes in the array are cycled through in order.",
+                    "type": "string"
+                  },
+                  "size": {
+                    "description": "The number of events in the event stream of each emit.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "tag": {
+                    "description": "The tag of the event. The value is the tag assigned to the generated events.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "tail": {
+                "description": "in_tail plugin",
+                "properties": {
+                  "emitUnmatchedLines": {
+                    "description": "Emits unmatched lines when <parse> format is not matched for incoming logs.",
+                    "type": "boolean"
+                  },
+                  "enableStatWatcher": {
+                    "description": "Enables the additional inotify-based watcher. Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.\nThis option is mainly for avoiding the stuck issue with inotify.",
+                    "type": "boolean"
+                  },
+                  "enableWatchTimer": {
+                    "description": "Enables the additional watch timer. Setting this parameter to false will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with inotify support.\nThe default is true which results in an additional 1 second timer being used.",
+                    "type": "boolean"
+                  },
+                  "encoding": {
+                    "description": "Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.\nIf encoding is specified, in_tail changes string to encoding.\nIf encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.",
+                    "type": "string"
+                  },
+                  "excludePath": {
+                    "description": "The paths excluded from the watcher list.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "followInodes": {
+                    "description": "Avoid to read rotated files duplicately. You should set true when you use * or strftime format in path.",
+                    "type": "boolean"
+                  },
+                  "fromEncoding": {
+                    "description": "Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.\nIf encoding is specified, in_tail changes string to encoding.\nIf encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.",
+                    "type": "string"
+                  },
+                  "group": {
+                    "description": "The in_tail plugin can assign each log file to a group, based on user defined rules.\nThe limit parameter controls the total number of lines collected for a group within a rate_period time interval.",
+                    "properties": {
+                      "pattern": {
+                        "description": "Specifies the regular expression for extracting metadata (namespace, podname) from log file path.\nDefault value of the pattern regexp extracts information about namespace, podname, docker_id, container of the log (K8s specific).",
+                        "type": "string"
+                      },
+                      "ratePeriod": {
+                        "description": "Time period in which the group line limit is applied. in_tail resets the counter after every rate_period interval.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "rule": {
+                        "description": "Grouping rules for log files.",
+                        "properties": {
+                          "limit": {
+                            "description": "Maximum number of lines allowed from a group in rate_period time interval. The default value of -1 doesn't throttle log files of that group.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "match": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "match parameter is used to check if a file belongs to a particular group based on hash keys (named captures from pattern) and hash values (regexp in string)",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "rule"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ignoreRepeatedPermissionError": {
+                    "description": "If you have to exclude the non-permission files from the watch list, set this parameter to true. It suppresses the repeated permission error logs.",
+                    "type": "boolean"
+                  },
+                  "limitRecentlyModified": {
+                    "description": "Limits the watching files that the modification time is within the specified time range when using * in path.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxLineSize": {
+                    "description": "The maximum length of a line. Longer lines than it will be just skipped.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "multilineFlushInterval": {
+                    "description": "The interval of flushing the buffer for multiline format.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "openOnEveryUpdate": {
+                    "description": "Opens and closes the file on every update instead of leaving it open until it gets rotated.",
+                    "type": "boolean"
+                  },
+                  "parse": {
+                    "description": "Parse defines various parameters for the parse plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "The path(s) to read. Multiple paths can be specified, separated by comma ','.",
+                    "type": "string"
+                  },
+                  "pathKey": {
+                    "description": "Adds the watching file path to the path_key field.",
+                    "type": "string"
+                  },
+                  "pathTimezone": {
+                    "description": "This parameter is for strftime formatted path like /path/to/%Y/%m/%d/.",
+                    "type": "string"
+                  },
+                  "posFile": {
+                    "description": "(recommended) Fluentd will record the position it last read from this file.\npos_file handles multiple positions in one file so no need to have multiple pos_file parameters per source.\nDon't share pos_file between in_tail configurations. It causes unexpected behavior e.g. corrupt pos_file content.",
+                    "type": "string"
+                  },
+                  "posFileCompactionInterval": {
+                    "description": "The interval of doing compaction of pos file.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readBytesLimitPerSecond": {
+                    "description": "The number of reading bytes per second to read with I/O operation. This value should be equal or greater than 8192.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readFromHead": {
+                    "description": "Starts to read the logs from the head of the file or the last read position recorded in pos_file, not tail.",
+                    "type": "boolean"
+                  },
+                  "readLinesLimit": {
+                    "description": "The number of lines to read with each I/O operation.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "refreshInterval": {
+                    "description": "The interval to refresh the list of watch files. This is used when the path includes *.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "rotateWait": {
+                    "description": "in_tail actually does a bit more than tail -F itself. When rotating a file, some data may still need to be written to the old file as opposed to the new one.\nin_tail takes care of this by keeping a reference to the old file (even after it has been rotated) for some time before transitioning completely to the new file.\nThis helps prevent data designated for the old file from getting lost. By default, this time interval is 5 seconds.\nThe rotate_wait parameter accepts a single integer representing the number of seconds you want this time interval to be.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "skipRefreshOnStartup": {
+                    "description": "Skips the refresh of the watch list on startup. This reduces the startup time when * is used in path.",
+                    "type": "boolean"
+                  },
+                  "tag": {
+                    "description": "The tag of the event.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parse",
+                  "path",
+                  "tag"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterInputStatus defines the observed state of ClusterInput",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusterinput_v1alpha2.json
+++ b/fluentd.fluent.io/clusterinput_v1alpha2.json
@@ -1,0 +1,957 @@
+{
+  "description": "ClusterInput is the Schema for the inputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "InputSpec defines the desired state of ClusterInput",
+      "properties": {
+        "alias": {
+          "description": "A user friendly alias name for this input plugin.\nUsed in metrics for distinction of each configured input.",
+          "type": "string"
+        },
+        "collectd": {
+          "description": "Collectd defines the Collectd input plugin configuration",
+          "properties": {
+            "listen": {
+              "description": "Set the address to listen to, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "Set the port to listen to, default: 25826",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "typesDB": {
+              "description": "Set the data specification file,default: /usr/share/collectd/types.db",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customPlugin": {
+          "description": "CustomPlugin defines Custom Input configuration.",
+          "properties": {
+            "config": {
+              "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+              "type": "string"
+            },
+            "yamlConfig": {
+              "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dummy": {
+          "description": "Dummy defines Dummy Input configuration.",
+          "properties": {
+            "dummy": {
+              "description": "Dummy JSON record.",
+              "type": "string"
+            },
+            "rate": {
+              "description": "Events number generated per second.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Sample events to generate.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "execWasi": {
+          "description": "ExecWasi defines the exec wasi input plugin configuration",
+          "properties": {
+            "accessiblePaths": {
+              "description": "Specify the whitelist of paths to be able to access paths from WASM programs.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "bufSize": {
+              "description": "Size of the buffer (check unit sizes for allowed values)",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "intervalNSec": {
+              "description": "Polling interval (nanoseconds).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "intervalSec": {
+              "description": "Polling interval (seconds).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "parser": {
+              "description": "Specify the name of a parser to interpret the entry as a structured message.",
+              "type": "string"
+            },
+            "threaded": {
+              "description": "Indicates whether to run this input in its own thread. Default: false.",
+              "type": "boolean"
+            },
+            "wasiPath": {
+              "description": "The place of a WASM program file.",
+              "type": "string"
+            },
+            "wasmHeapSize": {
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "wasmStackSize": {
+              "description": "Size of the stack size of Wasm execution. Review unit sizes for allowed values.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "fluentBitMetrics": {
+          "description": "FluentBitMetrics defines Fluent Bit Metrics Input configuration.",
+          "properties": {
+            "scrapeInterval": {
+              "description": "The rate at which metrics are collected from the host operating system. default is 2 seconds.",
+              "type": "string"
+            },
+            "scrapeOnStart": {
+              "description": "Scrape metrics upon start, useful to avoid waiting for 'scrape_interval' for the first round of metrics.",
+              "type": "boolean"
+            },
+            "tag": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forward": {
+          "description": "Forward defines forward  input plugin configuration",
+          "properties": {
+            "bufferMaxSize": {
+              "description": "Specify maximum buffer memory size used to recieve a forward message.\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferchunkSize": {
+              "description": "Set the initial buffer size to store incoming data.\nThis value is used too to increase buffer size as required.\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "Listener network interface.",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port for forward plugin instance.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tag": {
+              "description": "in_forward uses the tag value for incoming logs. If not set it uses tag from incoming log.",
+              "type": "string"
+            },
+            "tagPrefix": {
+              "description": "Adds the prefix to incoming event's tag",
+              "type": "string"
+            },
+            "threaded": {
+              "description": "Threaded mechanism allows input plugin to run in a separate thread which helps to desaturate the main pipeline.",
+              "type": "string"
+            },
+            "unixPath": {
+              "description": "Specify the path to unix socket to recieve a forward message. If set, Listen and port are ignnored.",
+              "type": "string"
+            },
+            "unixPerm": {
+              "description": "Set the permission of unix socket file.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "http": {
+          "description": "HTTP defines the HTTP input plugin configuration",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "This sets the chunk size for incoming incoming JSON messages.\nThese chunks are then stored/managed in the space available by buffer_max_size,default 512K.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Specify the maximum buffer size in KB to receive a JSON message,default 4M.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "The address to listen on,default 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port for Fluent Bit to listen on,default 9880",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "successfulHeader": {
+              "description": "Add an HTTP header key/value pair on success. Multiple headers can be set. Example: X-Custom custom-answer.",
+              "type": "string"
+            },
+            "successfulResponseCode": {
+              "description": "It allows to set successful response code. 200, 201 and 204 are supported,default 201.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tagKey": {
+              "description": "Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubernetesEvents": {
+          "description": "KubernetesEvents defines the KubernetesEvents input plugin configuration",
+          "properties": {
+            "db": {
+              "description": "Set a database file to keep track of recorded Kubernetes events",
+              "type": "string"
+            },
+            "dbSync": {
+              "description": "Set a database sync method. values: extra, full, normal and off",
+              "type": "string"
+            },
+            "intervalNsec": {
+              "description": "Set the polling interval for each channel (sub seconds: nanoseconds).",
+              "format": "int64",
+              "type": "integer"
+            },
+            "intervalSec": {
+              "description": "Set the polling interval for each channel.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "kubeCAFile": {
+              "description": "CA certificate file",
+              "type": "string"
+            },
+            "kubeCAPath": {
+              "description": "Absolute path to scan for certificate files",
+              "type": "string"
+            },
+            "kubeNamespace": {
+              "description": "Kubernetes namespace to query events from. Gets events from all namespaces by default",
+              "type": "string"
+            },
+            "kubeRequestLimit": {
+              "description": "kubernetes limit parameter for events query, no limit applied when set to 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "kubeRetentionTime": {
+              "description": "Kubernetes retention time for events.",
+              "type": "string"
+            },
+            "kubeTokenFile": {
+              "description": "Token file",
+              "type": "string"
+            },
+            "kubeTokenTTL": {
+              "description": "configurable 'time to live' for the K8s token. By default, it is set to 600 seconds.\nAfter this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.",
+              "type": "string"
+            },
+            "kubeURL": {
+              "description": "API Server end-point",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin.",
+              "type": "string"
+            },
+            "tlsDebug": {
+              "description": "Debug level between 0 (nothing) and 4 (every detail).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tlsVerify": {
+              "description": "When enabled, turns on certificate validation when connecting to the Kubernetes API server.",
+              "type": "boolean"
+            },
+            "tlsVhost": {
+              "description": "Set optional TLS virtual host.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "mqtt": {
+          "description": "MQTT defines the MQTT input plugin configuration",
+          "properties": {
+            "listen": {
+              "description": "Listener network interface, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port where listening for connections, default: 1883",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nginx": {
+          "description": "Nginx defines the Nginx input plugin configuration",
+          "properties": {
+            "host": {
+              "description": "Name of the target host or IP address to check, default: localhost",
+              "type": "string"
+            },
+            "nginxPlus": {
+              "description": "Turn on NGINX plus mode,default: true",
+              "type": "boolean"
+            },
+            "port": {
+              "description": "Port of the target nginx service to connect to, default: 80",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "statusURL": {
+              "description": "The URL of the Stub Status Handler,default: /status",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeExporterMetrics": {
+          "description": "NodeExporterMetrics defines Node Exporter Metrics Input configuration.",
+          "properties": {
+            "path": {
+              "properties": {
+                "procfs": {
+                  "description": "The mount point used to collect process information and metrics.",
+                  "type": "string"
+                },
+                "sysfs": {
+                  "description": "The path in the filesystem used to collect system metrics.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scrapeInterval": {
+              "description": "The rate at which metrics are collected from the host operating system, default is 5 seconds.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "openTelemetry": {
+          "description": "OpenTelemetry defines the OpenTelemetry input plugin configuration",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size(default 512K).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Specify the maximum buffer size in KB to receive a JSON message(default 4M).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "The address to listen on,default 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port for Fluent Bit to listen on.default 4318.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "rawTraces": {
+              "description": "Route trace data as a log message(default false).",
+              "type": "boolean"
+            },
+            "successfulResponseCode": {
+              "description": "It allows to set successful response code. 200, 201 and 204 are supported(default 201).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tag": {
+              "description": "opentelemetry uses the tag value for incoming metrics.",
+              "type": "string"
+            },
+            "tagFromURI": {
+              "description": "If true, tag will be created from uri. e.g. v1_metrics from /v1/metrics",
+              "type": "boolean"
+            },
+            "tagKey": {
+              "description": "Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processors": {
+          "description": "Processors defines the processors configuration",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "prometheusScrapeMetrics": {
+          "description": "PrometheusScrapeMetrics  defines Prometheus Scrape Metrics Input configuration.",
+          "properties": {
+            "host": {
+              "description": "The host of the prometheus metric endpoint that you want to scrape",
+              "type": "string"
+            },
+            "metricsPath": {
+              "description": "The metrics URI endpoint, that must start with a forward slash, deflaut: /metrics",
+              "type": "string"
+            },
+            "port": {
+              "description": "The port of the promethes metric endpoint that you want to scrape",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "scrapeInterval": {
+              "description": "The interval to scrape metrics, default: 10s",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Tag name associated to all records comming from this plugin",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "statsd": {
+          "description": "StatsD defines the StatsD input plugin configuration",
+          "properties": {
+            "listen": {
+              "description": "Listener network interface, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "UDP port where listening for connections, default: 8125",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syslog": {
+          "description": "Syslog defines the Syslog input plugin configuration",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "By default the buffer to store the incoming Syslog messages, do not allocate the maximum memory allowed, instead it allocate memory when is required.\nThe rounds of allocations are set by Buffer_Chunk_Size. If not set, Buffer_Chunk_Size is equal to 32000 bytes (32KB).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Specify the maximum buffer size to receive a Syslog message. If not set, the default size will be the value of Buffer_Chunk_Size.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "listen": {
+              "description": "If Mode is set to tcp or udp, specify the network interface to bind, default: 0.0.0.0",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Defines transport protocol mode: unix_udp (UDP over Unix socket), unix_tcp (TCP over Unix socket), tcp or udp",
+              "enum": [
+                "unix_udp",
+                "unix_tcp",
+                "tcp",
+                "udp"
+              ],
+              "type": "string"
+            },
+            "parser": {
+              "description": "Specify an alternative parser for the message. If Mode is set to tcp or udp then the default parser is syslog-rfc5424 otherwise syslog-rfc3164-local is used.\nIf your syslog messages have fractional seconds set this Parser value to syslog-rfc5424 instead.",
+              "type": "string"
+            },
+            "path": {
+              "description": "If Mode is set to unix_tcp or unix_udp, set the absolute path to the Unix socket file.",
+              "type": "string"
+            },
+            "port": {
+              "description": "If Mode is set to tcp or udp, specify the TCP port to listen for incoming connections.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "receiveBufferSize": {
+              "description": "Specify the maximum socket receive buffer size. If not set, the default value is OS-dependant,\nbut generally too low to accept thousands of syslog messages per second without loss on udp or unix_udp sockets. Note that on Linux the value is capped by sysctl net.core.rmem_max.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "sourceAddressKey": {
+              "description": "Specify the key where the source address will be injected.",
+              "type": "string"
+            },
+            "unixPerm": {
+              "description": "If Mode is set to unix_tcp or unix_udp, set the permission of the Unix socket file, default: 0644",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "systemd": {
+          "description": "Systemd defines Systemd Input configuration.",
+          "properties": {
+            "db": {
+              "description": "Specify the database file to keep track of monitored files and offsets.",
+              "type": "string"
+            },
+            "dbSync": {
+              "description": "Set a default synchronization (I/O) method. values: Extra, Full, Normal, Off.\nThis flag affects how the internal SQLite engine do synchronization to disk,\nfor more details about each option please refer to this section.\nnote: this option was introduced on Fluent Bit v1.4.6.",
+              "enum": [
+                "Extra",
+                "Full",
+                "Normal",
+                "Off"
+              ],
+              "type": "string"
+            },
+            "maxEntries": {
+              "description": "When Fluent Bit starts, the Journal might have a high number of logs in the queue.\nIn order to avoid delays and reduce memory usage, this option allows to specify the maximum number of log entries that can be processed per round.\nOnce the limit is reached, Fluent Bit will continue processing the remaining log entries once Journald performs the notification.",
+              "type": "integer"
+            },
+            "maxFields": {
+              "description": "Set a maximum number of fields (keys) allowed per record.",
+              "type": "integer"
+            },
+            "path": {
+              "description": "Optional path to the Systemd journal directory,\nif not set, the plugin will use default paths to read local-only logs.",
+              "type": "string"
+            },
+            "pauseOnChunksOverlimit": {
+              "description": "Specifies if the input plugin should be paused (stop ingesting new data) when the storage.max_chunks_up value is reached.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "readFromTail": {
+              "description": "Start reading new entries. Skip entries already stored in Journald.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "storageType": {
+              "description": "Specify the buffering mechanism to use. It can be memory or filesystem",
+              "enum": [
+                "filesystem",
+                "memory"
+              ],
+              "type": "string"
+            },
+            "stripUnderscores": {
+              "description": "Remove the leading underscore of the Journald field (key). For example the Journald field _PID becomes the key PID.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "systemdFilter": {
+              "description": "Allows to perform a query over logs that contains a specific Journald key/value pairs, e.g: _SYSTEMD_UNIT=UNIT.\nThe Systemd_Filter option can be specified multiple times in the input section to apply multiple filters as required.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "systemdFilterType": {
+              "description": "Define the filter type when Systemd_Filter is specified multiple times. Allowed values are And and Or.\nWith And a record is matched only when all of the Systemd_Filter have a match.\nWith Or a record is matched when any of the Systemd_Filter has a match.",
+              "enum": [
+                "And",
+                "Or"
+              ],
+              "type": "string"
+            },
+            "tag": {
+              "description": "The tag is used to route messages but on Systemd plugin there is an extra functionality:\nif the tag includes a star/wildcard, it will be expanded with the Systemd Unit file (e.g: host.* => host.UNIT_NAME).",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tail": {
+          "description": "Tail defines Tail Input configuration.",
+          "properties": {
+            "bufferChunkSize": {
+              "description": "Set the initial buffer size to read files data.\nThis value is used too to increase buffer size.\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "bufferMaxSize": {
+              "description": "Set the limit of the buffer size per monitored file.\nWhen a buffer needs to be increased (e.g: very long lines),\nthis value is used to restrict how much the memory buffer can grow.\nIf reading a file exceed this limit, the file is removed from the monitored file list\nThe value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "db": {
+              "description": "Specify the database file to keep track of monitored files and offsets.",
+              "type": "string"
+            },
+            "dbSync": {
+              "description": "Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off.",
+              "enum": [
+                "Extra",
+                "Full",
+                "Normal",
+                "Off"
+              ],
+              "type": "string"
+            },
+            "disableInotifyWatcher": {
+              "description": "DisableInotifyWatcher will disable inotify and use the file stat watcher instead.",
+              "type": "boolean"
+            },
+            "dockerMode": {
+              "description": "If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above.\nThis mode cannot be used at the same time as Multiline.",
+              "type": "boolean"
+            },
+            "dockerModeFlushSeconds": {
+              "description": "Wait period time in seconds to flush queued unfinished split lines.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "dockerModeParser": {
+              "description": "Specify an optional parser for the first line of the docker multiline mode. The parser name to be specified must be registered in the parsers.conf file.",
+              "type": "string"
+            },
+            "excludePath": {
+              "description": "Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria,\ne.g: exclude_path=*.gz,*.zip",
+              "type": "string"
+            },
+            "ignoredOlder": {
+              "description": "Ignores records which are older than this time in seconds.\nSupports m,h,d (minutes, hours, days) syntax.\nDefault behavior is to read all records from specified files.\nOnly available when a Parser is specificied and it can parse the time of a record.",
+              "pattern": "^\\d+(m|h|d)?$",
+              "type": "string"
+            },
+            "key": {
+              "description": "When a message is unstructured (no parser applied), it's appended as a string under the key name log.\nThis option allows to define an alternative name for that key.",
+              "type": "string"
+            },
+            "memBufLimit": {
+              "description": "Set a limit of memory that Tail plugin can use when appending data to the Engine.\nIf the limit is reach, it will be paused; when the data is flushed it resumes.",
+              "type": "string"
+            },
+            "multiline": {
+              "description": "If enabled, the plugin will try to discover multiline messages\nand use the proper parsers to compose the outgoing messages.\nNote that when this option is enabled the Parser option is not used.",
+              "type": "boolean"
+            },
+            "multilineFlushSeconds": {
+              "description": "Wait period time in seconds to process queued multiline messages",
+              "format": "int64",
+              "type": "integer"
+            },
+            "multilineParser": {
+              "description": "This will help to reassembly multiline messages originally split by Docker or CRI\nSpecify one or Multiline Parser definition to apply to the content.",
+              "type": "string"
+            },
+            "parser": {
+              "description": "Specify the name of a parser to interpret the entry as a structured message.",
+              "type": "string"
+            },
+            "parserFirstline": {
+              "description": "Name of the parser that matchs the beginning of a multiline message.\nNote that the regular expression defined in the parser must include a group name (named capture)",
+              "type": "string"
+            },
+            "parserN": {
+              "description": "Optional-extra parser to interpret and structure multiline entries.\nThis option can be used to define multiple parsers.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "path": {
+              "description": "Pattern specifying a specific log files or multiple ones through the use of common wildcards.",
+              "type": "string"
+            },
+            "pathKey": {
+              "description": "If enabled, it appends the name of the monitored file as part of the record.\nThe value assigned becomes the key in the map.",
+              "type": "string"
+            },
+            "pauseOnChunksOverlimit": {
+              "description": "Specifies if the input plugin should be paused (stop ingesting new data) when the storage.max_chunks_up value is reached.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "readFromHead": {
+              "description": "For new discovered files on start (without a database offset/position),\nread the content from the head of the file, not tail.",
+              "type": "boolean"
+            },
+            "refreshIntervalSeconds": {
+              "description": "The interval of refreshing the list of watched files in seconds.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rotateWaitSeconds": {
+              "description": "Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "skipLongLines": {
+              "description": "When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size),\nthe default behavior is to stop monitoring that file.\nSkip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines\nand continue processing other lines that fits into the buffer size.",
+              "type": "boolean"
+            },
+            "storageType": {
+              "description": "Specify the buffering mechanism to use. It can be memory or filesystem",
+              "enum": [
+                "filesystem",
+                "memory"
+              ],
+              "type": "string"
+            },
+            "tag": {
+              "description": "Set a tag (with regex-extract fields) that will be placed on lines read.\nE.g. kube.<namespace_name>.<pod_name>.<container_name>",
+              "type": "string"
+            },
+            "tagRegex": {
+              "description": "Set a regex to exctract fields from the file",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tcp": {
+          "description": "TCP defines the TCP input plugin configuration",
+          "properties": {
+            "bufferSize": {
+              "description": "Specify the maximum buffer size in KB to receive a JSON message. If not set, the default size will be the value of Chunk_Size.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "chunkSize": {
+              "description": "By default the buffer to store the incoming JSON messages, do not allocate the maximum memory allowed, instead it allocate memory when is required.\nThe rounds of allocations are set by Chunk_Size in KB. If not set, Chunk_Size is equal to 32 (32KB).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "format": {
+              "description": "Specify the expected payload format. It support the options json and none.\nWhen using json, it expects JSON maps, when is set to none, it will split every record using the defined Separator (option below).",
+              "type": "string"
+            },
+            "listen": {
+              "description": "Listener network interface,default 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port where listening for connections,default 5170",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "separator": {
+              "description": "When the expected Format is set to none, Fluent Bit needs a separator string to split the records. By default it uses the breakline character (LF or 0x10).",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "udp": {
+          "description": "UDP defines the UDP input plugin configuration",
+          "properties": {
+            "bufferSize": {
+              "description": "BufferSize Specify the maximum buffer size in KB to receive a JSON message.\nIf not set, the default size will be the value of Chunk_Size.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "chunkSize": {
+              "description": "By default the buffer to store the incoming JSON messages, do not allocate the maximum memory allowed,\ninstead it allocate memory when is required.\nThe rounds of allocations are set by Chunk_Size in KB. If not set, Chunk_Size is equal to 32 (32KB).",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "format": {
+              "description": "Format Specify the expected payload format. It support the options json and none.\nWhen using json, it expects JSON maps, when is set to none,\nit will split every record using the defined Separator (option below).",
+              "type": "string"
+            },
+            "listen": {
+              "description": "Listen Listener network interface, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port Specify the UDP port where listening for connections, default: 5170",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "separator": {
+              "description": "Separator When the expected Format is set to none, Fluent Bit needs a separator string to split the records. By default it uses the breakline character (LF or 0x10).",
+              "type": "string"
+            },
+            "sourceAddressKey": {
+              "description": "SourceAddressKey Specify the key where the source address will be injected.",
+              "type": "string"
+            },
+            "threaded": {
+              "description": "Threaded mechanism allows input plugin to run in a separate thread which helps to desaturate the main pipeline.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusteroutput_v1alpha1.json
+++ b/fluentd.fluent.io/clusteroutput_v1alpha1.json
@@ -1,0 +1,2552 @@
+{
+  "description": "ClusterOutput is the Schema for the clusteroutputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ClusterOutputSpec defines the desired state of ClusterOutput",
+      "properties": {
+        "outputs": {
+          "items": {
+            "description": "Output defines all available output plugins and their parameters",
+            "properties": {
+              "buffer": {
+                "description": "buffer section",
+                "properties": {
+                  "calcNumRecords": {
+                    "description": "Calculates the number of records, chunk size, during chunk resume.",
+                    "type": "string"
+                  },
+                  "chunkFormat": {
+                    "description": "ChunkFormat specifies the chunk format for calc_num_records.",
+                    "enum": [
+                      "msgpack",
+                      "text",
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  "chunkLimitRecords": {
+                    "description": "The max number of events that each chunks can store in it.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "chunkLimitSize": {
+                    "description": "Buffer parameters\nThe max size of each chunks: events will be written into chunks until the size of chunks become this size\nDefault: 8MB (memory) / 256MB (file)",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "compress": {
+                    "description": "Fluentd will decompress these compressed chunks automatically before passing them to the output plugin\nIf gzip is set, Fluentd compresses data records before writing to buffer chunks.\nDefault:text.",
+                    "enum": [
+                      "text",
+                      "gzip"
+                    ],
+                    "type": "string"
+                  },
+                  "delayedCommitTimeout": {
+                    "description": "The timeout (seconds) until output plugin decides if the async write operation has failed. Default is 60s",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "disableChunkBackup": {
+                    "description": "Instead of storing unrecoverable chunks in the backup directory, just discard them. This option is new in Fluentd v1.2.6.",
+                    "type": "boolean"
+                  },
+                  "flushAtShutdown": {
+                    "description": "Flush parameters\nThis specifies whether to flush/write all buffer chunks on shutdown or not.",
+                    "type": "boolean"
+                  },
+                  "flushInterval": {
+                    "description": "FlushInterval defines the flush interval",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "flushMode": {
+                    "description": "FlushMode defines the flush mode:\nlazy: flushes/writes chunks once per timekey\ninterval: flushes/writes chunks per specified time via flush_interval\nimmediate: flushes/writes chunks immediately after events are appended into chunks\ndefault: equals to lazy if time is specified as chunk key, interval otherwise",
+                    "enum": [
+                      "default",
+                      "lazy",
+                      "interval",
+                      "immediate"
+                    ],
+                    "type": "string"
+                  },
+                  "flushThreadCount": {
+                    "description": "The number of threads to flush/write chunks in parallel",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "The @id parameter specifies a unique name for the configuration.",
+                    "type": "string"
+                  },
+                  "localtime": {
+                    "description": "If true, uses local time.",
+                    "type": "boolean"
+                  },
+                  "logLevel": {
+                    "description": "The @log_level parameter specifies the plugin-specific logging level",
+                    "type": "string"
+                  },
+                  "overflowAction": {
+                    "description": "OverflowAtction defines the output plugin behave when its buffer queue is full.\nDefault: throw_exception",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "The path where buffer chunks are stored. This field would make no effect in memory buffer plugin.",
+                    "type": "string"
+                  },
+                  "pathSuffix": {
+                    "description": "Changes the suffix of the buffer file.",
+                    "type": "string"
+                  },
+                  "queueLimitLength": {
+                    "description": "The queue length limitation of this buffer plugin instance. Default: 0.95",
+                    "pattern": "^\\d+.?\\d+$",
+                    "type": "string"
+                  },
+                  "queuedChunksLimitSize": {
+                    "description": "Limit the number of queued chunks. Default: 1\nIf a smaller flush_interval is set, e.g. 1s,\nthere are lots of small queued chunks in the buffer.\nWith file buffer, it may consume a lot of fd resources when output destination has a problem.\nThis parameter mitigates such situations.",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "retryExponentialBackoffBase": {
+                    "description": "The base number of exponential backoff for retries.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?$",
+                    "type": "string"
+                  },
+                  "retryForever": {
+                    "description": "If true, plugin will ignore retry_timeout and retry_max_times options and retry flushing forever.",
+                    "type": "boolean"
+                  },
+                  "retryMaxInterval": {
+                    "description": "The maximum interval (seconds) for exponential backoff between retries while failing",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "retryMaxTimes": {
+                    "description": "The maximum number of times to retry to flush the failed chunks. Default: none",
+                    "type": "integer"
+                  },
+                  "retryRandomize": {
+                    "description": "If true, the output plugin will retry after randomized interval not to do burst retries",
+                    "type": "boolean"
+                  },
+                  "retrySecondaryThreshold": {
+                    "description": "The ratio of retry_timeout to switch to use the secondary while failing.",
+                    "pattern": "^\\d+.?\\d+$",
+                    "type": "string"
+                  },
+                  "retryTimeout": {
+                    "description": "Retry parameters\nThe maximum time (seconds) to retry to flush again the failed chunks, until the plugin discards the buffer chunks",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "retryType": {
+                    "description": "Output plugin will retry periodically with fixed intervals.",
+                    "type": "string"
+                  },
+                  "retryWait": {
+                    "description": "Wait in seconds before the next retry to flush or constant factor of exponential backoff",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "The output plugins group events into chunks.\nChunk keys, specified as the argument of <buffer> section, control how to group events into chunks.\nIf tag is empty, which means blank Chunk Keys.\nTag also supports Nested Field, combination of Chunk Keys, placeholders, etc.\nSee https://docs.fluentd.org/configuration/buffer-section.",
+                    "type": "string"
+                  },
+                  "timeFormat": {
+                    "description": "Process value according to the specified format. This is available only when time_type is string",
+                    "type": "string"
+                  },
+                  "timeFormatFallbacks": {
+                    "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                    "type": "string"
+                  },
+                  "timeType": {
+                    "description": "parses/formats value according to this type, default is string",
+                    "enum": [
+                      "float",
+                      "unixtime",
+                      "string",
+                      "mixed"
+                    ],
+                    "type": "string"
+                  },
+                  "timekey": {
+                    "description": "Output plugin will flush chunks per specified time (enabled when time is specified in chunk keys)",
+                    "type": "string"
+                  },
+                  "timekeyWait": {
+                    "description": "Output plugin will write chunks after timekey_wait seconds later after timekey expiration",
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "description": "Uses the specified timezone.",
+                    "type": "string"
+                  },
+                  "totalLimitSize": {
+                    "description": "The size limitation of this buffer plugin instance\nDefault: 512MB (memory) / 64GB (file)",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "The @type parameter specifies the type of the plugin.",
+                    "enum": [
+                      "file",
+                      "memory",
+                      "file_single"
+                    ],
+                    "type": "string"
+                  },
+                  "utc": {
+                    "description": "If true, uses UTC.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cloudWatch": {
+                "description": "out_cloudwatch plugin",
+                "properties": {
+                  "autoCreateStream": {
+                    "type": "boolean"
+                  },
+                  "awsEcsAuthentication": {
+                    "type": "boolean"
+                  },
+                  "awsKeyId": {
+                    "description": "Secret defines the key of a value.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "awsSecKey": {
+                    "description": "Secret defines the key of a value.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "awsStsDurationSeconds": {
+                    "type": "string"
+                  },
+                  "awsStsEndpointUrl": {
+                    "type": "string"
+                  },
+                  "awsStsExternalId": {
+                    "type": "string"
+                  },
+                  "awsStsPolicy": {
+                    "type": "string"
+                  },
+                  "awsStsRoleArn": {
+                    "type": "string"
+                  },
+                  "awsStsSessionName": {
+                    "type": "string"
+                  },
+                  "awsUseSts": {
+                    "type": "boolean"
+                  },
+                  "concurrency": {
+                    "type": "integer"
+                  },
+                  "durationSeconds": {
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "description": "Specify an AWS endpoint to send data to.",
+                    "type": "string"
+                  },
+                  "httpProxy": {
+                    "type": "string"
+                  },
+                  "includeTimeKey": {
+                    "type": "boolean"
+                  },
+                  "jsonHandler": {
+                    "type": "string"
+                  },
+                  "localtime": {
+                    "type": "boolean"
+                  },
+                  "logGroupAwsTags": {
+                    "type": "string"
+                  },
+                  "logGroupAwsTagsKey": {
+                    "type": "string"
+                  },
+                  "logGroupName": {
+                    "type": "string"
+                  },
+                  "logGroupNameKey": {
+                    "type": "string"
+                  },
+                  "logRejectedRequest": {
+                    "type": "string"
+                  },
+                  "logStreamName": {
+                    "type": "string"
+                  },
+                  "logStreamNameKey": {
+                    "type": "string"
+                  },
+                  "maxEventsPerBatch": {
+                    "type": "string"
+                  },
+                  "maxMessageLength": {
+                    "type": "string"
+                  },
+                  "messageKeys": {
+                    "type": "string"
+                  },
+                  "policy": {
+                    "type": "string"
+                  },
+                  "putLogEventsDisableRetryLimit": {
+                    "type": "boolean"
+                  },
+                  "putLogEventsRetryLimit": {
+                    "type": "string"
+                  },
+                  "putLogEventsRetryWait": {
+                    "type": "string"
+                  },
+                  "region": {
+                    "description": "The AWS region.",
+                    "type": "string"
+                  },
+                  "removeLogGroupAwsTagsKey": {
+                    "type": "boolean"
+                  },
+                  "removeLogGroupNameKey": {
+                    "type": "boolean"
+                  },
+                  "removeLogStreamNameKey": {
+                    "type": "boolean"
+                  },
+                  "removeRetentionInDaysKey": {
+                    "type": "boolean"
+                  },
+                  "retentionInDays": {
+                    "type": "string"
+                  },
+                  "retentionInDaysKey": {
+                    "type": "string"
+                  },
+                  "roleArn": {
+                    "description": "ARN of an IAM role to assume (for cross account access).",
+                    "type": "string"
+                  },
+                  "roleSessionName": {
+                    "description": "Role Session name",
+                    "type": "string"
+                  },
+                  "sslVerifyPeer": {
+                    "type": "boolean"
+                  },
+                  "useTagAsGroup": {
+                    "type": "string"
+                  },
+                  "useTagAsStream": {
+                    "type": "string"
+                  },
+                  "webIdentityTokenFile": {
+                    "description": "Web identity token file",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "copy": {
+                "description": "copy plugin",
+                "properties": {
+                  "copyMode": {
+                    "description": "CopyMode defines how to pass the events to <store> plugins.",
+                    "enum": [
+                      "no_copy",
+                      "shallow",
+                      "deep",
+                      "marshal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "copyMode"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "datadog": {
+                "description": "datadog plugin",
+                "properties": {
+                  "apiKey": {
+                    "description": "This parameter is required in order to authenticate your fluent agent.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "compressionLevel": {
+                    "description": "Set the log compression level for HTTP (1 to 9, 9 being the best ratio)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "ddHostname": {
+                    "description": "Used by Datadog to identify the host submitting the logs.",
+                    "type": "string"
+                  },
+                  "ddSource": {
+                    "description": "This tells Datadog what integration it is",
+                    "type": "string"
+                  },
+                  "ddSourcecategory": {
+                    "description": "Multiple value attribute. Can be used to refine the source attribute",
+                    "type": "string"
+                  },
+                  "ddTags": {
+                    "description": "Custom tags with the following format \"key1:value1, key2:value2\"",
+                    "type": "string"
+                  },
+                  "host": {
+                    "description": "Proxy endpoint when logs are not directly forwarded to Datadog",
+                    "type": "string"
+                  },
+                  "httpProxy": {
+                    "description": "HTTP proxy, only takes effect if HTTP forwarding is enabled (use_http). Defaults to HTTP_PROXY/http_proxy env vars.",
+                    "type": "string"
+                  },
+                  "includeTagKey": {
+                    "description": "Automatically include the Fluentd tag in the record.",
+                    "type": "boolean"
+                  },
+                  "maxBackoff": {
+                    "description": "The maximum time waited between each retry in seconds",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxRetries": {
+                    "description": "The number of retries before the output plugin stops. Set to -1 for unlimited retries",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "noSSLValidation": {
+                    "description": "Disable SSL validation (useful for proxy forwarding)",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "Proxy port when logs are not directly forwarded to Datadog and ssl is not used",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "service": {
+                    "description": "Used by Datadog to correlate between logs, traces and metrics.",
+                    "type": "string"
+                  },
+                  "sslPort": {
+                    "description": "Port used to send logs over a SSL encrypted connection to Datadog. If use_http is disabled, use 10516 for the US region and 443 for the EU region.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "tagKey": {
+                    "description": "Where to store the Fluentd tag.",
+                    "type": "string"
+                  },
+                  "timestampKey": {
+                    "description": "Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added.",
+                    "type": "string"
+                  },
+                  "useCompression": {
+                    "description": "Enable log compression for HTTP",
+                    "type": "boolean"
+                  },
+                  "useHTTP": {
+                    "description": "Enable HTTP forwarding. If you disable it, make sure to change the port to 10514 or ssl_port to 10516",
+                    "type": "boolean"
+                  },
+                  "useJson": {
+                    "description": "Event format, if true, the event is sent in json format. Othwerwise, in plain text.",
+                    "type": "boolean"
+                  },
+                  "useSSL": {
+                    "description": "If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "elasticsearch": {
+                "description": "out_es plugin",
+                "properties": {
+                  "caFile": {
+                    "description": "Optional, Absolute path to CA certificate file",
+                    "type": "string"
+                  },
+                  "clientCert": {
+                    "description": "Optional, Absolute path to client Certificate file",
+                    "type": "string"
+                  },
+                  "clientKey": {
+                    "description": "Optional, Absolute path to client private Key file",
+                    "type": "string"
+                  },
+                  "clientKeyPassword": {
+                    "description": "Optional, password for ClientKey file",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudAuth": {
+                    "description": "Authenticate towards Elastic Cloud using cloudAuth.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudId": {
+                    "description": "Authenticate towards Elastic Cloud using CloudId. If set, cloudAuth must\nbe set as well and host, port, user and password are ignored.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "enableIlm": {
+                    "description": "Optional, Enable Index Lifecycle Management (ILM)",
+                    "type": "boolean"
+                  },
+                  "failOnPuttingTemplateRetryExceeded": {
+                    "description": "Optional, Indicates whether to fail when max_retry_putting_template is exceeded. If you have multiple output plugin, you could use this property to do not fail on fluentd statup (default: false)",
+                    "type": "boolean"
+                  },
+                  "host": {
+                    "description": "The hostname of your Elasticsearch node (default: localhost).",
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "description": "Hosts defines a list of hosts if you want to connect to more than one Elasticsearch nodes",
+                    "type": "string"
+                  },
+                  "ilmPolicy": {
+                    "description": "Optional, Specify ILM policy contents as Hash",
+                    "type": "string"
+                  },
+                  "ilmPolicyId": {
+                    "description": "Optional, Specify ILM policy id",
+                    "type": "string"
+                  },
+                  "ilmPolicyOverride": {
+                    "description": "Optional, Specify whether overwriting ilm policy or not",
+                    "type": "boolean"
+                  },
+                  "indexName": {
+                    "description": "IndexName defines the placeholder syntax of Fluentd plugin API. See https://docs.fluentd.org/configuration/buffer-section.",
+                    "type": "string"
+                  },
+                  "logEs400Reason": {
+                    "description": "Optional, Enable logging of 400 reason without enabling debug log level",
+                    "type": "boolean"
+                  },
+                  "logstashFormat": {
+                    "description": "If true, Fluentd uses the conventional index name format logstash-%Y.%m.%d (default: false). This option supersedes the index_name option.",
+                    "type": "boolean"
+                  },
+                  "logstashPrefix": {
+                    "description": "LogstashPrefix defines the logstash prefix index name to write events when logstash_format is true (default: logstash).",
+                    "type": "string"
+                  },
+                  "maxRetryPuttingTemplate": {
+                    "description": "Optional, You can specify times of retry putting template (default: 10)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path defines the REST API endpoint of Elasticsearch to post write requests (default: nil).",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "The port number of your Elasticsearch node (default: 9200).",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "reconnectOnError": {
+                    "description": "Optional, Indicates that the plugin should reset connection on any error (reconnect on next send) (default: false)",
+                    "type": "boolean"
+                  },
+                  "reloadConnections": {
+                    "description": "Optional, Automatically reload connection after 10000 documents (default: true)",
+                    "type": "boolean"
+                  },
+                  "reloadOnFailure": {
+                    "description": "Optional, Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the request, this can be useful to quickly remove a dead node from the list of addresses (default: false)",
+                    "type": "boolean"
+                  },
+                  "requestTimeout": {
+                    "description": "Optional, HTTP Timeout (default: 5)",
+                    "pattern": "^\\d+(s|m|h|d)$",
+                    "type": "string"
+                  },
+                  "scheme": {
+                    "description": "Specify https if your Elasticsearch endpoint supports SSL (default: http).",
+                    "type": "string"
+                  },
+                  "sslVerify": {
+                    "description": "Optional, Force certificate validation",
+                    "type": "boolean"
+                  },
+                  "suppressTypeName": {
+                    "description": "Optional, Suppress '[types removal]' warnings on elasticsearch 7.x",
+                    "type": "boolean"
+                  },
+                  "templateOverwrite": {
+                    "description": "Optional, Always update the template, even if it already exists (default: false)",
+                    "type": "boolean"
+                  },
+                  "user": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "elasticsearchDataStream": {
+                "description": "out_es datastreams plugin",
+                "properties": {
+                  "caFile": {
+                    "description": "Optional, Absolute path to CA certificate file",
+                    "type": "string"
+                  },
+                  "clientCert": {
+                    "description": "Optional, Absolute path to client Certificate file",
+                    "type": "string"
+                  },
+                  "clientKey": {
+                    "description": "Optional, Absolute path to client private Key file",
+                    "type": "string"
+                  },
+                  "clientKeyPassword": {
+                    "description": "Optional, password for ClientKey file",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudAuth": {
+                    "description": "Authenticate towards Elastic Cloud using cloudAuth.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudId": {
+                    "description": "Authenticate towards Elastic Cloud using CloudId. If set, cloudAuth must\nbe set as well and host, port, user and password are ignored.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "dataStreamIlmName": {
+                    "description": "Optional, You can specify the name of an existing ILM policy, which will be applied to the data stream. If not present, it creates a new ILM default policy (unless data_stream_template_name is defined, in that case the ILM will be set to the one specified in the matching index template)",
+                    "type": "string"
+                  },
+                  "dataStreamIlmPolicy": {
+                    "description": "Optional, You can specify the ILM policy contents as hash. If not present, it will apply the ILM default policy",
+                    "type": "string"
+                  },
+                  "dataStreamIlmPolicyOverwrite": {
+                    "description": "Optional, Specify whether the data stream ILM policy should be overwritten",
+                    "type": "boolean"
+                  },
+                  "dataStreamName": {
+                    "description": "You can specify Elasticsearch data stream name by this parameter. This parameter is mandatory for elasticsearch_data_stream",
+                    "type": "string"
+                  },
+                  "dataStreamTemplateName": {
+                    "description": "Optional, You can specify an existing matching index template for the data stream. If not present, it creates a new matching index template",
+                    "type": "string"
+                  },
+                  "dataStreamTemplateUseIndexPatternsWildcard": {
+                    "description": "Optional, Specify whether index patterns should include a wildcard (*) when creating an index template. This is particularly useful to prevent errors in scenarios where index templates are generated automatically, and multiple services with distinct suffixes are in use",
+                    "type": "boolean"
+                  },
+                  "enableIlm": {
+                    "description": "Optional, Enable Index Lifecycle Management (ILM)",
+                    "type": "boolean"
+                  },
+                  "failOnPuttingTemplateRetryExceeded": {
+                    "description": "Optional, Indicates whether to fail when max_retry_putting_template is exceeded. If you have multiple output plugin, you could use this property to do not fail on fluentd statup (default: false)",
+                    "type": "boolean"
+                  },
+                  "host": {
+                    "description": "The hostname of your Elasticsearch node (default: localhost).",
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "description": "Hosts defines a list of hosts if you want to connect to more than one Elasticsearch nodes",
+                    "type": "string"
+                  },
+                  "ilmPolicy": {
+                    "description": "Optional, Specify ILM policy contents as Hash",
+                    "type": "string"
+                  },
+                  "ilmPolicyId": {
+                    "description": "Optional, Specify ILM policy id",
+                    "type": "string"
+                  },
+                  "ilmPolicyOverride": {
+                    "description": "Optional, Specify whether overwriting ilm policy or not",
+                    "type": "boolean"
+                  },
+                  "logEs400Reason": {
+                    "description": "Optional, Enable logging of 400 reason without enabling debug log level",
+                    "type": "boolean"
+                  },
+                  "maxRetryPuttingTemplate": {
+                    "description": "Optional, You can specify times of retry putting template (default: 10)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path defines the REST API endpoint of Elasticsearch to post write requests (default: nil).",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "The port number of your Elasticsearch node (default: 9200).",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "reconnectOnError": {
+                    "description": "Optional, Indicates that the plugin should reset connection on any error (reconnect on next send) (default: false)",
+                    "type": "boolean"
+                  },
+                  "reloadConnections": {
+                    "description": "Optional, Automatically reload connection after 10000 documents (default: true)",
+                    "type": "boolean"
+                  },
+                  "reloadOnFailure": {
+                    "description": "Optional, Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the request, this can be useful to quickly remove a dead node from the list of addresses (default: false)",
+                    "type": "boolean"
+                  },
+                  "requestTimeout": {
+                    "description": "Optional, HTTP Timeout (default: 5)",
+                    "pattern": "^\\d+(s|m|h|d)$",
+                    "type": "string"
+                  },
+                  "scheme": {
+                    "description": "Specify https if your Elasticsearch endpoint supports SSL (default: http).",
+                    "type": "string"
+                  },
+                  "sslVerify": {
+                    "description": "Optional, Force certificate validation",
+                    "type": "boolean"
+                  },
+                  "suppressTypeName": {
+                    "description": "Optional, Suppress '[types removal]' warnings on elasticsearch 7.x",
+                    "type": "boolean"
+                  },
+                  "templateOverwrite": {
+                    "description": "Optional, Always update the template, even if it already exists (default: false)",
+                    "type": "boolean"
+                  },
+                  "user": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "dataStreamName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "format": {
+                "description": "format section",
+                "properties": {
+                  "delimiter": {
+                    "description": "Delimiter for each field.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "The @id parameter specifies a unique name for the configuration.",
+                    "type": "string"
+                  },
+                  "localtime": {
+                    "description": "If true, uses local time.",
+                    "type": "boolean"
+                  },
+                  "logLevel": {
+                    "description": "The @log_level parameter specifies the plugin-specific logging level",
+                    "type": "string"
+                  },
+                  "newline": {
+                    "description": "Specify newline characters.",
+                    "enum": [
+                      "lf",
+                      "crlf"
+                    ],
+                    "type": "string"
+                  },
+                  "outputTag": {
+                    "description": "Output tag field if true.",
+                    "type": "boolean"
+                  },
+                  "outputTime": {
+                    "description": "Output time field if true.",
+                    "type": "boolean"
+                  },
+                  "timeFormat": {
+                    "description": "Process value according to the specified format. This is available only when time_type is string",
+                    "type": "string"
+                  },
+                  "timeFormatFallbacks": {
+                    "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                    "type": "string"
+                  },
+                  "timeType": {
+                    "description": "parses/formats value according to this type, default is string",
+                    "enum": [
+                      "float",
+                      "unixtime",
+                      "string",
+                      "mixed"
+                    ],
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "description": "Uses the specified timezone.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "The @type parameter specifies the type of the plugin.",
+                    "enum": [
+                      "out_file",
+                      "json",
+                      "ltsv",
+                      "csv",
+                      "msgpack",
+                      "hash",
+                      "single_value"
+                    ],
+                    "type": "string"
+                  },
+                  "utc": {
+                    "description": "If true, uses UTC.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "forward": {
+                "description": "out_forward plugin",
+                "properties": {
+                  "ackResponseTimeout": {
+                    "description": "This option is used when require_ack_response is true. This default value is based on popular tcp_syn_retries.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "connectTimeout": {
+                    "description": "The connection timeout for the socket. When the connection is timed out during the connection establishment, Errno::ETIMEDOUT error is raised.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "dnsRoundRobin": {
+                    "description": "Enable client-side DNS round robin. Uniform randomly pick an IP address to send data when a hostname has several IP addresses.\nheartbeat_type udp is not available with dns_round_robintrue. Use heartbeat_type tcp or heartbeat_type none.",
+                    "type": "boolean"
+                  },
+                  "expireDnsCache": {
+                    "description": "Sets TTL to expire DNS cache in seconds. Set 0 not to use DNS Cache.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "hardTimeout": {
+                    "description": "The hard timeout used to detect server failure. The default value is equal to the send_timeout parameter.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "heartbeatInterval": {
+                    "description": "The interval of the heartbeat packer.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "heartbeatType": {
+                    "description": "Specifies the transport protocol for heartbeats. Set none to disable.",
+                    "enum": [
+                      "transport",
+                      "tcp",
+                      "udp",
+                      "none"
+                    ],
+                    "type": "string"
+                  },
+                  "ignoreNetworkErrorsAtStartup": {
+                    "description": "Ignores DNS resolution and errors at startup time.",
+                    "type": "boolean"
+                  },
+                  "keepalive": {
+                    "description": "Enables the keepalive connection.",
+                    "type": "boolean"
+                  },
+                  "keepaliveTimeout": {
+                    "description": "Timeout for keepalive. Default value is nil which means to keep the connection alive as long as possible.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "phiFailureDetector": {
+                    "description": "Use the \"Phi accrual failure detector\" to detect server failure.",
+                    "type": "boolean"
+                  },
+                  "phiThreshold": {
+                    "description": "The threshold parameter used to detect server faults.",
+                    "type": "integer"
+                  },
+                  "recoverWait": {
+                    "description": "The wait time before accepting a server fault recovery.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "requireAckResponse": {
+                    "description": "Changes the protocol to at-least-once. The plugin waits the ack from destination's in_forward plugin.",
+                    "type": "boolean"
+                  },
+                  "security": {
+                    "description": "ServiceDiscovery defines the security section",
+                    "properties": {
+                      "allowAnonymousSource": {
+                        "description": "Allows the anonymous source. <client> sections are required, if disabled.",
+                        "type": "string"
+                      },
+                      "selfHostname": {
+                        "description": "The hostname.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key for authentication.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "Defines user section directly.",
+                        "properties": {
+                          "password": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "userAuth": {
+                        "description": "If true, user-based authentication is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "sendTimeout": {
+                    "description": "The timeout time when sending event logs.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "servers": {
+                    "description": "Servers defines the servers section, at least one is required",
+                    "items": {
+                      "description": "Server defines the common parameters for the server plugin",
+                      "properties": {
+                        "host": {
+                          "description": "Host defines the IP address or host name of the server.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "The @id parameter specifies a unique name for the configuration.",
+                          "type": "string"
+                        },
+                        "logLevel": {
+                          "description": "The @log_level parameter specifies the plugin-specific logging level",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name defines the name of the server. Used for logging and certificate verification in TLS transport (when the host is the address).",
+                          "type": "string"
+                        },
+                        "password": {
+                          "description": "Password defines the password for authentication.",
+                          "properties": {
+                            "valueFrom": {
+                              "description": "ValueSource defines how to find a value's key.",
+                              "properties": {
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "port": {
+                          "description": "Port defines the port number of the host. Note that both TCP packets (event stream) and UDP packets (heartbeat messages) are sent to this port.",
+                          "type": "string"
+                        },
+                        "sharedKey": {
+                          "description": "SharedKey defines the shared key per server.",
+                          "type": "string"
+                        },
+                        "standby": {
+                          "description": "Standby marks a node as the standby node for an Active-Standby model between Fluentd nodes.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "The @type parameter specifies the type of the plugin.",
+                          "type": "string"
+                        },
+                        "username": {
+                          "description": "Username defines the username for authentication.",
+                          "properties": {
+                            "valueFrom": {
+                              "description": "ValueSource defines how to find a value's key.",
+                              "properties": {
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "weight": {
+                          "description": "Weight defines the load balancing weight",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "serviceDiscovery": {
+                    "description": "ServiceDiscovery defines the service_discovery section",
+                    "properties": {
+                      "confEncoding": {
+                        "description": "The encoding of the configuration file.",
+                        "type": "string"
+                      },
+                      "dnsLookup": {
+                        "description": "DnsLookup resolves the hostname to IP address of the SRV's Target.",
+                        "type": "string"
+                      },
+                      "dnsServerHost": {
+                        "description": "DnsServerHost defines the hostname of the DNS server to request the SRV record.",
+                        "type": "string"
+                      },
+                      "hostname": {
+                        "description": "The name in RFC2782.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "interval": {
+                        "description": "Interval defines the interval of sending requests to DNS server.",
+                        "type": "string"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "The path of the target list. Default is '/etc/fluent/sd.yaml'",
+                        "type": "string"
+                      },
+                      "proto": {
+                        "description": "Proto without the underscore in RFC2782.",
+                        "type": "string"
+                      },
+                      "server": {
+                        "description": "The server section of this plugin",
+                        "properties": {
+                          "host": {
+                            "description": "Host defines the IP address or host name of the server.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "The @id parameter specifies a unique name for the configuration.",
+                            "type": "string"
+                          },
+                          "logLevel": {
+                            "description": "The @log_level parameter specifies the plugin-specific logging level",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name defines the name of the server. Used for logging and certificate verification in TLS transport (when the host is the address).",
+                            "type": "string"
+                          },
+                          "password": {
+                            "description": "Password defines the password for authentication.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "port": {
+                            "description": "Port defines the port number of the host. Note that both TCP packets (event stream) and UDP packets (heartbeat messages) are sent to this port.",
+                            "type": "string"
+                          },
+                          "sharedKey": {
+                            "description": "SharedKey defines the shared key per server.",
+                            "type": "string"
+                          },
+                          "standby": {
+                            "description": "Standby marks a node as the standby node for an Active-Standby model between Fluentd nodes.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "The @type parameter specifies the type of the plugin.",
+                            "type": "string"
+                          },
+                          "username": {
+                            "description": "Username defines the username for authentication.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight defines the load balancing weight",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "service": {
+                        "description": "Service without the underscore in RFC2782.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "static",
+                          "file",
+                          "srv"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tlsAllowSelfSignedCert": {
+                    "description": "Allows self-signed certificates or not.",
+                    "type": "boolean"
+                  },
+                  "tlsCertLogicalStoreName": {
+                    "description": "The certificate logical store name on Windows system certstore. This parameter is for Windows only.",
+                    "type": "string"
+                  },
+                  "tlsCertPath": {
+                    "description": "The additional CA certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsCertThumbprint": {
+                    "description": "The certificate thumbprint for searching from Windows system certstore. This parameter is for Windows only.",
+                    "type": "string"
+                  },
+                  "tlsCertUseEnterpriseStore": {
+                    "description": "Enables the certificate enterprise store on Windows system certstore. This parameter is for Windows only.",
+                    "type": "boolean"
+                  },
+                  "tlsCiphers": {
+                    "description": "The cipher configuration of TLS transport.",
+                    "type": "string"
+                  },
+                  "tlsClientCertPath": {
+                    "description": "The client certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsClientPrivateKeyPassphrase": {
+                    "description": "The TLS private key passphrase for the client.",
+                    "type": "string"
+                  },
+                  "tlsClientPrivateKeyPath": {
+                    "description": "The client private key path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsInsecureMode": {
+                    "description": "Skips all verification of certificates or not.",
+                    "type": "boolean"
+                  },
+                  "tlsVerifyHostname": {
+                    "description": "Verifies hostname of servers and certificates or not in TLS transport.",
+                    "type": "boolean"
+                  },
+                  "tlsVersion": {
+                    "description": "The default version of TLS transport.",
+                    "enum": [
+                      "TLSv1_1",
+                      "TLSv1_2"
+                    ],
+                    "type": "string"
+                  },
+                  "verifyConnectionAtStartup": {
+                    "description": "Verify that a connection can be made with one of out_forward nodes at the time of startup.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "servers"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "http": {
+                "description": "out_http plugin",
+                "properties": {
+                  "auth": {
+                    "description": "Auth section for this plugin",
+                    "properties": {
+                      "auth": {
+                        "description": "The method for HTTP authentication. Now only basic.",
+                        "type": "string"
+                      },
+                      "password": {
+                        "description": "The password for basic authentication.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "username": {
+                        "description": "The username for basic authentication.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "contentType": {
+                    "description": "ContentType defines Content-Type for HTTP request. out_http automatically set Content-Type for built-in formatters when this parameter is not specified.",
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "description": "Endpoint defines the endpoint for HTTP request. If you want to use HTTPS, use https prefix.",
+                    "type": "string"
+                  },
+                  "errorResponseAsUnrecoverable": {
+                    "description": "Raise UnrecoverableError when the response code is not SUCCESS.",
+                    "type": "boolean"
+                  },
+                  "headers": {
+                    "description": "Headers defines the additional headers for HTTP request.",
+                    "type": "string"
+                  },
+                  "headersFromPlaceholders": {
+                    "description": "Additional placeholder based headers for HTTP request. If you want to use tag or record field, use this parameter instead of headers.",
+                    "type": "string"
+                  },
+                  "httpMethod": {
+                    "description": "HttpMethod defines the method for HTTP request.",
+                    "enum": [
+                      "post",
+                      "put"
+                    ],
+                    "type": "string"
+                  },
+                  "jsonArray": {
+                    "description": "JsonArray defines whether to use the array format of JSON or not",
+                    "type": "boolean"
+                  },
+                  "openTimeout": {
+                    "description": "OpenTimeout defines the connection open timeout in seconds.",
+                    "type": "integer"
+                  },
+                  "proxy": {
+                    "description": "Proxy defines the proxy for HTTP request.",
+                    "type": "string"
+                  },
+                  "readTimeout": {
+                    "description": "ReadTimeout defines the read timeout in seconds.",
+                    "type": "integer"
+                  },
+                  "retryableResponseCodes": {
+                    "description": "The list of retryable response codes. If the response code is included in this list, out_http retries the buffer flush.",
+                    "type": "string"
+                  },
+                  "sslTimeout": {
+                    "description": "SslTimeout defines the TLS timeout in seconds.",
+                    "type": "integer"
+                  },
+                  "tlsCaCertPath": {
+                    "description": "TlsCaCertPath defines the CA certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsCiphers": {
+                    "description": "TlsCiphers defines the cipher suites configuration of TLS.",
+                    "type": "string"
+                  },
+                  "tlsClientCertPath": {
+                    "description": "TlsClientCertPath defines the client certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsPrivateKeyPassphrase": {
+                    "description": "TlsPrivateKeyPassphrase defines the client private key passphrase for TLS.",
+                    "type": "string"
+                  },
+                  "tlsPrivateKeyPath": {
+                    "description": "TlsPrivateKeyPath defines the client private key path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsVerifyMode": {
+                    "description": "TlsVerifyMode defines the verify mode of TLS.",
+                    "enum": [
+                      "peer",
+                      "none"
+                    ],
+                    "type": "string"
+                  },
+                  "tlsVersion": {
+                    "description": "TlsVersion defines the default version of TLS transport.",
+                    "enum": [
+                      "TLSv1_1",
+                      "TLSv1_2"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "inject": {
+                "description": "inject section",
+                "properties": {
+                  "hostname": {
+                    "description": "Hostname value",
+                    "type": "string"
+                  },
+                  "hostnameKey": {
+                    "description": "The field name to inject hostname",
+                    "type": "string"
+                  },
+                  "inline": {
+                    "description": "Time section",
+                    "properties": {
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tagKey": {
+                    "description": "The field name to inject tag",
+                    "type": "string"
+                  },
+                  "timeKey": {
+                    "description": "The field name to inject time",
+                    "type": "string"
+                  },
+                  "workerIdKey": {
+                    "description": "The field name to inject worker_id",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kafka": {
+                "description": "out_kafka plugin",
+                "properties": {
+                  "brokers": {
+                    "description": "The list of all seed brokers, with their host and port information. Default: localhost:9092",
+                    "type": "string"
+                  },
+                  "compressionCodec": {
+                    "description": "The codec the producer uses to compress messages (default: nil).",
+                    "enum": [
+                      "gzip",
+                      "snappy"
+                    ],
+                    "type": "string"
+                  },
+                  "defaultTopic": {
+                    "description": "The name of the default topic. (default: nil)",
+                    "type": "string"
+                  },
+                  "requiredAcks": {
+                    "description": "The number of acks required per request.",
+                    "type": "integer"
+                  },
+                  "topicKey": {
+                    "description": "The field name for the target topic. If the field value is app, this plugin writes events to the app topic.",
+                    "type": "string"
+                  },
+                  "useEventTime": {
+                    "description": "Set fluentd event time to Kafka's CreateTime.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "loki": {
+                "description": "out_loki plugin",
+                "properties": {
+                  "bearerTokenFile": {
+                    "description": "Set path to file with bearer authentication token\nCan be used as alterntative to HTTP basic authentication",
+                    "type": "string"
+                  },
+                  "dropSingleKey": {
+                    "description": "If a record only has 1 key, then just set the log line to the value and discard the key.",
+                    "type": "boolean"
+                  },
+                  "extractKubernetesLabels": {
+                    "description": "If set to true, it will add all Kubernetes labels to the Stream labels.",
+                    "type": "boolean"
+                  },
+                  "httpPassword": {
+                    "description": "Password for user defined in HTTP_User\nSet HTTP basic authentication password",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpUser": {
+                    "description": "Set HTTP basic authentication user name.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "includeThreadLabel": {
+                    "description": "Whether or not to include the fluentd_thread label when multiple threads are used for flushing",
+                    "type": "boolean"
+                  },
+                  "insecure": {
+                    "description": "Disable certificate validation",
+                    "type": "boolean"
+                  },
+                  "labelKeys": {
+                    "description": "Optional list of record keys that will be placed as stream labels.\nThis configuration property is for records key only.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "description": "Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs.\nIn addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "lineFormat": {
+                    "description": "Format to use when flattening the record to a log line. Valid values are json or key_value.\nIf set to json,  the log line sent to Loki will be the Fluentd record dumped as JSON.\nIf set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.",
+                    "enum": [
+                      "json",
+                      "key_value"
+                    ],
+                    "type": "string"
+                  },
+                  "removeKeys": {
+                    "description": "Optional list of record keys that will be removed from stream labels.\nThis configuration property is for records key only.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tenantID": {
+                    "description": "Tenant ID used by default to push logs to Loki.\nIf omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tlsCaCertFile": {
+                    "description": "TlsCaCert defines the CA certificate file for TLS.",
+                    "type": "string"
+                  },
+                  "tlsClientCertFile": {
+                    "description": "TlsClientCert defines the client certificate file for TLS.",
+                    "type": "string"
+                  },
+                  "tlsPrivateKeyFile": {
+                    "description": "TlsPrivateKey defines the client private key file for TLS.",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "Loki URL.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "opensearch": {
+                "description": "out_opensearch plugin",
+                "properties": {
+                  "host": {
+                    "description": "The hostname of your Opensearch node (default: localhost).",
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "description": "Hosts defines a list of hosts if you want to connect to more than one Openearch nodes",
+                    "type": "string"
+                  },
+                  "indexName": {
+                    "description": "IndexName defines the placeholder syntax of Fluentd plugin API. See https://docs.fluentd.org/configuration/buffer-section.",
+                    "type": "string"
+                  },
+                  "logstashFormat": {
+                    "description": "If true, Fluentd uses the conventional index name format logstash-%Y.%m.%d (default: false). This option supersedes the index_name option.",
+                    "type": "boolean"
+                  },
+                  "logstashPrefix": {
+                    "description": "LogstashPrefix defines the logstash prefix index name to write events when logstash_format is true (default: logstash).",
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "Optional, The login credentials to connect to Opensearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path defines the REST API endpoint of Opensearch to post write requests (default: nil).",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "The port number of your Opensearch node (default: 9200).",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "scheme": {
+                    "description": "Specify https if your Opensearch endpoint supports SSL (default: http).",
+                    "type": "string"
+                  },
+                  "sslVerify": {
+                    "description": "Optional, Force certificate validation",
+                    "type": "boolean"
+                  },
+                  "user": {
+                    "description": "Optional, The login credentials to connect to Opensearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "s3": {
+                "description": "out_s3 plugin",
+                "properties": {
+                  "awsKeyId": {
+                    "description": "The AWS access key id.",
+                    "type": "string"
+                  },
+                  "awsSecKey": {
+                    "description": "The AWS secret key.",
+                    "type": "string"
+                  },
+                  "forcePathStyle": {
+                    "description": "This prevents AWS SDK from breaking endpoint URL",
+                    "type": "boolean"
+                  },
+                  "path": {
+                    "description": "The path prefix of the files on S3.",
+                    "type": "string"
+                  },
+                  "proxyUri": {
+                    "description": "The proxy URL.",
+                    "type": "string"
+                  },
+                  "s3Bucket": {
+                    "description": "The Amazon S3 bucket name.",
+                    "type": "string"
+                  },
+                  "s3Endpoint": {
+                    "description": "The endpoint URL (like \"http://localhost:9000/\")",
+                    "type": "string"
+                  },
+                  "s3ObjectKeyFormat": {
+                    "description": "The actual S3 path. This is interpolated to the actual path.",
+                    "type": "string"
+                  },
+                  "s3Region": {
+                    "description": "The Amazon S3 region name",
+                    "type": "string"
+                  },
+                  "sseCustomerAlgorithm": {
+                    "description": "The AWS KMS enctyption algorithm.",
+                    "type": "string"
+                  },
+                  "sseCustomerKey": {
+                    "description": "The AWS KMS key.",
+                    "type": "string"
+                  },
+                  "sseCustomerKeyMd5": {
+                    "description": "The AWS KMS key MD5.",
+                    "type": "string"
+                  },
+                  "ssekmsKeyId": {
+                    "description": "The AWS KMS key ID.",
+                    "type": "string"
+                  },
+                  "sslVerifyPeer": {
+                    "description": "Verify the SSL certificate of the endpoint.",
+                    "type": "boolean"
+                  },
+                  "storeAs": {
+                    "description": "The compression type.",
+                    "enum": [
+                      "gzip",
+                      "lzo",
+                      "json",
+                      "txt"
+                    ],
+                    "type": "string"
+                  },
+                  "timeSliceFormat": {
+                    "description": "This timestamp is added to each file name",
+                    "type": "string"
+                  },
+                  "useServerSideEncryption": {
+                    "description": "the following parameters are for S3 kms https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdout": {
+                "description": "out_stdout plugin",
+                "type": "object"
+              },
+              "tag": {
+                "description": "Which tag to be matched.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ClusterOutputStatus defines the observed state of ClusterOutput",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/clusteroutput_v1alpha2.json
+++ b/fluentd.fluent.io/clusteroutput_v1alpha2.json
@@ -1,0 +1,4769 @@
+{
+  "description": "ClusterOutput is the Schema for the cluster-level outputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OutputSpec defines the desired state of ClusterOutput",
+      "properties": {
+        "alias": {
+          "description": "A user friendly alias name for this output plugin.\nUsed in metrics for distinction of each configured output.",
+          "type": "string"
+        },
+        "azureBlob": {
+          "description": "AzureBlob defines AzureBlob Output Configuration",
+          "properties": {
+            "accountName": {
+              "description": "Azure Storage account name",
+              "type": "string"
+            },
+            "autoCreateContainer": {
+              "description": "Creates container if ContainerName is not set.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "blobType": {
+              "description": "Specify the desired blob type. Must be `appendblob` or `blockblob`",
+              "enum": [
+                "appendblob",
+                "blockblob"
+              ],
+              "type": "string"
+            },
+            "containerName": {
+              "description": "Name of the container that will contain the blobs",
+              "type": "string"
+            },
+            "emulatorMode": {
+              "description": "Optional toggle to use an Azure emulator",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "HTTP Service of the endpoint (if using EmulatorMode)",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Optional path to store the blobs.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the Azure Storage Shared Key to authenticate against the storage account",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Enable/Disable TLS Encryption. Azure services require TLS to be enabled.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "accountName",
+            "containerName",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azureLogAnalytics": {
+          "description": "AzureLogAnalytics defines AzureLogAnalytics Output Configuration",
+          "properties": {
+            "customerID": {
+              "description": "Customer ID or Workspace ID",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logType": {
+              "description": "Name of the event type.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the primary or the secondary client authentication key",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeGenerated": {
+              "description": "If set, overrides the timeKey value with the `time-generated-field` HTTP header value.",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Specify the name of the key where the timestamp is stored.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "customerID",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudWatch": {
+          "description": "CloudWatch defines CloudWatch Output Configuration",
+          "properties": {
+            "autoCreateGroup": {
+              "description": "Automatically create the log group. Defaults to False.",
+              "type": "boolean"
+            },
+            "autoRetryRequests": {
+              "description": "Automatically retry failed requests to CloudWatch once. Defaults to True.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Custom endpoint for CloudWatch logs API",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API.",
+              "type": "string"
+            },
+            "logFormat": {
+              "description": "Optional parameter to tell CloudWatch the format of the data",
+              "type": "string"
+            },
+            "logGroupName": {
+              "description": "Name of Cloudwatch Log Group to send log records to",
+              "type": "string"
+            },
+            "logGroupTemplate": {
+              "description": "Template for Log Group name, overrides LogGroupName if set.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "If set, only the value of the key will be sent to CloudWatch",
+              "type": "string"
+            },
+            "logRetentionDays": {
+              "description": "Number of days logs are retained for",
+              "enum": [
+                1,
+                3,
+                5,
+                7,
+                14,
+                30,
+                60,
+                90,
+                120,
+                150,
+                180,
+                365,
+                400,
+                545,
+                731,
+                1827,
+                3653
+              ],
+              "format": "int32",
+              "type": "integer"
+            },
+            "logStreamName": {
+              "description": "The name of the CloudWatch Log Stream to send log records to",
+              "type": "string"
+            },
+            "logStreamPrefix": {
+              "description": "Prefix for the Log Stream name. Not compatible with LogStreamName setting",
+              "type": "string"
+            },
+            "logStreamTemplate": {
+              "description": "Template for Log Stream name. Overrides LogStreamPrefix and LogStreamName if set.",
+              "type": "string"
+            },
+            "metricDimensions": {
+              "description": "Optional lists of lists for dimension keys to be added to all metrics. Use comma separated strings\nfor one list of dimensions and semicolon separated strings for list of lists dimensions.",
+              "type": "string"
+            },
+            "metricNamespace": {
+              "description": "Optional string to represent the CloudWatch namespace.",
+              "type": "string"
+            },
+            "region": {
+              "description": "AWS Region",
+              "type": "string"
+            },
+            "roleArn": {
+              "description": "Role ARN to use for cross-account access",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom STS endpoint for the AWS STS API",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customPlugin": {
+          "description": "CustomPlugin defines Custom Output configuration.",
+          "properties": {
+            "config": {
+              "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+              "type": "string"
+            },
+            "yamlConfig": {
+              "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "datadog": {
+          "description": "DataDog defines DataDog Output configuration.",
+          "properties": {
+            "apikey": {
+              "description": "Your Datadog API key.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "compress": {
+              "description": "Compress  the payload in GZIP format.\nDatadog supports and recommends setting this to gzip.",
+              "type": "string"
+            },
+            "dd_message_key": {
+              "description": "By default, the plugin searches for the key 'log' and remap the value to the key 'message'. If the property is set, the plugin will search the property name key.",
+              "type": "string"
+            },
+            "dd_service": {
+              "description": "The human readable name for your service generating the logs.",
+              "type": "string"
+            },
+            "dd_source": {
+              "description": "A human readable name for the underlying technology of your service.",
+              "type": "string"
+            },
+            "dd_tags": {
+              "description": "The tags you want to assign to your logs in Datadog.",
+              "type": "string"
+            },
+            "host": {
+              "description": "Host is the Datadog server where you are sending your logs.",
+              "type": "string"
+            },
+            "include_tag_key": {
+              "description": "If enabled, a tag is appended to output. The key name is used tag_key property.",
+              "type": "boolean"
+            },
+            "json_date_key": {
+              "description": "Date key name for output.",
+              "type": "string"
+            },
+            "provider": {
+              "description": "To activate the remapping, specify configuration flag provider.",
+              "type": "string"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy.",
+              "type": "string"
+            },
+            "tag_key": {
+              "description": "The key name of tag. If include_tag_key is false, This property is ignored.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "TLS controls whether to use end-to-end security communications security protocol.\nDatadog recommends setting this to on.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "es": {
+          "description": "Elasticsearch defines Elasticsearch Output configuration.",
+          "properties": {
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsAuthSecret": {
+              "description": "AWSAuthSecret Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon ES cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the Elasticsearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "cloudAuth": {
+              "description": "Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "type": "string"
+            },
+            "cloudAuthSecret": {
+              "description": "CloudAuthSecret Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cloudID": {
+              "description": "If you are using Elastic's Elasticsearch Service you can specify the cloud_id of the cluster running.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying ES.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Elasticsearch instance",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for Elastic X-Pack access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Elasticsearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve Elasticsearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "Newer versions of Elasticsearch allows setting up filters called pipelines.\nThis option allows defining which pipeline the database should use.\nFor performance reasons is strongly suggested parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target Elasticsearch instance",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "string"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "file": {
+          "description": "File defines File Output configuration.",
+          "properties": {
+            "delimiter": {
+              "description": "The character to separate each pair. Applicable only if format is csv or ltsv.",
+              "type": "string"
+            },
+            "file": {
+              "description": "Set file name to store the records. If not set, the file name will be the tag associated with the records.",
+              "type": "string"
+            },
+            "format": {
+              "description": "The format of the file content. See also Format section. Default: out_file.",
+              "enum": [
+                "out_file",
+                "plain",
+                "csv",
+                "ltsv",
+                "template"
+              ],
+              "type": "string"
+            },
+            "labelDelimiter": {
+              "description": "The character to separate each pair. Applicable only if format is ltsv.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory.",
+              "type": "string"
+            },
+            "template": {
+              "description": "The format string. Applicable only if format is template.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "firehose": {
+          "description": "Firehose defines Firehose Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues.",
+              "type": "boolean"
+            },
+            "dataKeys": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited.",
+              "type": "string"
+            },
+            "deliveryStream": {
+              "description": "The name of the Kinesis Firehose Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis Firehose API.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Firehose. If you specify a key name with this option, then only the value of that key will be sent to Firehose. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Firehose.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom endpoint for the STS API; used to assume your custom role provided with role_arn.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default, the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, %Y-%m-%dT%H *string This option is used with time_key. You can also use %L for milliseconds and %f for microseconds. If you are using ECS FireLens, make sure you are running Amazon ECS Container Agent v1.42.0 or later, otherwise the timestamps associated with your container logs will only have second precision.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "deliveryStream",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forward": {
+          "description": "Forward defines Forward Output configuration.",
+          "properties": {
+            "emptySharedKey": {
+              "description": "Use this option to connect to Fluentd with a zero-length secret.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "password": {
+              "description": "Specify the password corresponding to the username.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "requireAckResponse": {
+              "description": "Send \"chunk\"-option and wait for \"ack\" response from server.\nEnables at-least-once and receiving server can control rate of traffic.\n(Requires Fluentd v0.14.0+ server)",
+              "type": "boolean"
+            },
+            "selfHostname": {
+              "description": "Default value of the auto-generated certificate common name (CN).",
+              "type": "string"
+            },
+            "sendOptions": {
+              "description": "Always send options (with \"size\"=count of messages)",
+              "type": "boolean"
+            },
+            "sharedKey": {
+              "description": "A key string known by the remote Fluentd used for authorization.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Overwrite the tag as we transmit. This allows the receiving pipeline start\nfresh, or to attribute source.",
+              "type": "string"
+            },
+            "timeAsInteger": {
+              "description": "Set timestamps in integer format, it enable compatibility mode for Fluentd v0.12 series.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "username": {
+              "description": "Specify the username to present to a Fluentd server that enables user_auth.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gelf": {
+          "description": "Gelf defines GELF Output configuration.",
+          "properties": {
+            "compress": {
+              "description": "If transport protocol is udp, it defines if UDP packets should be compressed.",
+              "type": "boolean"
+            },
+            "fullMessageKey": {
+              "description": "FullMessageKey is the key to use as the long message that can i.e. contain a backtrace.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Graylog server.",
+              "type": "string"
+            },
+            "hostKey": {
+              "description": "HostKey is the key which its value is used as the name of the host, source or application that sent this message.",
+              "type": "string"
+            },
+            "levelKey": {
+              "description": "LevelKey is the key to be used as the log level.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "The protocol to use (tls, tcp or udp).",
+              "enum": [
+                "tls",
+                "tcp",
+                "udp"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "packetSize": {
+              "description": "If transport protocol is udp, it sets the size of packets to be sent.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "port": {
+              "description": "The port that the target Graylog server is listening on.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "shortMessageKey": {
+              "description": "ShortMessageKey is the key to use as the short message.",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "TimestampKey is the key which its value is used as the timestamp of the message.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "http": {
+          "description": "HTTP defines HTTP Output configuration.",
+          "properties": {
+            "allowDuplicatedHeaders": {
+              "description": "Specify if duplicated headers are allowed.\nIf a duplicated header is found, the latest key/value set is preserved.",
+              "type": "boolean"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "type": "string"
+            },
+            "format": {
+              "description": "Specify the data format to be used in the HTTP request body, by default it uses msgpack.\nOther supported formats are json, json_stream and json_lines and gelf.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_stream",
+                "json_lines",
+                "gelf"
+              ],
+              "type": "string"
+            },
+            "gelfFullMessageKey": {
+              "description": "Specify the key to use for the full message in gelf format",
+              "type": "string"
+            },
+            "gelfHostKey": {
+              "description": "Specify the key to use for the host in gelf format",
+              "type": "string"
+            },
+            "gelfLevelKey": {
+              "description": "Specify the key to use for the level in gelf format",
+              "type": "string"
+            },
+            "gelfShortMessageKey": {
+              "description": "Specify the key to use as the short message in gelf format",
+              "type": "string"
+            },
+            "gelfTimestampKey": {
+              "description": "Specify the key to use for timestamp in gelf format",
+              "type": "string"
+            },
+            "headerTag": {
+              "description": "Specify an optional HTTP header field for the original message tag.",
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Basic Auth Password. Requires HTTP_User to be set",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Server",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://host:port.\nNote that https is not supported yet.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "HTTP output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "influxDB": {
+          "description": "InfluxDB defines InfluxDB Output configuration.",
+          "properties": {
+            "autoTags": {
+              "description": "Automatically tag keys where value is string.",
+              "type": "boolean"
+            },
+            "bucket": {
+              "description": "InfluxDB bucket name where records will be inserted - if specified, database is ignored and v2 of API is used",
+              "type": "string"
+            },
+            "database": {
+              "description": "InfluxDB database name where records will be inserted.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target InfluxDB service.",
+              "format": "ipv6",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpToken": {
+              "description": "Authentication token used with InfluxDB v2 - if specified, both HTTPUser and HTTPPasswd are ignored",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username for HTTP Basic Authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "org": {
+              "description": "InfluxDB organization name where the bucket is (v2 only)",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target InfluxDB service.",
+              "format": "int32",
+              "maximum": 65536,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sequenceTag": {
+              "description": "The name of the tag whose value is incremented for the consecutive simultaneous events.",
+              "type": "string"
+            },
+            "tagKeys": {
+              "description": "List of keys that needs to be tagged",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tagListKey": {
+              "description": "Key of the string array optionally contained within each log record that contains tag keys for that record",
+              "type": "string"
+            },
+            "tagsListEnabled": {
+              "description": "Dynamically tag keys which are in the string array at Tags_List_Key key.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafka": {
+          "description": "Kafka defines Kafka Output configuration.",
+          "properties": {
+            "brokers": {
+              "description": "Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092.",
+              "type": "string"
+            },
+            "dynamicTopic": {
+              "description": "adds unknown topics (found in Topic_Key) to Topics. So in Topics only a default topic needs to be configured",
+              "type": "boolean"
+            },
+            "format": {
+              "description": "Specify data format, options available: json, msgpack.",
+              "type": "string"
+            },
+            "messageKey": {
+              "description": "Optional key to store the message",
+              "type": "string"
+            },
+            "messageKeyField": {
+              "description": "If set, the value of Message_Key_Field in the record will indicate the message key.\nIf not set nor found in the record, Message_Key will be used (if set).",
+              "type": "string"
+            },
+            "queueFullRetries": {
+              "description": "Fluent Bit queues data into rdkafka library,\nif for some reason the underlying library cannot flush the records the queue might fills up blocking new addition of records.\nThe queue_full_retries option set the number of local retries to enqueue the data.\nThe default value is 10 times, the interval between each retry is 1 second.\nSetting the queue_full_retries value to 0 set's an unlimited number of retries.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rdkafka": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "{property} can be any librdkafka properties",
+              "type": "object"
+            },
+            "timestampFormat": {
+              "description": "iso8601 or double",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "Set the key to store the record timestamp",
+              "type": "string"
+            },
+            "topicKey": {
+              "description": "If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use.\nE.g: if Topic_Key is router and the record is {\"key1\": 123, \"router\": \"route_2\"},\nFluent Bit will use topic route_2. Note that if the value of Topic_Key is not present in Topics,\nthen by default the first topic in the Topics list will indicate the topic to be used.",
+              "type": "string"
+            },
+            "topics": {
+              "description": "Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka.\nIf only one topic is set, that one will be used for all records.\nInstead if multiple topics exists, the one set in the record by Topic_Key will be used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kinesis": {
+          "description": "Kinesis defines Kinesis Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis API.",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Kinesis.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stream": {
+              "description": "The name of the Kinesis Streams Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond precision with '%3N' and supports nanosecond precision with '%9N' and '%L'; for example, adding '%3N' to support millisecond '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region",
+            "stream"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "description": "Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace, Defaults to the SERVICE section's Log_Level",
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "loki": {
+          "description": "Loki defines Loki Output configuration.",
+          "properties": {
+            "autoKubernetesLabels": {
+              "description": "If set to true, it will add all Kubernetes labels to the Stream labels.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "bearerToken": {
+              "description": "Set bearer token authentication token value.\nCan be used as alterntative to HTTP basic authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dropSingleKey": {
+              "description": "If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Loki hostname or IP address.",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User\nSet HTTP basic authentication password",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Set HTTP basic authentication user name.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "labelKeys": {
+              "description": "Optional list of record keys that will be placed as stream labels.\nThis configuration property is for records key only.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelMapPath": {
+              "description": "Specify the label map file path. The file defines how to extract labels from each record.",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs.\nIn addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "lineFormat": {
+              "description": "Format to use when flattening the record to a log line. Valid values are json or key_value.\nIf set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON.\nIf set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.",
+              "enum": [
+                "json",
+                "key_value"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "Loki TCP port",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "removeKeys": {
+              "description": "Optional list of keys to remove.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tenantID": {
+              "description": "Tenant ID used by default to push logs to Loki.\nIf omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tenantIDKey": {
+              "description": "Specify the name of the key from the original record that contains the Tenant ID.\nThe value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify a custom HTTP URI. It must start with forward slash.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        },
+        "null": {
+          "description": "Null defines Null Output configuration.",
+          "type": "object"
+        },
+        "opensearch": {
+          "description": "OpenSearch defines OpenSearch Output configuration.",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the OpenSearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "compress": {
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying OpenSearch.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "OpenSearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve OpenSearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "OpenSearch allows to setup filters called pipelines.\nThis option allows to define which pipeline the database should use.\nFor performance reasons is strongly suggested to do parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `9200`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "boolean"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "opentelemetry": {
+          "description": "OpenTelemetry defines OpenTelemetry Output configuration.",
+          "properties": {
+            "addLabel": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields.",
+              "type": "object"
+            },
+            "header": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log.",
+              "type": "boolean"
+            },
+            "logsBodyKeyAttributes": {
+              "description": "If true, remaining unmatched keys are added as attributes.",
+              "type": "boolean"
+            },
+            "logsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for logs, e.g: /v1/logs",
+              "type": "string"
+            },
+            "metricsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for metrics, e.g: /v1/metrics",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `80`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT. Note that HTTPS is not currently supported.\nIt is recommended not to set this and to configure the HTTP proxy environment variables instead as they support both HTTP and HTTPS.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tracesUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for traces, e.g: /v1/traces",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processors": {
+          "description": "Processors defines the processors configuration",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "prometheusExporter": {
+          "description": "PrometheusExporter_types defines Prometheus exporter configuration to expose metrics from Fluent Bit.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "This is the port Fluent Bit will bind to when hosting prometheus metrics.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "prometheusRemoteWrite": {
+          "description": "PrometheusRemoteWrite_types defines Prometheus Remote Write configuration.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 127.0.0.1",
+              "type": "string"
+            },
+            "httpPasswd": {
+              "description": "Basic Auth Password.\nRequires HTTP_user to be se",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log,default: false",
+              "type": "boolean"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Serveri, default:80",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something ,default: /",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0,default : 2",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "retry_limit": {
+          "description": "RetryLimit represents configuration for the scheduler which can be set independently on each output section.\nThis option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.",
+          "type": "string"
+        },
+        "s3": {
+          "description": "S3 defines S3 Output configuration.",
+          "properties": {
+            "AutoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once.",
+              "type": "boolean"
+            },
+            "Bucket": {
+              "description": "S3 Bucket name",
+              "type": "string"
+            },
+            "CannedAcl": {
+              "description": "Predefined Canned ACL Policy for S3 objects.",
+              "type": "string"
+            },
+            "Compression": {
+              "description": "Compression type for S3 objects.",
+              "type": "string"
+            },
+            "ContentType": {
+              "description": "A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header.",
+              "type": "string"
+            },
+            "Endpoint": {
+              "description": "Custom endpoint for the S3 API.",
+              "type": "string"
+            },
+            "ExternalId": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "JsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681)",
+              "type": "string"
+            },
+            "JsonDateKey": {
+              "description": "Specify the name of the time key in the output record. To disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "LogKey": {
+              "description": "By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3.",
+              "type": "string"
+            },
+            "PreserveDataOrdering": {
+              "description": "Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads.",
+              "type": "boolean"
+            },
+            "Profile": {
+              "description": "Option to specify an AWS Profile for credentials.",
+              "type": "string"
+            },
+            "Region": {
+              "description": "The AWS region of your S3 bucket",
+              "type": "string"
+            },
+            "RetryLimit": {
+              "description": "Integer value to set the maximum number of retries allowed.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "RoleArn": {
+              "description": "ARN of an IAM role to assume",
+              "type": "string"
+            },
+            "S3KeyFormat": {
+              "description": "Format string for keys in S3.",
+              "type": "string"
+            },
+            "S3KeyFormatTagDelimiters": {
+              "description": "A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option.",
+              "type": "string"
+            },
+            "SendContentMd5": {
+              "description": "Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled.",
+              "type": "boolean"
+            },
+            "StaticFilePath": {
+              "description": "Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true.",
+              "type": "boolean"
+            },
+            "StorageClass": {
+              "description": "Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class.",
+              "type": "string"
+            },
+            "StoreDir": {
+              "description": "Directory to locally buffer data before sending.",
+              "type": "string"
+            },
+            "StoreDirLimitSize": {
+              "description": "The size of the limitation for disk usage in S3.",
+              "type": "string"
+            },
+            "StsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "TotalFileSize": {
+              "description": "Specifies the size of files in S3. Minimum size is 1M. With use_put_object On the maximum size is 1G. With multipart upload mode, the maximum size is 50G.",
+              "type": "string"
+            },
+            "UploadChunkSize": {
+              "description": "The size of each 'part' for multipart uploads. Max: 50M",
+              "type": "string"
+            },
+            "UploadTimeout": {
+              "description": "Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour.",
+              "type": "string"
+            },
+            "UsePutObject": {
+              "description": "Use the S3 PutObject API, instead of the multipart upload API.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "Bucket",
+            "Region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "splunk": {
+          "description": "Splunk defines Splunk Output Configuration",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value `2` is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "channel": {
+              "description": "Specify X-Splunk-Request-Channel Header for the HTTP Event Collector interface.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. The only available option is gzip.",
+              "type": "string"
+            },
+            "eventFields": {
+              "description": "Set event fields for the record. This option is an array and the format is \"key_name\nrecord_accessor_pattern\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "eventHost": {
+              "description": "Specify the key name that contains the host value. This option allows a record accessors pattern.",
+              "type": "string"
+            },
+            "eventIndex": {
+              "description": "The name of the index by which the event data is to be indexed.",
+              "type": "string"
+            },
+            "eventIndexKey": {
+              "description": "Set a record key that will populate the index field. If the key is found, it will have precedence\nover the value set in event_index.",
+              "type": "string"
+            },
+            "eventKey": {
+              "description": "Specify the key name that will be used to send a single value as part of the record.",
+              "type": "string"
+            },
+            "eventSource": {
+              "description": "Set the source value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetype": {
+              "description": "Set the sourcetype value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetypeKey": {
+              "description": "Set a record key that will populate 'sourcetype'. If the key is found, it will have precedence\nover the value set in event_sourcetype.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpBufferSize": {
+              "description": "Buffer size used to receive Splunk HTTP responses: Default `2M`",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "httpDebugBadRequest": {
+              "description": "If the HTTP server response code is 400 (bad request) and this flag is enabled, it will print the full HTTP request\nand response to the stdout interface. This feature is available for debugging purposes.",
+              "type": "boolean"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target Splunk instance, default `8088`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "splunkSendRaw": {
+              "description": "When enabled, the record keys and values are set in the top level of the map instead of under the event key. Refer to\nthe Sending Raw Events section from the docs more details to make this option work properly.",
+              "type": "boolean"
+            },
+            "splunkToken": {
+              "description": "Specify the Authentication Token for the HTTP Event Collector interface.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stackdriver": {
+          "description": "Stackdriver defines Stackdriver Output Configuration",
+          "properties": {
+            "autoformatStackdriverTrace": {
+              "description": "Rewrite the trace field to be formatted for use with GCP Cloud Trace",
+              "type": "boolean"
+            },
+            "customK8sRegex": {
+              "description": "A custom regex to extract fields from the local_resource_id of the logs",
+              "type": "string"
+            },
+            "exportToProjectID": {
+              "description": "The GCP Project that should receive the logs",
+              "type": "string"
+            },
+            "googleServiceCredentials": {
+              "description": "Path to GCP Credentials JSON file",
+              "type": "string"
+            },
+            "job": {
+              "description": "Identifier for a grouping of tasks. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "k8sClusterLocation": {
+              "description": "Location of the cluster that contains the pods/nodes. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "k8sClusterName": {
+              "description": "Name of the cluster that the pod is running in. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Optional list of comma separated of strings for key/value pairs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelsKey": {
+              "description": "Used by Stackdriver to find related labels and extract them to LogEntry Labels",
+              "type": "string"
+            },
+            "location": {
+              "description": "GCP/AWS region to store data. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "logNameKey": {
+              "description": "The value of this field is set as the logName field in Stackdriver",
+              "type": "string"
+            },
+            "metadataServer": {
+              "description": "Metadata Server Prefix",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace identifier. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "nodeID": {
+              "description": "Node identifier within the namespace. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Set resource types of data",
+              "type": "string"
+            },
+            "resourceLabels": {
+              "description": "Optional list of comma seperated strings. Setting these fields overrides the Stackdriver monitored resource API values",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "serviceAccountEmail": {
+              "description": "Email associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountSecret": {
+              "description": "Private Key associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "severityKey": {
+              "description": "Specify the key that contains the severity information for the logs",
+              "type": "string"
+            },
+            "tagPrefix": {
+              "description": "Used to validate the tags of logs that when the Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "taskID": {
+              "description": "Identifier for a task within a namespace. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Number of dedicated threads for the Stackdriver Output Plugin",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stdout": {
+          "description": "Stdout defines Stdout Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.",
+              "enum": [
+                "double",
+                "iso8601",
+                "epoch"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the date field in output.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syslog": {
+          "description": "Syslog defines Syslog Output configuration.",
+          "properties": {
+            "host": {
+              "description": "Host domain or IP address of the remote Syslog server.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode of the desired transport type, the available options are tcp, tls and udp.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP or UDP port of the remote Syslog server.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "syslogAppnameKey": {
+              "description": "Key name from the original record that contains the application name that generated the message.",
+              "type": "string"
+            },
+            "syslogFacilityKey": {
+              "description": "Key from the original record that contains the Syslog facility number.",
+              "type": "string"
+            },
+            "syslogFormat": {
+              "description": "Syslog protocol format to use, the available options are rfc3164 and rfc5424.",
+              "type": "string"
+            },
+            "syslogHostnameKey": {
+              "description": "Key name from the original record that contains the hostname that generated the message.",
+              "type": "string"
+            },
+            "syslogMaxSize": {
+              "description": "Maximum size allowed per message, in bytes.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "syslogMessageIDKey": {
+              "description": "Key name from the original record that contains the Message ID associated to the message.",
+              "type": "string"
+            },
+            "syslogMessageKey": {
+              "description": "Key key name that contains the message to deliver.",
+              "type": "string"
+            },
+            "syslogProcessIDKey": {
+              "description": "Key name from the original record that contains the Process ID that generated the message.",
+              "type": "string"
+            },
+            "syslogSDKey": {
+              "description": "Key name from the original record that contains the Structured Data (SD) content.",
+              "type": "string"
+            },
+            "syslogSeverityKey": {
+              "description": "Key from the original record that contains the Syslog severity number.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Syslog output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tcp": {
+          "description": "TCP defines TCP Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "enum": [
+                "double",
+                "epoch",
+                "iso8601"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "TSpecify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/filter_v1alpha1.json
+++ b/fluentd.fluent.io/filter_v1alpha1.json
@@ -1,0 +1,561 @@
+{
+  "description": "Filter is the Schema for the filters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FilterSpec defines the desired state of Filter",
+      "properties": {
+        "filters": {
+          "items": {
+            "description": "Filter defines all available filter plugins and their parameters.",
+            "properties": {
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "grep": {
+                "description": "The filter_grep filter plugin",
+                "properties": {
+                  "and": {
+                    "items": {
+                      "description": "And defines the parameters for the \"and\" plugin",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude defines the parameters for the exclude plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "regexp": {
+                          "description": "Regexp defines the parameters for the regexp plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "exclude": {
+                    "items": {
+                      "description": "Exclude defines the parameters for the exclude plugin",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "or": {
+                    "items": {
+                      "description": "Or defines the parameters for the \"or\" plugin",
+                      "properties": {
+                        "exclude": {
+                          "description": "Exclude defines the parameters for the exclude plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "regexp": {
+                          "description": "Regexp defines the parameters for the regexp plugin",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "regexp": {
+                    "items": {
+                      "description": "Regexp defines the parameters for the regexp plugin",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "parser": {
+                "description": "The filter_parser filter plugin",
+                "properties": {
+                  "emitInvalidRecordToError": {
+                    "description": "Emits invalid record to @ERROR label. Invalid cases are: key does not exist;the format is not matched;an unexpected error.\nIf you want to ignore these errors, set false.",
+                    "type": "boolean"
+                  },
+                  "hashValueField": {
+                    "description": "Stores the parsed values as a hash value in a field.",
+                    "type": "string"
+                  },
+                  "injectKeyPrefix": {
+                    "description": "Stores the parsed values with the specified key name prefix.",
+                    "type": "string"
+                  },
+                  "keyName": {
+                    "description": "Specifies the field name in the record to parse. Required parameter.\ni.e: If set keyName to log, {\"key\":\"value\",\"log\":\"{\\\"time\\\":1622473200,\\\"user\\\":1}\"} => {\"user\":1}",
+                    "type": "string"
+                  },
+                  "parse": {
+                    "description": "Parse defines various parameters for the parse plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "removeKeyNameField": {
+                    "description": "Removes key_name field when parsing is succeeded.",
+                    "type": "boolean"
+                  },
+                  "replaceInvalidSequence": {
+                    "description": "If true, invalid string is replaced with safe characters and re-parse it.",
+                    "type": "boolean"
+                  },
+                  "reserveData": {
+                    "description": "Keeps the original key-value pair in the parsed result. Default is false.\ni.e: If set keyName to log, reverseData to true,\n{\"key\":\"value\",\"log\":\"{\\\"user\\\":1,\\\"num\\\":2}\"} => {\"key\":\"value\",\"log\":\"{\\\"user\\\":1,\\\"num\\\":2}\",\"user\":1,\"num\":2}",
+                    "type": "boolean"
+                  },
+                  "reserveTime": {
+                    "description": "Keeps the original event time in the parsed result. Default is false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "keyName",
+                  "parse"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "recordTransformer": {
+                "description": "The filter_record_transformer filter plugin",
+                "properties": {
+                  "autoTypecast": {
+                    "description": "Automatically casts the field types. Default is false.\nThis option is effective only for field values comprised of a single placeholder.",
+                    "type": "boolean"
+                  },
+                  "enableRuby": {
+                    "description": "When set to true, the full Ruby syntax is enabled in the ${...} expression. The default value is false.\ni.e: jsonized_record ${record.to_json}",
+                    "type": "boolean"
+                  },
+                  "keepKeys": {
+                    "description": "A list of keys to keep. Only relevant if renew_record is set to true.",
+                    "type": "string"
+                  },
+                  "records": {
+                    "items": {
+                      "description": "The parameters inside <record> directives are considered to be new key-value pairs",
+                      "properties": {
+                        "key": {
+                          "description": "New field can be defined as key",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "The value must from Record properties.\nSee https://docs.fluentd.org/filter/record_transformer#less-than-record-greater-than-directive",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "removeKeys": {
+                    "description": "A list of keys to delete. Supports nested field via record_accessor syntax since v1.1.0.",
+                    "type": "string"
+                  },
+                  "renewRecord": {
+                    "description": "By default, the record transformer filter mutates the incoming data. However, if this parameter is set to true, it modifies a new empty hash instead.",
+                    "type": "boolean"
+                  },
+                  "renewTimeKey": {
+                    "description": "renew_time_key foo overwrites the time of events with a value of the record field foo if exists. The value of foo must be a Unix timestamp.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdout": {
+                "description": "The filter_stdout filter plugin",
+                "properties": {
+                  "format": {
+                    "description": "The format section",
+                    "properties": {
+                      "delimiter": {
+                        "description": "Delimiter for each field.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "newline": {
+                        "description": "Specify newline characters.",
+                        "enum": [
+                          "lf",
+                          "crlf"
+                        ],
+                        "type": "string"
+                      },
+                      "outputTag": {
+                        "description": "Output tag field if true.",
+                        "type": "boolean"
+                      },
+                      "outputTime": {
+                        "description": "Output time field if true.",
+                        "type": "boolean"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "out_file",
+                          "json",
+                          "ltsv",
+                          "csv",
+                          "msgpack",
+                          "hash",
+                          "single_value"
+                        ],
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "inject": {
+                    "description": "The inject section",
+                    "properties": {
+                      "hostname": {
+                        "description": "Hostname value",
+                        "type": "string"
+                      },
+                      "hostnameKey": {
+                        "description": "The field name to inject hostname",
+                        "type": "string"
+                      },
+                      "inline": {
+                        "description": "Time section",
+                        "properties": {
+                          "localtime": {
+                            "description": "If true, uses local time.",
+                            "type": "boolean"
+                          },
+                          "timeFormat": {
+                            "description": "Process value according to the specified format. This is available only when time_type is string",
+                            "type": "string"
+                          },
+                          "timeFormatFallbacks": {
+                            "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                            "type": "string"
+                          },
+                          "timeType": {
+                            "description": "parses/formats value according to this type, default is string",
+                            "enum": [
+                              "float",
+                              "unixtime",
+                              "string",
+                              "mixed"
+                            ],
+                            "type": "string"
+                          },
+                          "timezone": {
+                            "description": "Uses the specified timezone.",
+                            "type": "string"
+                          },
+                          "utc": {
+                            "description": "If true, uses UTC.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tagKey": {
+                        "description": "The field name to inject tag",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "The field name to inject time",
+                        "type": "string"
+                      },
+                      "workerIdKey": {
+                        "description": "The field name to inject worker_id",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "tag": {
+                "description": "Which tag to be matched.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FilterStatus defines the observed state of Filter",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/filter_v1alpha2.json
+++ b/fluentd.fluent.io/filter_v1alpha2.json
@@ -1,0 +1,935 @@
+{
+  "description": "Filter is the Schema for namespace level filter API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FilterSpec defines the desired state of ClusterFilter",
+      "properties": {
+        "filters": {
+          "description": "A set of filter plugins in order.",
+          "items": {
+            "properties": {
+              "aws": {
+                "description": "Aws defines a Aws configuration.",
+                "properties": {
+                  "accountID": {
+                    "description": "The account ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "amiID": {
+                    "description": "The EC2 instance image id.Default is false.",
+                    "type": "boolean"
+                  },
+                  "az": {
+                    "description": "The availability zone; for example, \"us-east-1a\". Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceID": {
+                    "description": "The EC2 instance ID.Default is true.",
+                    "type": "boolean"
+                  },
+                  "ec2InstanceType": {
+                    "description": "The EC2 instance type.Default is false.",
+                    "type": "boolean"
+                  },
+                  "hostName": {
+                    "description": "The hostname for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  },
+                  "imdsVersion": {
+                    "description": "Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2'.",
+                    "enum": [
+                      "v1",
+                      "v2"
+                    ],
+                    "type": "string"
+                  },
+                  "privateIP": {
+                    "description": "The EC2 instance private ip.Default is false.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "vpcID": {
+                    "description": "The VPC ID for current EC2 instance.Default is false.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "customPlugin": {
+                "description": "CustomPlugin defines a Custom plugin configuration.",
+                "properties": {
+                  "config": {
+                    "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+                    "type": "string"
+                  },
+                  "yamlConfig": {
+                    "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "grep": {
+                "description": "Grep defines Grep Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Exclude records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Keep records which field matches the regular expression.\nValue Format: FIELD REGEX",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kubernetes": {
+                "description": "Kubernetes defines Kubernetes Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "annotations": {
+                    "description": "Include Kubernetes resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "bufferSize": {
+                    "description": "Set the buffer size for HTTP client when reading responses from Kubernetes API server.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "cacheUseDockerId": {
+                    "description": "When enabled, metadata will be fetched from K8s when docker_id is changed.",
+                    "type": "boolean"
+                  },
+                  "dnsRetries": {
+                    "description": "DNS lookup retries N times until the network start working",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dnsWaitTime": {
+                    "description": "DNS lookup interval between network status checks",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "dummyMeta": {
+                    "description": "If set, use dummy-meta data (for test/dev purposes)",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingExclude": {
+                    "description": "Allow Kubernetes Pods to exclude their logs from the log processor\n(read more about it in Kubernetes Annotations section).",
+                    "type": "boolean"
+                  },
+                  "k8sLoggingParser": {
+                    "description": "Allow Kubernetes Pods to suggest a pre-defined Parser\n(read more about it in Kubernetes Annotations section)",
+                    "type": "boolean"
+                  },
+                  "keepLog": {
+                    "description": "When Keep_Log is disabled, the log field is removed\nfrom the incoming message once it has been successfully merged\n(Merge_Log must be enabled as well).",
+                    "type": "boolean"
+                  },
+                  "kubeCAFile": {
+                    "description": "CA certificate file",
+                    "type": "string"
+                  },
+                  "kubeCAPath": {
+                    "description": "Absolute path to scan for certificate files",
+                    "type": "string"
+                  },
+                  "kubeMetaCacheTTL": {
+                    "description": "configurable TTL for K8s cached metadata. By default, it is set to 0\nwhich means TTL for cache entries is disabled and cache entries are evicted at random\nwhen capacity is reached. In order to enable this option, you should set the number to a time interval.\nFor example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted.",
+                    "type": "string"
+                  },
+                  "kubeMetaNamespaceCacheTTL": {
+                    "description": "Configurable TTL for K8s cached namespace metadata.\nBy default, it is set to 900 which means a 15min TTL for namespace cache entries.\nSetting this to 0 will mean entries are evicted at random once the cache is full.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "kubeMetaPreloadCacheDir": {
+                    "description": "If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory,\nnamed as namespace-pod.meta",
+                    "type": "string"
+                  },
+                  "kubeTagPrefix": {
+                    "description": "When the source records comes from Tail input plugin,\nthis option allows to specify what's the prefix used in Tail configuration.",
+                    "type": "string"
+                  },
+                  "kubeTokenCommand": {
+                    "description": "Command to get Kubernetes authorization token.\nBy default, it will be NULL and we will use token file to get token.",
+                    "type": "string"
+                  },
+                  "kubeTokenFile": {
+                    "description": "Token file",
+                    "type": "string"
+                  },
+                  "kubeTokenTTL": {
+                    "description": "configurable 'time to live' for the K8s token. By default, it is set to 600 seconds.\nAfter this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.",
+                    "type": "string"
+                  },
+                  "kubeURL": {
+                    "description": "API Server end-point",
+                    "type": "string"
+                  },
+                  "kubeletHost": {
+                    "description": "kubelet host using for HTTP request, this only works when Use_Kubelet set to On.",
+                    "type": "string"
+                  },
+                  "kubeletPort": {
+                    "description": "kubelet port using for HTTP request, this only works when useKubelet is set to On.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "labels": {
+                    "description": "Include Kubernetes resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "mergeLog": {
+                    "description": "When enabled, it checks if the log field content is a JSON string map,\nif so, it append the map fields as part of the log structure.",
+                    "type": "boolean"
+                  },
+                  "mergeLogKey": {
+                    "description": "When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message\nand make a structured representation of it at the same level of the log field in the map.\nNow if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.",
+                    "type": "string"
+                  },
+                  "mergeLogTrim": {
+                    "description": "When Merge_Log is enabled, trim (remove possible \\n or \\r) field values.",
+                    "type": "boolean"
+                  },
+                  "mergeParser": {
+                    "description": "Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.",
+                    "type": "string"
+                  },
+                  "namespaceAnnotations": {
+                    "description": "Include Kubernetes namespace resource annotations in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceLabels": {
+                    "description": "Include Kubernetes namespace resource labels in the extra metadata.",
+                    "type": "boolean"
+                  },
+                  "namespaceMetadataOnly": {
+                    "description": "Include Kubernetes namespace metadata only and no pod metadata.\nIf this is set, the values of Labels and Annotations are ignored.",
+                    "type": "boolean"
+                  },
+                  "regexParser": {
+                    "description": "Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.\nThe parser must be registered in a parsers file (refer to parser filter-kube-test as an example).",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tlsDebug": {
+                    "description": "Debug level between 0 (nothing) and 4 (every detail).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tlsVerify": {
+                    "description": "When enabled, turns on certificate validation when connecting to the Kubernetes API server.",
+                    "type": "boolean"
+                  },
+                  "useJournal": {
+                    "description": "When enabled, the filter reads logs coming in Journald format.",
+                    "type": "boolean"
+                  },
+                  "useKubelet": {
+                    "description": "This is an optional feature flag to get metadata information from kubelet\ninstead of calling Kube Server API to enhance the log.\nThis could mitigate the Kube API heavy traffic issue for large cluster.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logToMetrics": {
+                "description": "LogToMetrics defines a Log to Metrics Filter configuration.",
+                "properties": {
+                  "addLabel": {
+                    "description": "Add a custom label NAME and set the value to the value of KEY",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "bucket": {
+                    "description": "Defines a bucket for histogram",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "discardLogs": {
+                    "description": "Flag that defines if logs should be discarded after processing. This applies\nfor all logs, no matter if they have emitted metrics or not.",
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "description": "set a buffer limit to restrict memory usage of metrics emitter",
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "Name of the emitter (advanced users)",
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "description": "Optional filter for records in which the content of KEY does not matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "kubernetesMode": {
+                    "description": "If enabled, it will automatically put pod_id, pod_name, namespace_name, docker_id and container_name\ninto the metric as labels. This option is intended to be used in combination with the kubernetes filter plugin.",
+                    "type": "boolean"
+                  },
+                  "labelField": {
+                    "description": "Includes a record field as label dimension in the metric.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "metricDescription": {
+                    "description": "Sets a help text for the metric.",
+                    "type": "string"
+                  },
+                  "metricMode": {
+                    "description": "Defines the mode for the metric. Valid values are [counter, gauge or histogram]",
+                    "type": "string"
+                  },
+                  "metricName": {
+                    "description": "Sets the name of the metric.",
+                    "type": "string"
+                  },
+                  "metricNamespace": {
+                    "description": "Namespace of the metric",
+                    "type": "string"
+                  },
+                  "metricSubsystem": {
+                    "description": "Sets a sub-system for the metric.",
+                    "type": "string"
+                  },
+                  "regex": {
+                    "description": "Optional filter for records in which the content of KEY matches the regular expression.\nValue Format: FIELD REGEX",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Defines the tag for the generated metrics record",
+                    "type": "string"
+                  },
+                  "valueField": {
+                    "description": "Specify the record field that holds a numerical value",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "lua": {
+                "description": "Lua defines Lua Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "call": {
+                    "description": "Lua function name that will be triggered to do filtering.\nIt's assumed that the function is declared inside the Script defined above.",
+                    "type": "string"
+                  },
+                  "code": {
+                    "description": "Inline LUA code instead of loading from a path via script.",
+                    "type": "string"
+                  },
+                  "protectedMode": {
+                    "description": "If enabled, Lua script will be executed in protected mode.\nIt prevents to crash when invalid Lua script is executed. Default is true.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "script": {
+                    "description": "Path to the Lua script that will be used.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "timeAsTable": {
+                    "description": "By default when the Lua script is invoked, the record timestamp is passed as a\nFloating number which might lead to loss precision when the data is converted back.\nIf you desire timestamp precision enabling this option will pass the timestamp as\na Lua table with keys sec for seconds since epoch and nsec for nanoseconds.",
+                    "type": "boolean"
+                  },
+                  "typeArrayKey": {
+                    "description": "If these keys are matched, the fields are handled as array. If more than\none key, delimit by space. It is useful the array can be empty.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "typeIntKey": {
+                    "description": "If these keys are matched, the fields are converted to integer.\nIf more than one key, delimit by space.\nNote that starting from Fluent Bit v1.6 integer data types are preserved\nand not converted to double as in previous versions.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "call"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "modify": {
+                "description": "Modify defines Modify Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "conditions": {
+                    "description": "All conditions have to be true for the rules to be applied.",
+                    "items": {
+                      "description": "The plugin supports the following conditions",
+                      "properties": {
+                        "aKeyMatches": {
+                          "description": "Is true if a key matches regex KEY",
+                          "type": "string"
+                        },
+                        "keyDoesNotExist": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY does not exist",
+                          "type": "object"
+                        },
+                        "keyExists": {
+                          "description": "Is true if KEY exists",
+                          "type": "string"
+                        },
+                        "keyValueDoesNotEqual": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is not VALUE",
+                          "type": "object"
+                        },
+                        "keyValueDoesNotMatch": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value does not match VALUE",
+                          "type": "object"
+                        },
+                        "keyValueEquals": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if KEY exists and its value is VALUE",
+                          "type": "object"
+                        },
+                        "keyValueMatches": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if key KEY exists and its value matches VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysDoNotHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that do not match VALUE",
+                          "type": "object"
+                        },
+                        "matchingKeysHaveMatchingValues": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Is true if all keys matching KEY have values that match VALUE",
+                          "type": "object"
+                        },
+                        "noKeyMatches": {
+                          "description": "Is true if no key matches regex KEY",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Rules are applied in the order they appear,\nwith each rule operating on the result of the previous rule.",
+                    "items": {
+                      "description": "The plugin supports the following rules",
+                      "properties": {
+                        "add": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE if KEY does not exist",
+                          "type": "object"
+                        },
+                        "copy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "hardCopy": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Copy a key/value pair with key KEY to COPIED_KEY if KEY exists.\nIf COPIED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "hardRename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists.\nIf RENAMED_KEY already exists, this field is overwritten",
+                          "type": "object"
+                        },
+                        "remove": {
+                          "description": "Remove a key/value pair with key KEY if it exists",
+                          "type": "string"
+                        },
+                        "removeRegex": {
+                          "description": "Remove all key/value pairs with key matching regexp KEY",
+                          "type": "string"
+                        },
+                        "removeWildcard": {
+                          "description": "Remove all key/value pairs with key matching wildcard KEY",
+                          "type": "string"
+                        },
+                        "rename": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist",
+                          "type": "object"
+                        },
+                        "set": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "multiline": {
+                "description": "Multiline defines a Multiline configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "buffer": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "emitterMemBufLimit": {
+                    "default": 10,
+                    "description": "Set a limit on the amount of memory in MB the emitter can consume if the outputs provide backpressure. The default for this limit is 10M. The pipeline will pause once the buffer exceeds the value of this setting. For example, if the value is set to 10MB then the pipeline will pause if the buffer exceeds 10M. The pipeline will remain paused until the output drains the buffer below the 10M limit.",
+                    "type": "integer"
+                  },
+                  "emitterName": {
+                    "description": "Name for the emitter input instance which re-emits the completed records at the beginning of the pipeline.",
+                    "type": "string"
+                  },
+                  "emitterType": {
+                    "default": "memory",
+                    "description": "The storage type for the emitter input instance. This option supports the values memory (default) and filesystem.",
+                    "enum": [
+                      "memory",
+                      "filesystem"
+                    ],
+                    "type": "string"
+                  },
+                  "flushMs": {
+                    "default": 2000,
+                    "type": "integer"
+                  },
+                  "keyContent": {
+                    "description": "Key name that holds the content to process.\nNote that a Multiline Parser definition can already specify the key_content to use, but this option allows to overwrite that value for the purpose of the filter.",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "enum": [
+                      "parser",
+                      "partial_message"
+                    ],
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify one or multiple Multiline Parsing definitions to apply to the content.\nYou can specify multiple multiline parsers to detect different formats by separating them with a comma.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parser"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nest": {
+                "description": "Nest defines Nest Filter configuration.",
+                "properties": {
+                  "addPrefix": {
+                    "description": "Prefix affected keys with this string",
+                    "type": "string"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "nestUnder": {
+                    "description": "Nest records matching the Wildcard under this key",
+                    "type": "string"
+                  },
+                  "nestedUnder": {
+                    "description": "Lift records nested under the Nested_under key",
+                    "type": "string"
+                  },
+                  "operation": {
+                    "description": "Select the operation nest or lift",
+                    "enum": [
+                      "nest",
+                      "lift"
+                    ],
+                    "type": "string"
+                  },
+                  "removePrefix": {
+                    "description": "Remove prefix from affected keys if it matches this string",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wildcard": {
+                    "description": "Nest records which field matches the wildcard",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "parser": {
+                "description": "Parser defines Parser Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "keyName": {
+                    "description": "Specify field name in record to parse.",
+                    "type": "string"
+                  },
+                  "parser": {
+                    "description": "Specify the parser name to interpret the field.\nMultiple Parser entries are allowed (split by comma).",
+                    "type": "string"
+                  },
+                  "preserveKey": {
+                    "description": "Keep original Key_Name field in the parsed result.\nIf false, the field will be removed.",
+                    "type": "boolean"
+                  },
+                  "reserveData": {
+                    "description": "Keep all other original fields in the parsed result.\nIf false, all other original fields will be removed.",
+                    "type": "boolean"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "unescapeKey": {
+                    "description": "If the key is a escaped string (e.g: stringify JSON), unescape the string before to apply the parser.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "recordModifier": {
+                "description": "RecordModifier defines Record Modifier Filter configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "allowlistKeys": {
+                    "description": "If the key is not matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "records": {
+                    "description": "Append fields. This parameter needs key and value pair.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "removeKeys": {
+                    "description": "If the key is matched, that field is removed.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "uuidKeys": {
+                    "description": "If set, the plugin appends uuid to each record. The value assigned becomes the key in the map.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "whitelistKeys": {
+                    "description": "An alias of allowlistKeys for backwards compatibility.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rewriteTag": {
+                "description": "RewriteTag defines a RewriteTag configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "emitterMemBufLimit": {
+                    "type": "string"
+                  },
+                  "emitterName": {
+                    "description": "When the filter emits a record under the new Tag, there is an internal emitter\nplugin that takes care of the job. Since this emitter expose metrics as any other\ncomponent of the pipeline, you can use this property to configure an optional name for it.",
+                    "type": "string"
+                  },
+                  "emitterStorageType": {
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Defines the matching criteria and the format of the Tag for the matching record.\nThe Rule format have four components: KEY REGEX NEW_TAG KEEP.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "throttle": {
+                "description": "Throttle defines a Throttle configuration.",
+                "properties": {
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "interval": {
+                    "description": "Interval is the time interval expressed in \"sleep\" format. e.g. 3s, 1.5m, 0.5h, etc.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "printStatus": {
+                    "description": "PrintStatus represents whether to print status messages with current rate and the limits to information logs.",
+                    "type": "boolean"
+                  },
+                  "rate": {
+                    "description": "Rate is the amount of messages for the time.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "window": {
+                    "description": "Window is the amount of intervals to calculate average over.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "wasm": {
+                "description": "Wasm defines a Wasm configuration.",
+                "properties": {
+                  "accessiblePaths": {
+                    "description": "Specify the whitelist of paths to be able to access paths from WASM programs.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "alias": {
+                    "description": "Alias for the plugin",
+                    "type": "string"
+                  },
+                  "eventFormat": {
+                    "description": "Define event format to interact with Wasm programs: msgpack or json. Default: json",
+                    "type": "string"
+                  },
+                  "functionName": {
+                    "description": "Wasm function name that will be triggered to do filtering. It's assumed that the function is built inside the Wasm program specified above.",
+                    "type": "string"
+                  },
+                  "retryLimit": {
+                    "description": "RetryLimit describes how many times fluent-bit should retry to send data to a specific output. If set to false fluent-bit will try indefinetly. If set to any integer N>0 it will try at most N+1 times. Leading zeros are not allowed (values such as 007, 0150, 01 do not work). If this property is not defined fluent-bit will use the default value: 1.",
+                    "pattern": "^(((f|F)alse)|(no_limits)|(no_retries)|([1-9]+[0-9]*))$",
+                    "type": "string"
+                  },
+                  "wasmHeapSize": {
+                    "description": "Size of the heap size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  },
+                  "wasmPath": {
+                    "description": "Path to the built Wasm program that will be used. This can be a relative path against the main configuration file.",
+                    "type": "string"
+                  },
+                  "wasmStackSize": {
+                    "description": "Size of the stack size of Wasm execution. Review unit sizes for allowed values.",
+                    "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "logLevel": {
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case-sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/fluentd_v1alpha1.json
+++ b/fluentd.fluent.io/fluentd_v1alpha1.json
@@ -1,0 +1,6748 @@
+{
+  "description": "Fluentd is the Schema for the fluentds API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluentdSpec defines the desired state of Fluentd",
+      "properties": {
+        "affinity": {
+          "description": "Pod's scheduling constraints.",
+          "properties": {
+            "nodeAffinity": {
+              "description": "Describes node affinity scheduling rules for the pod.",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                    "properties": {
+                      "preference": {
+                        "description": "A node selector term, associated with the corresponding weight.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                      "items": {
+                        "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAffinity": {
+              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAntiAffinity": {
+              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to each Fluentd pod.",
+          "type": "object"
+        },
+        "args": {
+          "description": "Fluentd Watcher command line arguments.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "buffer": {
+          "description": "Buffer definition",
+          "properties": {
+            "disableBufferVolume": {
+              "description": "Enabled buffer pvc by default.",
+              "type": "boolean"
+            },
+            "emptyDir": {
+              "description": "Represents an empty directory for a pod.\nEmpty directory volumes support ownership management and SELinux relabeling.",
+              "properties": {
+                "medium": {
+                  "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                  "type": "string"
+                },
+                "sizeLimit": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "hostPath": {
+              "description": "Volume definition.",
+              "properties": {
+                "path": {
+                  "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "pvc": {
+              "description": "PVC definition",
+              "properties": {
+                "apiVersion": {
+                  "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                  "type": "string"
+                },
+                "metadata": {
+                  "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                  "properties": {
+                    "accessModes": {
+                      "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "dataSource": {
+                      "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind is the type of resource being referenced",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of resource being referenced",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSourceRef": {
+                      "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind is the type of resource being referenced",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of resource being referenced",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "resources": {
+                      "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                      "properties": {
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "selector": {
+                      "description": "selector is a label query over volumes to consider for binding.",
+                      "properties": {
+                        "matchExpressions": {
+                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                          "items": {
+                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                            "properties": {
+                              "key": {
+                                "description": "key is the label key that the selector applies to.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                "type": "string"
+                              },
+                              "values": {
+                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "operator"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "matchLabels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "storageClassName": {
+                      "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                      "type": "string"
+                    },
+                    "volumeAttributesClassName": {
+                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                      "type": "string"
+                    },
+                    "volumeMode": {
+                      "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                      "type": "string"
+                    },
+                    "volumeName": {
+                      "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "description": "status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                  "properties": {
+                    "accessModes": {
+                      "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "allocatedResourceStatuses": {
+                      "additionalProperties": {
+                        "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
+                        "type": "string"
+                      },
+                      "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+                      "type": "object",
+                      "x-kubernetes-map-type": "granular"
+                    },
+                    "allocatedResources": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+                      "type": "object"
+                    },
+                    "capacity": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "capacity represents the actual resources of the underlying volume.",
+                      "type": "object"
+                    },
+                    "conditions": {
+                      "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
+                      "items": {
+                        "description": "PersistentVolumeClaimCondition contains details about state of pvc",
+                        "properties": {
+                          "lastProbeTime": {
+                            "description": "lastProbeTime is the time we probed the condition.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "message": {
+                            "description": "message is the human-readable message indicating details about last transition.",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "type"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "currentVolumeAttributesClassName": {
+                      "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim\nThis is an alpha field and requires enabling VolumeAttributesClass feature.",
+                      "type": "string"
+                    },
+                    "modifyVolumeStatus": {
+                      "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.\nThis is an alpha field and requires enabling VolumeAttributesClass feature.",
+                      "properties": {
+                        "status": {
+                          "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
+                          "type": "string"
+                        },
+                        "targetVolumeAttributesClassName": {
+                          "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "phase": {
+                      "description": "phase represents the current phase of PersistentVolumeClaim.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "containerSecurityContext": {
+          "description": "ContainerSecurityContext represents the security context for the fluentd container.",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "capabilities": {
+              "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "add": {
+                  "description": "Added capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "drop": {
+                  "description": "Removed capabilities",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "privileged": {
+              "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "procMount": {
+              "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "readOnlyRootFilesystem": {
+              "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "defaultFilterSelector": {
+          "description": "Select cluster filter plugins used to filter for the default cluster output",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "defaultInputSelector": {
+          "description": "Select cluster input plugins used to gather the default cluster output",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "defaultOutputSelector": {
+          "description": "Select cluster output plugins used to send all logs that did not match any route to the matching outputs",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "disableService": {
+          "description": "By default will build the related service according to the globalinputs definition.",
+          "type": "boolean"
+        },
+        "envVars": {
+          "description": "EnvVars represent environment variables that can be passed to fluentd pods.",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "fluentdCfgSelector": {
+          "description": "FluentdCfgSelector defines the selectors to select the fluentd config CRs.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "globalInputs": {
+          "description": "Fluentd global inputs.",
+          "items": {
+            "description": "Input defines all available input plugins and their parameters",
+            "properties": {
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "forward": {
+                "description": "in_forward plugin",
+                "properties": {
+                  "addTagPrefix": {
+                    "description": "Adds the prefix to the incoming event's tag.",
+                    "type": "string"
+                  },
+                  "bind": {
+                    "description": "The port to listen to, default is \"0.0.0.0\"",
+                    "type": "string"
+                  },
+                  "chunkSizeLimit": {
+                    "description": "The size limit of the received chunk. If the chunk size is larger than this value, the received chunk is dropped.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "chunkSizeWarnLimit": {
+                    "description": "The warning size limit of the received chunk. If the chunk size is larger than this value, a warning message will be sent.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "client": {
+                    "description": "The security section of client plugin",
+                    "properties": {
+                      "host": {
+                        "description": "The IP address or hostname of the client. This is exclusive with Network.",
+                        "type": "string"
+                      },
+                      "network": {
+                        "description": "The network address specification. This is exclusive with Host.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key per client.",
+                        "type": "string"
+                      },
+                      "users": {
+                        "description": "The array of usernames.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "denyKeepalive": {
+                    "description": "The connections will be disconnected right after receiving a message, if true.",
+                    "type": "boolean"
+                  },
+                  "lingerTimeout": {
+                    "description": "The timeout used to set the linger option.",
+                    "type": "integer"
+                  },
+                  "port": {
+                    "description": "The port to listen to, default is 24224.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "resolveHostname": {
+                    "description": "Tries to resolve hostname from IP addresses or not.",
+                    "type": "boolean"
+                  },
+                  "security": {
+                    "description": "The security section of forward plugin",
+                    "properties": {
+                      "allowAnonymousSource": {
+                        "description": "Allows the anonymous source. <client> sections are required, if disabled.",
+                        "type": "string"
+                      },
+                      "selfHostname": {
+                        "description": "The hostname.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key for authentication.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "Defines user section directly.",
+                        "properties": {
+                          "password": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "userAuth": {
+                        "description": "If true, user-based authentication is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "sendKeepalivePacket": {
+                    "description": "Enables the TCP keepalive for sockets.",
+                    "type": "boolean"
+                  },
+                  "skipInvalidEvent": {
+                    "description": "Skips the invalid incoming event.",
+                    "type": "boolean"
+                  },
+                  "sourceAddressKey": {
+                    "description": "The field name of the client's source address. If set, the client's address will be set to its key.",
+                    "type": "string"
+                  },
+                  "sourceHostnameKey": {
+                    "description": "The field name of the client's hostname. If set, the client's hostname will be set to its key.",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "in_forward uses incoming event's tag by default (See Protocol Section).\nIf the tag parameter is set, its value is used instead.",
+                    "type": "string"
+                  },
+                  "transport": {
+                    "description": "The transport section of forward plugin",
+                    "properties": {
+                      "caCertPath": {
+                        "description": "for Cert generated",
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "description": "for Cert signed by public CA",
+                        "type": "string"
+                      },
+                      "caPrivateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "caPrivateKeyPath": {
+                        "type": "string"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "certVerifier": {
+                        "description": "other parameters",
+                        "type": "string"
+                      },
+                      "ciphers": {
+                        "type": "string"
+                      },
+                      "clientCertAuth": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "privateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "privateKeyPath": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocal name of this plugin, i.e: tls",
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "The security section of user plugin",
+                    "properties": {
+                      "password": {
+                        "description": "Secret defines the key of a value.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "username": {
+                        "description": "Secret defines the key of a value.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "http": {
+                "description": "in_http plugin",
+                "properties": {
+                  "addHttpHeaders": {
+                    "description": "Adds HTTP_ prefix headers to the record.",
+                    "type": "boolean"
+                  },
+                  "addRemoteAddr": {
+                    "description": "Adds REMOTE_ADDR field to the record. The value of REMOTE_ADDR is the client's address.\ni.e: X-Forwarded-For: host1, host2",
+                    "type": "string"
+                  },
+                  "bind": {
+                    "description": "The port to listen to, default is \"0.0.0.0\"",
+                    "type": "string"
+                  },
+                  "bodySizeLimit": {
+                    "description": "The size limit of the POSTed element.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "corsAllOrigins": {
+                    "description": "Whitelist domains for CORS.",
+                    "type": "string"
+                  },
+                  "corsAllowCredentials": {
+                    "description": "Add Access-Control-Allow-Credentials header. It's needed when a request's credentials mode is include",
+                    "type": "string"
+                  },
+                  "keepaliveTimeout": {
+                    "description": "The timeout limit for keeping the connection alive.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "parse": {
+                    "description": "The parse section of http plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "description": "The port to listen to, default is 9880.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "respondsWithEmptyImg": {
+                    "description": "Responds with an empty GIF image of 1x1 pixel (rather than an empty string).",
+                    "type": "boolean"
+                  },
+                  "transport": {
+                    "description": "The transport section of http plugin",
+                    "properties": {
+                      "caCertPath": {
+                        "description": "for Cert generated",
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "description": "for Cert signed by public CA",
+                        "type": "string"
+                      },
+                      "caPrivateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "caPrivateKeyPath": {
+                        "type": "string"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "certVerifier": {
+                        "description": "other parameters",
+                        "type": "string"
+                      },
+                      "ciphers": {
+                        "type": "string"
+                      },
+                      "clientCertAuth": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "privateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "privateKeyPath": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocal name of this plugin, i.e: tls",
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "The @id parameter specifies a unique name for the configuration.",
+                "type": "string"
+              },
+              "label": {
+                "description": "The @label parameter is to route the input events to <label> sections.",
+                "type": "string"
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "monitorAgent": {
+                "description": "monitor_agent plugin",
+                "properties": {
+                  "bind": {
+                    "description": "The bind address to listen to.",
+                    "type": "string"
+                  },
+                  "emitInterval": {
+                    "description": "The interval time between event emits. This will be used when \"tag\" is configured.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "includeConfig": {
+                    "description": "You can set this option to false to remove the config field from the response.",
+                    "type": "boolean"
+                  },
+                  "includeRetry": {
+                    "description": "You can set this option to false to remove the retry field from the response.",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "The port to listen to.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "tag": {
+                    "description": "If you set this parameter, this plugin emits metrics as records.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "sample": {
+                "description": "in_sample plugin",
+                "properties": {
+                  "autoIncrementKey": {
+                    "description": "If specified, each generated event has an auto-incremented key field.",
+                    "type": "string"
+                  },
+                  "rate": {
+                    "description": "It configures how many events to generate per second.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "sample": {
+                    "description": "The sample data to be generated. It should be either an array of JSON hashes or a single JSON hash. If it is an array of JSON hashes, the hashes in the array are cycled through in order.",
+                    "type": "string"
+                  },
+                  "size": {
+                    "description": "The number of events in the event stream of each emit.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "tag": {
+                    "description": "The tag of the event. The value is the tag assigned to the generated events.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "tail": {
+                "description": "in_tail plugin",
+                "properties": {
+                  "emitUnmatchedLines": {
+                    "description": "Emits unmatched lines when <parse> format is not matched for incoming logs.",
+                    "type": "boolean"
+                  },
+                  "enableStatWatcher": {
+                    "description": "Enables the additional inotify-based watcher. Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.\nThis option is mainly for avoiding the stuck issue with inotify.",
+                    "type": "boolean"
+                  },
+                  "enableWatchTimer": {
+                    "description": "Enables the additional watch timer. Setting this parameter to false will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with inotify support.\nThe default is true which results in an additional 1 second timer being used.",
+                    "type": "boolean"
+                  },
+                  "encoding": {
+                    "description": "Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.\nIf encoding is specified, in_tail changes string to encoding.\nIf encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.",
+                    "type": "string"
+                  },
+                  "excludePath": {
+                    "description": "The paths excluded from the watcher list.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "followInodes": {
+                    "description": "Avoid to read rotated files duplicately. You should set true when you use * or strftime format in path.",
+                    "type": "boolean"
+                  },
+                  "fromEncoding": {
+                    "description": "Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.\nIf encoding is specified, in_tail changes string to encoding.\nIf encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.",
+                    "type": "string"
+                  },
+                  "group": {
+                    "description": "The in_tail plugin can assign each log file to a group, based on user defined rules.\nThe limit parameter controls the total number of lines collected for a group within a rate_period time interval.",
+                    "properties": {
+                      "pattern": {
+                        "description": "Specifies the regular expression for extracting metadata (namespace, podname) from log file path.\nDefault value of the pattern regexp extracts information about namespace, podname, docker_id, container of the log (K8s specific).",
+                        "type": "string"
+                      },
+                      "ratePeriod": {
+                        "description": "Time period in which the group line limit is applied. in_tail resets the counter after every rate_period interval.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "rule": {
+                        "description": "Grouping rules for log files.",
+                        "properties": {
+                          "limit": {
+                            "description": "Maximum number of lines allowed from a group in rate_period time interval. The default value of -1 doesn't throttle log files of that group.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "match": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "match parameter is used to check if a file belongs to a particular group based on hash keys (named captures from pattern) and hash values (regexp in string)",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "rule"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ignoreRepeatedPermissionError": {
+                    "description": "If you have to exclude the non-permission files from the watch list, set this parameter to true. It suppresses the repeated permission error logs.",
+                    "type": "boolean"
+                  },
+                  "limitRecentlyModified": {
+                    "description": "Limits the watching files that the modification time is within the specified time range when using * in path.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxLineSize": {
+                    "description": "The maximum length of a line. Longer lines than it will be just skipped.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "multilineFlushInterval": {
+                    "description": "The interval of flushing the buffer for multiline format.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "openOnEveryUpdate": {
+                    "description": "Opens and closes the file on every update instead of leaving it open until it gets rotated.",
+                    "type": "boolean"
+                  },
+                  "parse": {
+                    "description": "Parse defines various parameters for the parse plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "The path(s) to read. Multiple paths can be specified, separated by comma ','.",
+                    "type": "string"
+                  },
+                  "pathKey": {
+                    "description": "Adds the watching file path to the path_key field.",
+                    "type": "string"
+                  },
+                  "pathTimezone": {
+                    "description": "This parameter is for strftime formatted path like /path/to/%Y/%m/%d/.",
+                    "type": "string"
+                  },
+                  "posFile": {
+                    "description": "(recommended) Fluentd will record the position it last read from this file.\npos_file handles multiple positions in one file so no need to have multiple pos_file parameters per source.\nDon't share pos_file between in_tail configurations. It causes unexpected behavior e.g. corrupt pos_file content.",
+                    "type": "string"
+                  },
+                  "posFileCompactionInterval": {
+                    "description": "The interval of doing compaction of pos file.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readBytesLimitPerSecond": {
+                    "description": "The number of reading bytes per second to read with I/O operation. This value should be equal or greater than 8192.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readFromHead": {
+                    "description": "Starts to read the logs from the head of the file or the last read position recorded in pos_file, not tail.",
+                    "type": "boolean"
+                  },
+                  "readLinesLimit": {
+                    "description": "The number of lines to read with each I/O operation.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "refreshInterval": {
+                    "description": "The interval to refresh the list of watch files. This is used when the path includes *.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "rotateWait": {
+                    "description": "in_tail actually does a bit more than tail -F itself. When rotating a file, some data may still need to be written to the old file as opposed to the new one.\nin_tail takes care of this by keeping a reference to the old file (even after it has been rotated) for some time before transitioning completely to the new file.\nThis helps prevent data designated for the old file from getting lost. By default, this time interval is 5 seconds.\nThe rotate_wait parameter accepts a single integer representing the number of seconds you want this time interval to be.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "skipRefreshOnStartup": {
+                    "description": "Skips the refresh of the watch list on startup. This reduces the startup time when * is used in path.",
+                    "type": "boolean"
+                  },
+                  "tag": {
+                    "description": "The tag of the event.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parse",
+                  "path",
+                  "tag"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "image": {
+          "description": "Fluentd image.",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Fluentd image pull policy.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "Fluentd image pull secret",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "livenessProbe": {
+          "description": "LivenessProbe represents the liveness probe for the fluentd container.",
+          "properties": {
+            "exec": {
+              "description": "Exec specifies the action to take.",
+              "properties": {
+                "command": {
+                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "description": "GRPC specifies an action involving a GRPC port.",
+              "properties": {
+                "port": {
+                  "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "description": "HTTPGet specifies the http request to perform.",
+              "properties": {
+                "host": {
+                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                  "items": {
+                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                    "properties": {
+                      "name": {
+                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The header field value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "description": "Path to access on the HTTP server.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "description": "TCPSocket specifies an action involving a TCP port.",
+              "properties": {
+                "host": {
+                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "default": "info",
+          "description": "Global logging verbosity",
+          "enum": [
+            "fatal",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "mode": {
+          "default": "collector",
+          "description": "Mode to determine whether to run Fluentd as collector or agent.",
+          "enum": [
+            "collector",
+            "agent"
+          ],
+          "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "NodeSelector",
+          "type": "object"
+        },
+        "positionDB": {
+          "description": "Storage for position db. You will use it if tail input is enabled.\nApplicable when the mode is \"agent\", and will be ignored when the mode is \"collector\"",
+          "properties": {
+            "awsElasticBlockStore": {
+              "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "partition": {
+                  "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "readOnly": {
+                  "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                  "type": "boolean"
+                },
+                "volumeID": {
+                  "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumeID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "azureDisk": {
+              "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+              "properties": {
+                "cachingMode": {
+                  "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                  "type": "string"
+                },
+                "diskName": {
+                  "description": "diskName is the Name of the data disk in the blob storage",
+                  "type": "string"
+                },
+                "diskURI": {
+                  "description": "diskURI is the URI of data disk in the blob storage",
+                  "type": "string"
+                },
+                "fsType": {
+                  "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "diskName",
+                "diskURI"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "azureFile": {
+              "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+              "properties": {
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretName": {
+                  "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                  "type": "string"
+                },
+                "shareName": {
+                  "description": "shareName is the azure share Name",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "secretName",
+                "shareName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cephfs": {
+              "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+              "properties": {
+                "monitors": {
+                  "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "type": "boolean"
+                },
+                "secretFile": {
+                  "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "user": {
+                  "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "monitors"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cinder": {
+              "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "volumeID": {
+                  "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumeID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "configMap": {
+              "description": "configMap represents a configMap that should populate this volume",
+              "properties": {
+                "defaultMode": {
+                  "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "items": {
+                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                  "items": {
+                    "description": "Maps a string key to a path within a volume.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the key to project.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "name": {
+                  "default": "",
+                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                  "type": "string"
+                },
+                "optional": {
+                  "description": "optional specify whether the ConfigMap or its keys must be defined",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "csi": {
+              "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+              "properties": {
+                "driver": {
+                  "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                  "type": "string"
+                },
+                "fsType": {
+                  "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                  "type": "string"
+                },
+                "nodePublishSecretRef": {
+                  "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "readOnly": {
+                  "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                  "type": "boolean"
+                },
+                "volumeAttributes": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "driver"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "downwardAPI": {
+              "description": "downwardAPI represents downward API about the pod that should populate this volume",
+              "properties": {
+                "defaultMode": {
+                  "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "items": {
+                  "description": "Items is a list of downward API volume file",
+                  "items": {
+                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                    "properties": {
+                      "fieldRef": {
+                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "mode": {
+                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                        "type": "string"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resource"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "emptyDir": {
+              "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+              "properties": {
+                "medium": {
+                  "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                  "type": "string"
+                },
+                "sizeLimit": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "ephemeral": {
+              "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+              "properties": {
+                "volumeClaimTemplate": {
+                  "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\n\nRequired, must not be nil.",
+                  "properties": {
+                    "metadata": {
+                      "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                      "properties": {
+                        "accessModes": {
+                          "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "dataSource": {
+                          "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "dataSourceRef": {
+                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "resources": {
+                          "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                          "properties": {
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "description": "selector is a label query over volumes to consider for binding.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "storageClassName": {
+                          "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                          "type": "string"
+                        },
+                        "volumeAttributesClassName": {
+                          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                          "type": "string"
+                        },
+                        "volumeMode": {
+                          "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                          "type": "string"
+                        },
+                        "volumeName": {
+                          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "spec"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fc": {
+              "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "lun": {
+                  "description": "lun is Optional: FC target lun number",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "readOnly": {
+                  "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "targetWWNs": {
+                  "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "wwids": {
+                  "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "flexVolume": {
+              "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+              "properties": {
+                "driver": {
+                  "description": "driver is the name of the driver to use for this volume.",
+                  "type": "string"
+                },
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                  "type": "string"
+                },
+                "options": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "options is Optional: this field holds extra command options if any.",
+                  "type": "object"
+                },
+                "readOnly": {
+                  "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "driver"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "flocker": {
+              "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+              "properties": {
+                "datasetName": {
+                  "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                  "type": "string"
+                },
+                "datasetUUID": {
+                  "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "gcePersistentDisk": {
+              "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "partition": {
+                  "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "pdName": {
+                  "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "pdName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "gitRepo": {
+              "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+              "properties": {
+                "directory": {
+                  "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                  "type": "string"
+                },
+                "repository": {
+                  "description": "repository is the URL",
+                  "type": "string"
+                },
+                "revision": {
+                  "description": "revision is the commit hash for the specified revision.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "repository"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "glusterfs": {
+              "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+              "properties": {
+                "endpoints": {
+                  "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                  "type": "string"
+                },
+                "path": {
+                  "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "endpoints",
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "hostPath": {
+              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.",
+              "properties": {
+                "path": {
+                  "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "iscsi": {
+              "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+              "properties": {
+                "chapAuthDiscovery": {
+                  "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                  "type": "boolean"
+                },
+                "chapAuthSession": {
+                  "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                  "type": "boolean"
+                },
+                "fsType": {
+                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "initiatorName": {
+                  "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                  "type": "string"
+                },
+                "iqn": {
+                  "description": "iqn is the target iSCSI Qualified Name.",
+                  "type": "string"
+                },
+                "iscsiInterface": {
+                  "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                  "type": "string"
+                },
+                "lun": {
+                  "description": "lun represents iSCSI Target Lun number.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "portals": {
+                  "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "targetPortal": {
+                  "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "iqn",
+                "lun",
+                "targetPortal"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nfs": {
+              "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+              "properties": {
+                "path": {
+                  "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                  "type": "boolean"
+                },
+                "server": {
+                  "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "server"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "persistentVolumeClaim": {
+              "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+              "properties": {
+                "claimName": {
+                  "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "claimName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "photonPersistentDisk": {
+              "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "pdID": {
+                  "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pdID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "portworxVolume": {
+              "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+              "properties": {
+                "fsType": {
+                  "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "volumeID": {
+                  "description": "volumeID uniquely identifies a Portworx volume",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumeID"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "projected": {
+              "description": "projected items for all in one resources secrets, configmaps, and downward API",
+              "properties": {
+                "defaultMode": {
+                  "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sources": {
+                  "description": "sources is the list of volume projections",
+                  "items": {
+                    "description": "Projection that may be projected along with other supported volume types",
+                    "properties": {
+                      "clusterTrustBundle": {
+                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                        "properties": {
+                          "labelSelector": {
+                            "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                            "type": "boolean"
+                          },
+                          "path": {
+                            "description": "Relative path from the volume root to write the bundle.",
+                            "type": "string"
+                          },
+                          "signerName": {
+                            "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "description": "configMap information about the configMap data to project",
+                        "properties": {
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "description": "downwardAPI information about the downwardAPI data to project",
+                        "properties": {
+                          "items": {
+                            "description": "Items is a list of DownwardAPIVolume file",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "secret information about the secret data to project",
+                        "properties": {
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "serviceAccountToken": {
+                        "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                        "properties": {
+                          "audience": {
+                            "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                            "type": "string"
+                          },
+                          "expirationSeconds": {
+                            "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "path": {
+                            "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "quobyte": {
+              "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+              "properties": {
+                "group": {
+                  "description": "group to map volume access to\nDefault is no group",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                  "type": "boolean"
+                },
+                "registry": {
+                  "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                  "type": "string"
+                },
+                "tenant": {
+                  "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "user to map volume access to\nDefaults to serivceaccount user",
+                  "type": "string"
+                },
+                "volume": {
+                  "description": "volume is a string that references an already created Quobyte volume by name.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "registry",
+                "volume"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "rbd": {
+              "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                  "type": "string"
+                },
+                "image": {
+                  "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "keyring": {
+                  "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "monitors": {
+                  "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "pool": {
+                  "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "user": {
+                  "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "image",
+                "monitors"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "scaleIO": {
+              "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                  "type": "string"
+                },
+                "gateway": {
+                  "description": "gateway is the host address of the ScaleIO API Gateway.",
+                  "type": "string"
+                },
+                "protectionDomain": {
+                  "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "sslEnabled": {
+                  "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                  "type": "boolean"
+                },
+                "storageMode": {
+                  "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                  "type": "string"
+                },
+                "storagePool": {
+                  "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                  "type": "string"
+                },
+                "system": {
+                  "description": "system is the name of the storage system as configured in ScaleIO.",
+                  "type": "string"
+                },
+                "volumeName": {
+                  "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "gateway",
+                "secretRef",
+                "system"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secret": {
+              "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+              "properties": {
+                "defaultMode": {
+                  "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "items": {
+                  "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                  "items": {
+                    "description": "Maps a string key to a path within a volume.",
+                    "properties": {
+                      "key": {
+                        "description": "key is the key to project.",
+                        "type": "string"
+                      },
+                      "mode": {
+                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "path": {
+                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "optional": {
+                  "description": "optional field specify whether the Secret or its keys must be defined",
+                  "type": "boolean"
+                },
+                "secretName": {
+                  "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "storageos": {
+              "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "readOnly": {
+                  "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "volumeName": {
+                  "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                  "type": "string"
+                },
+                "volumeNamespace": {
+                  "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "vsphereVolume": {
+              "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+              "properties": {
+                "fsType": {
+                  "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                  "type": "string"
+                },
+                "storagePolicyID": {
+                  "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                  "type": "string"
+                },
+                "storagePolicyName": {
+                  "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                  "type": "string"
+                },
+                "volumePath": {
+                  "description": "volumePath is the path that identifies vSphere volume vmdk",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "volumePath"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "priorityClassName": {
+          "description": "PriorityClassName represents the pod's priority class.",
+          "type": "string"
+        },
+        "rbacRules": {
+          "description": "RBACRules represents additional rbac rules which will be applied to the fluentd clusterrole.",
+          "items": {
+            "description": "PolicyRule holds information that describes a policy rule, but does not contain information\nabout who the rule applies to or which namespace the rule applies to.",
+            "properties": {
+              "apiGroups": {
+                "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of\nthe enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "nonResourceURLs": {
+                "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path\nSince non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.\nRules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resourceNames": {
+                "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "resources": {
+                "description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "verbs": {
+                "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              }
+            },
+            "required": [
+              "verbs"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "readinessProbe": {
+          "description": "ReadinessProbe represents the readiness probe for the fluentd container.",
+          "properties": {
+            "exec": {
+              "description": "Exec specifies the action to take.",
+              "properties": {
+                "command": {
+                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "description": "GRPC specifies an action involving a GRPC port.",
+              "properties": {
+                "port": {
+                  "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "description": "HTTPGet specifies the http request to perform.",
+              "properties": {
+                "host": {
+                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                  "items": {
+                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                    "properties": {
+                      "name": {
+                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The header field value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "description": "Path to access on the HTTP server.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "description": "TCPSocket specifies an action involving a TCP port.",
+              "properties": {
+                "host": {
+                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "description": "Numbers of the Fluentd instance\nApplicable when the mode is \"collector\", and will be ignored when the mode is \"agent\"",
+          "format": "int32",
+          "type": "integer"
+        },
+        "resources": {
+          "description": "Compute Resources required by container.",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName represents the container runtime configuration.",
+          "type": "string"
+        },
+        "schedulerName": {
+          "description": "SchedulerName represents the desired scheduler for fluentd pods.",
+          "type": "string"
+        },
+        "securityContext": {
+          "description": "PodSecurityContext represents the security context for the fluentd pods.",
+          "properties": {
+            "appArmorProfile": {
+              "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fsGroup": {
+              "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+              "type": "string"
+            },
+            "runAsGroup": {
+              "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "seccompProfile": {
+              "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "supplementalGroups": {
+              "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container. Note that group memberships\ndefined in the container image for the uid of the container process are still effective,\neven if they are not included in this list.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "sysctls": {
+              "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+              "items": {
+                "description": "Sysctl defines a kernel parameter to be set",
+                "properties": {
+                  "name": {
+                    "description": "Name of a property to set",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value of a property to set",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "windowsOptions": {
+              "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+              "properties": {
+                "gmsaCredentialSpec": {
+                  "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                  "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                  "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                  "type": "string"
+                },
+                "hostProcess": {
+                  "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                  "type": "boolean"
+                },
+                "runAsUserName": {
+                  "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "service": {
+          "description": "Service represents configurations on the fluentd service.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to add to each FluentD service.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to add to each FluentD service",
+              "type": "object"
+            },
+            "name": {
+              "description": "Name is the name of the FluentD service.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccountAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the Fluentd service account",
+          "type": "object"
+        },
+        "tolerations": {
+          "description": "Tolerations",
+          "items": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumeClaimTemplates": {
+          "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference.\nThe StatefulSet controller is responsible for mapping network identities to\nclaims in a way that maintains the identity of a pod. Every claim in\nthis list must have at least one matching (by name) volumeMount in one\ncontainer in the template.\nApplicable when the mode is \"collector\", and will be ignored when the mode is \"agent\"",
+          "items": {
+            "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "metadata": {
+                "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                "properties": {
+                  "annotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "finalizers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "spec": {
+                "description": "spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                "properties": {
+                  "accessModes": {
+                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "dataSource": {
+                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                    "properties": {
+                      "apiGroup": {
+                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind is the type of resource being referenced",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of resource being referenced",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "dataSourceRef": {
+                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                    "properties": {
+                      "apiGroup": {
+                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind is the type of resource being referenced",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the name of resource being referenced",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "resources": {
+                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                    "properties": {
+                      "limits": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      },
+                      "requests": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "selector": {
+                    "description": "selector is a label query over volumes to consider for binding.",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "storageClassName": {
+                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                    "type": "string"
+                  },
+                  "volumeAttributesClassName": {
+                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                    "type": "string"
+                  },
+                  "volumeMode": {
+                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                    "type": "string"
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "status": {
+                "description": "status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                "properties": {
+                  "accessModes": {
+                    "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "allocatedResourceStatuses": {
+                    "additionalProperties": {
+                      "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
+                      "type": "string"
+                    },
+                    "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+                    "type": "object",
+                    "x-kubernetes-map-type": "granular"
+                  },
+                  "allocatedResources": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+                    "type": "object"
+                  },
+                  "capacity": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "capacity represents the actual resources of the underlying volume.",
+                    "type": "object"
+                  },
+                  "conditions": {
+                    "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
+                    "items": {
+                      "description": "PersistentVolumeClaimCondition contains details about state of pvc",
+                      "properties": {
+                        "lastProbeTime": {
+                          "description": "lastProbeTime is the time we probed the condition.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "lastTransitionTime": {
+                          "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "message": {
+                          "description": "message is the human-readable message indicating details about last transition.",
+                          "type": "string"
+                        },
+                        "reason": {
+                          "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "currentVolumeAttributesClassName": {
+                    "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim\nThis is an alpha field and requires enabling VolumeAttributesClass feature.",
+                    "type": "string"
+                  },
+                  "modifyVolumeStatus": {
+                    "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.\nThis is an alpha field and requires enabling VolumeAttributesClass feature.",
+                    "properties": {
+                      "status": {
+                        "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
+                        "type": "string"
+                      },
+                      "targetVolumeAttributesClassName": {
+                        "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "status"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "phase": {
+                    "description": "phase represents the current phase of PersistentVolumeClaim.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumeMounts": {
+          "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+          "items": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+              "mountPath": {
+                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                "type": "string"
+              },
+              "mountPropagation": {
+                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                "type": "string"
+              },
+              "name": {
+                "description": "This must match the Name of a Volume.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                "type": "string"
+              },
+              "subPathExpr": {
+                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mountPath",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "volumes": {
+          "description": "List of volumes that can be mounted by containers belonging to the pod.",
+          "items": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+            "properties": {
+              "awsElasticBlockStore": {
+                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureDisk": {
+                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                "properties": {
+                  "cachingMode": {
+                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                    "type": "string"
+                  },
+                  "diskName": {
+                    "description": "diskName is the Name of the data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "diskURI": {
+                    "description": "diskURI is the URI of data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "diskName",
+                  "diskURI"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureFile": {
+                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                "properties": {
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                    "type": "string"
+                  },
+                  "shareName": {
+                    "description": "shareName is the azure share Name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secretName",
+                  "shareName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cephfs": {
+                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                "properties": {
+                  "monitors": {
+                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "path": {
+                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretFile": {
+                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cinder": {
+                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeID": {
+                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "configMap represents a configMap that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "csi": {
+                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "downwardAPI": {
+                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "Items is a list of downward API volume file",
+                    "items": {
+                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                      "properties": {
+                        "fieldRef": {
+                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                          "type": "string"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "emptyDir": {
+                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ephemeral": {
+                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                "properties": {
+                  "volumeClaimTemplate": {
+                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\n\nRequired, must not be nil.",
+                    "properties": {
+                      "metadata": {
+                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                        "properties": {
+                          "accessModes": {
+                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "dataSource": {
+                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "dataSourceRef": {
+                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "selector": {
+                            "description": "selector is a label query over volumes to consider for binding.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "storageClassName": {
+                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "fc": {
+                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun is Optional: FC target lun number",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "targetWWNs": {
+                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "wwids": {
+                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flexVolume": {
+                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the driver to use for this volume.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                    "type": "string"
+                  },
+                  "options": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "options is Optional: this field holds extra command options if any.",
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flocker": {
+                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                "properties": {
+                  "datasetName": {
+                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                    "type": "string"
+                  },
+                  "datasetUUID": {
+                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gcePersistentDisk": {
+                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "pdName": {
+                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "pdName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gitRepo": {
+                "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                "properties": {
+                  "directory": {
+                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                    "type": "string"
+                  },
+                  "repository": {
+                    "description": "repository is the URL",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "revision is the commit hash for the specified revision.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repository"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "glusterfs": {
+                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                "properties": {
+                  "endpoints": {
+                    "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "endpoints",
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "hostPath": {
+                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.",
+                "properties": {
+                  "path": {
+                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "iscsi": {
+                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                "properties": {
+                  "chapAuthDiscovery": {
+                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "chapAuthSession": {
+                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "initiatorName": {
+                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                    "type": "string"
+                  },
+                  "iqn": {
+                    "description": "iqn is the target iSCSI Qualified Name.",
+                    "type": "string"
+                  },
+                  "iscsiInterface": {
+                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun represents iSCSI Target Lun number.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "portals": {
+                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "targetPortal": {
+                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "iqn",
+                  "lun",
+                  "targetPortal"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "nfs": {
+                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                "properties": {
+                  "path": {
+                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "boolean"
+                  },
+                  "server": {
+                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "server"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "persistentVolumeClaim": {
+                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "photonPersistentDisk": {
+                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "pdID": {
+                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pdID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "portworxVolume": {
+                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID uniquely identifies a Portworx volume",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "projected": {
+                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "quobyte": {
+                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                "properties": {
+                  "group": {
+                    "description": "group to map volume access to\nDefault is no group",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "registry": {
+                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                    "type": "string"
+                  },
+                  "tenant": {
+                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "user to map volume access to\nDefaults to serivceaccount user",
+                    "type": "string"
+                  },
+                  "volume": {
+                    "description": "volume is a string that references an already created Quobyte volume by name.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "registry",
+                  "volume"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rbd": {
+                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                    "type": "string"
+                  },
+                  "image": {
+                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "keyring": {
+                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "monitors": {
+                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "pool": {
+                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "image",
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scaleIO": {
+                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                    "type": "string"
+                  },
+                  "gateway": {
+                    "description": "gateway is the host address of the ScaleIO API Gateway.",
+                    "type": "string"
+                  },
+                  "protectionDomain": {
+                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "sslEnabled": {
+                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                    "type": "boolean"
+                  },
+                  "storageMode": {
+                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                    "type": "string"
+                  },
+                  "storagePool": {
+                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                    "type": "string"
+                  },
+                  "system": {
+                    "description": "system is the name of the storage system as configured in ScaleIO.",
+                    "type": "string"
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "gateway",
+                  "secretRef",
+                  "system"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "secret": {
+                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "storageos": {
+                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                    "type": "string"
+                  },
+                  "volumeNamespace": {
+                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "vsphereVolume": {
+                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "storagePolicyID": {
+                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                    "type": "string"
+                  },
+                  "storagePolicyName": {
+                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                    "type": "string"
+                  },
+                  "volumePath": {
+                    "description": "volumePath is the path that identifies vSphere volume vmdk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumePath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "workers": {
+          "description": "Numbers of the workers in Fluentd instance",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FluentdStatus defines the observed state of Fluentd",
+      "properties": {
+        "messages": {
+          "description": "Messages defines the plugin errors which is selected by this fluentdconfig",
+          "type": "string"
+        },
+        "state": {
+          "description": "The state of this fluentd",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/fluentdconfig_v1alpha1.json
+++ b/fluentd.fluent.io/fluentdconfig_v1alpha1.json
@@ -1,0 +1,354 @@
+{
+  "description": "FluentdConfig is the Schema for the fluentdconfigs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluentdConfigSpec defines the desired state of FluentdConfig",
+      "properties": {
+        "clusterFilterSelector": {
+          "description": "Select cluster filter plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "clusterInputSelector": {
+          "description": "Select cluster input plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "clusterOutputSelector": {
+          "description": "Select cluster output plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "emit_mode": {
+          "description": "Emit mode. If batch, the plugin will emit events per labels matched. Enum: record, batch.\nwill make no effect if EnableFilterKubernetes is set false.",
+          "enum": [
+            "record",
+            "batch"
+          ],
+          "type": "string"
+        },
+        "filterSelector": {
+          "description": "Select namespaced filter plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "inputSelector": {
+          "description": "Select cluster input plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "outputSelector": {
+          "description": "Select namespaced output plugins",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "stickyTags": {
+          "description": "Sticky tags will match only one record from an event stream. The same tag will be treated the same way.\nwill make no effect if EnableFilterKubernetes is set false.",
+          "type": "string"
+        },
+        "watchedConstainers": {
+          "description": "A set of container names. Ignored if left empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "watchedHosts": {
+          "description": "A set of hosts. Ignored if left empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "watchedLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Use this field to filter the logs, will make no effect if EnableFilterKubernetes is set false.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FluentdConfigStatus defines the observed state of FluentdConfig",
+      "properties": {
+        "messages": {
+          "description": "Messages defines the plugin errors which is selected by this fluentdconfig",
+          "type": "string"
+        },
+        "state": {
+          "description": "The state of this fluentd config",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/input_v1alpha1.json
+++ b/fluentd.fluent.io/input_v1alpha1.json
@@ -1,0 +1,998 @@
+{
+  "description": "Input is the Schema for the inputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "InputSpec defines the desired state of Input",
+      "properties": {
+        "inputs": {
+          "items": {
+            "description": "Input defines all available input plugins and their parameters",
+            "properties": {
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "forward": {
+                "description": "in_forward plugin",
+                "properties": {
+                  "addTagPrefix": {
+                    "description": "Adds the prefix to the incoming event's tag.",
+                    "type": "string"
+                  },
+                  "bind": {
+                    "description": "The port to listen to, default is \"0.0.0.0\"",
+                    "type": "string"
+                  },
+                  "chunkSizeLimit": {
+                    "description": "The size limit of the received chunk. If the chunk size is larger than this value, the received chunk is dropped.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "chunkSizeWarnLimit": {
+                    "description": "The warning size limit of the received chunk. If the chunk size is larger than this value, a warning message will be sent.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "client": {
+                    "description": "The security section of client plugin",
+                    "properties": {
+                      "host": {
+                        "description": "The IP address or hostname of the client. This is exclusive with Network.",
+                        "type": "string"
+                      },
+                      "network": {
+                        "description": "The network address specification. This is exclusive with Host.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key per client.",
+                        "type": "string"
+                      },
+                      "users": {
+                        "description": "The array of usernames.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "denyKeepalive": {
+                    "description": "The connections will be disconnected right after receiving a message, if true.",
+                    "type": "boolean"
+                  },
+                  "lingerTimeout": {
+                    "description": "The timeout used to set the linger option.",
+                    "type": "integer"
+                  },
+                  "port": {
+                    "description": "The port to listen to, default is 24224.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "resolveHostname": {
+                    "description": "Tries to resolve hostname from IP addresses or not.",
+                    "type": "boolean"
+                  },
+                  "security": {
+                    "description": "The security section of forward plugin",
+                    "properties": {
+                      "allowAnonymousSource": {
+                        "description": "Allows the anonymous source. <client> sections are required, if disabled.",
+                        "type": "string"
+                      },
+                      "selfHostname": {
+                        "description": "The hostname.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key for authentication.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "Defines user section directly.",
+                        "properties": {
+                          "password": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "userAuth": {
+                        "description": "If true, user-based authentication is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "sendKeepalivePacket": {
+                    "description": "Enables the TCP keepalive for sockets.",
+                    "type": "boolean"
+                  },
+                  "skipInvalidEvent": {
+                    "description": "Skips the invalid incoming event.",
+                    "type": "boolean"
+                  },
+                  "sourceAddressKey": {
+                    "description": "The field name of the client's source address. If set, the client's address will be set to its key.",
+                    "type": "string"
+                  },
+                  "sourceHostnameKey": {
+                    "description": "The field name of the client's hostname. If set, the client's hostname will be set to its key.",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "in_forward uses incoming event's tag by default (See Protocol Section).\nIf the tag parameter is set, its value is used instead.",
+                    "type": "string"
+                  },
+                  "transport": {
+                    "description": "The transport section of forward plugin",
+                    "properties": {
+                      "caCertPath": {
+                        "description": "for Cert generated",
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "description": "for Cert signed by public CA",
+                        "type": "string"
+                      },
+                      "caPrivateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "caPrivateKeyPath": {
+                        "type": "string"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "certVerifier": {
+                        "description": "other parameters",
+                        "type": "string"
+                      },
+                      "ciphers": {
+                        "type": "string"
+                      },
+                      "clientCertAuth": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "privateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "privateKeyPath": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocal name of this plugin, i.e: tls",
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "The security section of user plugin",
+                    "properties": {
+                      "password": {
+                        "description": "Secret defines the key of a value.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "username": {
+                        "description": "Secret defines the key of a value.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "http": {
+                "description": "in_http plugin",
+                "properties": {
+                  "addHttpHeaders": {
+                    "description": "Adds HTTP_ prefix headers to the record.",
+                    "type": "boolean"
+                  },
+                  "addRemoteAddr": {
+                    "description": "Adds REMOTE_ADDR field to the record. The value of REMOTE_ADDR is the client's address.\ni.e: X-Forwarded-For: host1, host2",
+                    "type": "string"
+                  },
+                  "bind": {
+                    "description": "The port to listen to, default is \"0.0.0.0\"",
+                    "type": "string"
+                  },
+                  "bodySizeLimit": {
+                    "description": "The size limit of the POSTed element.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "corsAllOrigins": {
+                    "description": "Whitelist domains for CORS.",
+                    "type": "string"
+                  },
+                  "corsAllowCredentials": {
+                    "description": "Add Access-Control-Allow-Credentials header. It's needed when a request's credentials mode is include",
+                    "type": "string"
+                  },
+                  "keepaliveTimeout": {
+                    "description": "The timeout limit for keeping the connection alive.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "parse": {
+                    "description": "The parse section of http plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "port": {
+                    "description": "The port to listen to, default is 9880.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "respondsWithEmptyImg": {
+                    "description": "Responds with an empty GIF image of 1x1 pixel (rather than an empty string).",
+                    "type": "boolean"
+                  },
+                  "transport": {
+                    "description": "The transport section of http plugin",
+                    "properties": {
+                      "caCertPath": {
+                        "description": "for Cert generated",
+                        "type": "string"
+                      },
+                      "caPath": {
+                        "description": "for Cert signed by public CA",
+                        "type": "string"
+                      },
+                      "caPrivateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "caPrivateKeyPath": {
+                        "type": "string"
+                      },
+                      "certPath": {
+                        "type": "string"
+                      },
+                      "certVerifier": {
+                        "description": "other parameters",
+                        "type": "string"
+                      },
+                      "ciphers": {
+                        "type": "string"
+                      },
+                      "clientCertAuth": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "privateKeyPassphrase": {
+                        "type": "string"
+                      },
+                      "privateKeyPath": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "description": "The protocal name of this plugin, i.e: tls",
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "The @id parameter specifies a unique name for the configuration.",
+                "type": "string"
+              },
+              "label": {
+                "description": "The @label parameter is to route the input events to <label> sections.",
+                "type": "string"
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "monitorAgent": {
+                "description": "monitor_agent plugin",
+                "properties": {
+                  "bind": {
+                    "description": "The bind address to listen to.",
+                    "type": "string"
+                  },
+                  "emitInterval": {
+                    "description": "The interval time between event emits. This will be used when \"tag\" is configured.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "includeConfig": {
+                    "description": "You can set this option to false to remove the config field from the response.",
+                    "type": "boolean"
+                  },
+                  "includeRetry": {
+                    "description": "You can set this option to false to remove the retry field from the response.",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "The port to listen to.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "tag": {
+                    "description": "If you set this parameter, this plugin emits metrics as records.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "sample": {
+                "description": "in_sample plugin",
+                "properties": {
+                  "autoIncrementKey": {
+                    "description": "If specified, each generated event has an auto-incremented key field.",
+                    "type": "string"
+                  },
+                  "rate": {
+                    "description": "It configures how many events to generate per second.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "sample": {
+                    "description": "The sample data to be generated. It should be either an array of JSON hashes or a single JSON hash. If it is an array of JSON hashes, the hashes in the array are cycled through in order.",
+                    "type": "string"
+                  },
+                  "size": {
+                    "description": "The number of events in the event stream of each emit.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "tag": {
+                    "description": "The tag of the event. The value is the tag assigned to the generated events.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "tail": {
+                "description": "in_tail plugin",
+                "properties": {
+                  "emitUnmatchedLines": {
+                    "description": "Emits unmatched lines when <parse> format is not matched for incoming logs.",
+                    "type": "boolean"
+                  },
+                  "enableStatWatcher": {
+                    "description": "Enables the additional inotify-based watcher. Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.\nThis option is mainly for avoiding the stuck issue with inotify.",
+                    "type": "boolean"
+                  },
+                  "enableWatchTimer": {
+                    "description": "Enables the additional watch timer. Setting this parameter to false will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with inotify support.\nThe default is true which results in an additional 1 second timer being used.",
+                    "type": "boolean"
+                  },
+                  "encoding": {
+                    "description": "Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.\nIf encoding is specified, in_tail changes string to encoding.\nIf encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.",
+                    "type": "string"
+                  },
+                  "excludePath": {
+                    "description": "The paths excluded from the watcher list.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "followInodes": {
+                    "description": "Avoid to read rotated files duplicately. You should set true when you use * or strftime format in path.",
+                    "type": "boolean"
+                  },
+                  "fromEncoding": {
+                    "description": "Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.\nIf encoding is specified, in_tail changes string to encoding.\nIf encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.",
+                    "type": "string"
+                  },
+                  "group": {
+                    "description": "The in_tail plugin can assign each log file to a group, based on user defined rules.\nThe limit parameter controls the total number of lines collected for a group within a rate_period time interval.",
+                    "properties": {
+                      "pattern": {
+                        "description": "Specifies the regular expression for extracting metadata (namespace, podname) from log file path.\nDefault value of the pattern regexp extracts information about namespace, podname, docker_id, container of the log (K8s specific).",
+                        "type": "string"
+                      },
+                      "ratePeriod": {
+                        "description": "Time period in which the group line limit is applied. in_tail resets the counter after every rate_period interval.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "rule": {
+                        "description": "Grouping rules for log files.",
+                        "properties": {
+                          "limit": {
+                            "description": "Maximum number of lines allowed from a group in rate_period time interval. The default value of -1 doesn't throttle log files of that group.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "match": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "match parameter is used to check if a file belongs to a particular group based on hash keys (named captures from pattern) and hash values (regexp in string)",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "rule"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ignoreRepeatedPermissionError": {
+                    "description": "If you have to exclude the non-permission files from the watch list, set this parameter to true. It suppresses the repeated permission error logs.",
+                    "type": "boolean"
+                  },
+                  "limitRecentlyModified": {
+                    "description": "Limits the watching files that the modification time is within the specified time range when using * in path.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxLineSize": {
+                    "description": "The maximum length of a line. Longer lines than it will be just skipped.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "multilineFlushInterval": {
+                    "description": "The interval of flushing the buffer for multiline format.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "openOnEveryUpdate": {
+                    "description": "Opens and closes the file on every update instead of leaving it open until it gets rotated.",
+                    "type": "boolean"
+                  },
+                  "parse": {
+                    "description": "Parse defines various parameters for the parse plugin",
+                    "properties": {
+                      "customPatternPath": {
+                        "description": "Path to the file that includes custom grok patterns.",
+                        "type": "string"
+                      },
+                      "estimateCurrentEvent": {
+                        "description": "If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified.",
+                        "type": "boolean"
+                      },
+                      "expression": {
+                        "description": "Specifies the regular expression for matching logs. Regular expression also supports i and m suffix.",
+                        "type": "string"
+                      },
+                      "grok": {
+                        "description": "Grok Sections",
+                        "items": {
+                          "properties": {
+                            "keepTimeKey": {
+                              "description": "If true, keep time field in the record.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The name of this grok section.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "The pattern of grok. Required parameter.",
+                              "type": "string"
+                            },
+                            "timeFormat": {
+                              "description": "Process value using specified format. This is available only when time_type is string",
+                              "type": "string"
+                            },
+                            "timeKey": {
+                              "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                              "type": "string"
+                            },
+                            "timeZone": {
+                              "description": "Use specified timezone. one can parse/format the time value in the specified timezone.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "grokFailureKey": {
+                        "description": "The key has grok failure reason.",
+                        "type": "string"
+                      },
+                      "grokPattern": {
+                        "description": "The pattern of grok.",
+                        "type": "string"
+                      },
+                      "grokPatternSeries": {
+                        "description": "Specify grok pattern series set.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "keepTimeKey": {
+                        "description": "If true, keep time field in th record.",
+                        "type": "boolean"
+                      },
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "multiLineStartRegexp": {
+                        "description": "The regexp to match beginning of multiline. This is only for \"multiline_grok\".",
+                        "type": "string"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeKey": {
+                        "description": "Specify time field for event time. If the event doesn't have this field, current time is used.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "description": "Specify timeout for parse processing.",
+                        "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "regexp",
+                          "apache2",
+                          "apache_error",
+                          "nginx",
+                          "syslog",
+                          "csv",
+                          "tsv",
+                          "ltsv",
+                          "json",
+                          "multiline",
+                          "none",
+                          "grok",
+                          "multiline_grok"
+                        ],
+                        "type": "string"
+                      },
+                      "types": {
+                        "description": "Specify types for converting field into another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "The path(s) to read. Multiple paths can be specified, separated by comma ','.",
+                    "type": "string"
+                  },
+                  "pathKey": {
+                    "description": "Adds the watching file path to the path_key field.",
+                    "type": "string"
+                  },
+                  "pathTimezone": {
+                    "description": "This parameter is for strftime formatted path like /path/to/%Y/%m/%d/.",
+                    "type": "string"
+                  },
+                  "posFile": {
+                    "description": "(recommended) Fluentd will record the position it last read from this file.\npos_file handles multiple positions in one file so no need to have multiple pos_file parameters per source.\nDon't share pos_file between in_tail configurations. It causes unexpected behavior e.g. corrupt pos_file content.",
+                    "type": "string"
+                  },
+                  "posFileCompactionInterval": {
+                    "description": "The interval of doing compaction of pos file.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readBytesLimitPerSecond": {
+                    "description": "The number of reading bytes per second to read with I/O operation. This value should be equal or greater than 8192.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readFromHead": {
+                    "description": "Starts to read the logs from the head of the file or the last read position recorded in pos_file, not tail.",
+                    "type": "boolean"
+                  },
+                  "readLinesLimit": {
+                    "description": "The number of lines to read with each I/O operation.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "refreshInterval": {
+                    "description": "The interval to refresh the list of watch files. This is used when the path includes *.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "rotateWait": {
+                    "description": "in_tail actually does a bit more than tail -F itself. When rotating a file, some data may still need to be written to the old file as opposed to the new one.\nin_tail takes care of this by keeping a reference to the old file (even after it has been rotated) for some time before transitioning completely to the new file.\nThis helps prevent data designated for the old file from getting lost. By default, this time interval is 5 seconds.\nThe rotate_wait parameter accepts a single integer representing the number of seconds you want this time interval to be.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "skipRefreshOnStartup": {
+                    "description": "Skips the refresh of the watch list on startup. This reduces the startup time when * is used in path.",
+                    "type": "boolean"
+                  },
+                  "tag": {
+                    "description": "The tag of the event.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parse",
+                  "path",
+                  "tag"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "InputStatus defines the observed state of Input",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/output_v1alpha1.json
+++ b/fluentd.fluent.io/output_v1alpha1.json
@@ -1,0 +1,2552 @@
+{
+  "description": "Output is the Schema for the outputs API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OutputSpec defines the desired state of Output",
+      "properties": {
+        "outputs": {
+          "items": {
+            "description": "Output defines all available output plugins and their parameters",
+            "properties": {
+              "buffer": {
+                "description": "buffer section",
+                "properties": {
+                  "calcNumRecords": {
+                    "description": "Calculates the number of records, chunk size, during chunk resume.",
+                    "type": "string"
+                  },
+                  "chunkFormat": {
+                    "description": "ChunkFormat specifies the chunk format for calc_num_records.",
+                    "enum": [
+                      "msgpack",
+                      "text",
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  "chunkLimitRecords": {
+                    "description": "The max number of events that each chunks can store in it.",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "chunkLimitSize": {
+                    "description": "Buffer parameters\nThe max size of each chunks: events will be written into chunks until the size of chunks become this size\nDefault: 8MB (memory) / 256MB (file)",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "compress": {
+                    "description": "Fluentd will decompress these compressed chunks automatically before passing them to the output plugin\nIf gzip is set, Fluentd compresses data records before writing to buffer chunks.\nDefault:text.",
+                    "enum": [
+                      "text",
+                      "gzip"
+                    ],
+                    "type": "string"
+                  },
+                  "delayedCommitTimeout": {
+                    "description": "The timeout (seconds) until output plugin decides if the async write operation has failed. Default is 60s",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "disableChunkBackup": {
+                    "description": "Instead of storing unrecoverable chunks in the backup directory, just discard them. This option is new in Fluentd v1.2.6.",
+                    "type": "boolean"
+                  },
+                  "flushAtShutdown": {
+                    "description": "Flush parameters\nThis specifies whether to flush/write all buffer chunks on shutdown or not.",
+                    "type": "boolean"
+                  },
+                  "flushInterval": {
+                    "description": "FlushInterval defines the flush interval",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "flushMode": {
+                    "description": "FlushMode defines the flush mode:\nlazy: flushes/writes chunks once per timekey\ninterval: flushes/writes chunks per specified time via flush_interval\nimmediate: flushes/writes chunks immediately after events are appended into chunks\ndefault: equals to lazy if time is specified as chunk key, interval otherwise",
+                    "enum": [
+                      "default",
+                      "lazy",
+                      "interval",
+                      "immediate"
+                    ],
+                    "type": "string"
+                  },
+                  "flushThreadCount": {
+                    "description": "The number of threads to flush/write chunks in parallel",
+                    "pattern": "^\\d+$",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "The @id parameter specifies a unique name for the configuration.",
+                    "type": "string"
+                  },
+                  "localtime": {
+                    "description": "If true, uses local time.",
+                    "type": "boolean"
+                  },
+                  "logLevel": {
+                    "description": "The @log_level parameter specifies the plugin-specific logging level",
+                    "type": "string"
+                  },
+                  "overflowAction": {
+                    "description": "OverflowAtction defines the output plugin behave when its buffer queue is full.\nDefault: throw_exception",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "The path where buffer chunks are stored. This field would make no effect in memory buffer plugin.",
+                    "type": "string"
+                  },
+                  "pathSuffix": {
+                    "description": "Changes the suffix of the buffer file.",
+                    "type": "string"
+                  },
+                  "queueLimitLength": {
+                    "description": "The queue length limitation of this buffer plugin instance. Default: 0.95",
+                    "pattern": "^\\d+.?\\d+$",
+                    "type": "string"
+                  },
+                  "queuedChunksLimitSize": {
+                    "description": "Limit the number of queued chunks. Default: 1\nIf a smaller flush_interval is set, e.g. 1s,\nthere are lots of small queued chunks in the buffer.\nWith file buffer, it may consume a lot of fd resources when output destination has a problem.\nThis parameter mitigates such situations.",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "retryExponentialBackoffBase": {
+                    "description": "The base number of exponential backoff for retries.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?$",
+                    "type": "string"
+                  },
+                  "retryForever": {
+                    "description": "If true, plugin will ignore retry_timeout and retry_max_times options and retry flushing forever.",
+                    "type": "boolean"
+                  },
+                  "retryMaxInterval": {
+                    "description": "The maximum interval (seconds) for exponential backoff between retries while failing",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "retryMaxTimes": {
+                    "description": "The maximum number of times to retry to flush the failed chunks. Default: none",
+                    "type": "integer"
+                  },
+                  "retryRandomize": {
+                    "description": "If true, the output plugin will retry after randomized interval not to do burst retries",
+                    "type": "boolean"
+                  },
+                  "retrySecondaryThreshold": {
+                    "description": "The ratio of retry_timeout to switch to use the secondary while failing.",
+                    "pattern": "^\\d+.?\\d+$",
+                    "type": "string"
+                  },
+                  "retryTimeout": {
+                    "description": "Retry parameters\nThe maximum time (seconds) to retry to flush again the failed chunks, until the plugin discards the buffer chunks",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "retryType": {
+                    "description": "Output plugin will retry periodically with fixed intervals.",
+                    "type": "string"
+                  },
+                  "retryWait": {
+                    "description": "Wait in seconds before the next retry to flush or constant factor of exponential backoff",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "The output plugins group events into chunks.\nChunk keys, specified as the argument of <buffer> section, control how to group events into chunks.\nIf tag is empty, which means blank Chunk Keys.\nTag also supports Nested Field, combination of Chunk Keys, placeholders, etc.\nSee https://docs.fluentd.org/configuration/buffer-section.",
+                    "type": "string"
+                  },
+                  "timeFormat": {
+                    "description": "Process value according to the specified format. This is available only when time_type is string",
+                    "type": "string"
+                  },
+                  "timeFormatFallbacks": {
+                    "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                    "type": "string"
+                  },
+                  "timeType": {
+                    "description": "parses/formats value according to this type, default is string",
+                    "enum": [
+                      "float",
+                      "unixtime",
+                      "string",
+                      "mixed"
+                    ],
+                    "type": "string"
+                  },
+                  "timekey": {
+                    "description": "Output plugin will flush chunks per specified time (enabled when time is specified in chunk keys)",
+                    "type": "string"
+                  },
+                  "timekeyWait": {
+                    "description": "Output plugin will write chunks after timekey_wait seconds later after timekey expiration",
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "description": "Uses the specified timezone.",
+                    "type": "string"
+                  },
+                  "totalLimitSize": {
+                    "description": "The size limitation of this buffer plugin instance\nDefault: 512MB (memory) / 64GB (file)",
+                    "pattern": "^\\d+(KB|MB|GB|TB)$",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "The @type parameter specifies the type of the plugin.",
+                    "enum": [
+                      "file",
+                      "memory",
+                      "file_single"
+                    ],
+                    "type": "string"
+                  },
+                  "utc": {
+                    "description": "If true, uses UTC.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cloudWatch": {
+                "description": "out_cloudwatch plugin",
+                "properties": {
+                  "autoCreateStream": {
+                    "type": "boolean"
+                  },
+                  "awsEcsAuthentication": {
+                    "type": "boolean"
+                  },
+                  "awsKeyId": {
+                    "description": "Secret defines the key of a value.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "awsSecKey": {
+                    "description": "Secret defines the key of a value.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "awsStsDurationSeconds": {
+                    "type": "string"
+                  },
+                  "awsStsEndpointUrl": {
+                    "type": "string"
+                  },
+                  "awsStsExternalId": {
+                    "type": "string"
+                  },
+                  "awsStsPolicy": {
+                    "type": "string"
+                  },
+                  "awsStsRoleArn": {
+                    "type": "string"
+                  },
+                  "awsStsSessionName": {
+                    "type": "string"
+                  },
+                  "awsUseSts": {
+                    "type": "boolean"
+                  },
+                  "concurrency": {
+                    "type": "integer"
+                  },
+                  "durationSeconds": {
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "description": "Specify an AWS endpoint to send data to.",
+                    "type": "string"
+                  },
+                  "httpProxy": {
+                    "type": "string"
+                  },
+                  "includeTimeKey": {
+                    "type": "boolean"
+                  },
+                  "jsonHandler": {
+                    "type": "string"
+                  },
+                  "localtime": {
+                    "type": "boolean"
+                  },
+                  "logGroupAwsTags": {
+                    "type": "string"
+                  },
+                  "logGroupAwsTagsKey": {
+                    "type": "string"
+                  },
+                  "logGroupName": {
+                    "type": "string"
+                  },
+                  "logGroupNameKey": {
+                    "type": "string"
+                  },
+                  "logRejectedRequest": {
+                    "type": "string"
+                  },
+                  "logStreamName": {
+                    "type": "string"
+                  },
+                  "logStreamNameKey": {
+                    "type": "string"
+                  },
+                  "maxEventsPerBatch": {
+                    "type": "string"
+                  },
+                  "maxMessageLength": {
+                    "type": "string"
+                  },
+                  "messageKeys": {
+                    "type": "string"
+                  },
+                  "policy": {
+                    "type": "string"
+                  },
+                  "putLogEventsDisableRetryLimit": {
+                    "type": "boolean"
+                  },
+                  "putLogEventsRetryLimit": {
+                    "type": "string"
+                  },
+                  "putLogEventsRetryWait": {
+                    "type": "string"
+                  },
+                  "region": {
+                    "description": "The AWS region.",
+                    "type": "string"
+                  },
+                  "removeLogGroupAwsTagsKey": {
+                    "type": "boolean"
+                  },
+                  "removeLogGroupNameKey": {
+                    "type": "boolean"
+                  },
+                  "removeLogStreamNameKey": {
+                    "type": "boolean"
+                  },
+                  "removeRetentionInDaysKey": {
+                    "type": "boolean"
+                  },
+                  "retentionInDays": {
+                    "type": "string"
+                  },
+                  "retentionInDaysKey": {
+                    "type": "string"
+                  },
+                  "roleArn": {
+                    "description": "ARN of an IAM role to assume (for cross account access).",
+                    "type": "string"
+                  },
+                  "roleSessionName": {
+                    "description": "Role Session name",
+                    "type": "string"
+                  },
+                  "sslVerifyPeer": {
+                    "type": "boolean"
+                  },
+                  "useTagAsGroup": {
+                    "type": "string"
+                  },
+                  "useTagAsStream": {
+                    "type": "string"
+                  },
+                  "webIdentityTokenFile": {
+                    "description": "Web identity token file",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "copy": {
+                "description": "copy plugin",
+                "properties": {
+                  "copyMode": {
+                    "description": "CopyMode defines how to pass the events to <store> plugins.",
+                    "enum": [
+                      "no_copy",
+                      "shallow",
+                      "deep",
+                      "marshal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "copyMode"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "customPlugin": {
+                "description": "Custom plugin type",
+                "properties": {
+                  "config": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "datadog": {
+                "description": "datadog plugin",
+                "properties": {
+                  "apiKey": {
+                    "description": "This parameter is required in order to authenticate your fluent agent.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "compressionLevel": {
+                    "description": "Set the log compression level for HTTP (1 to 9, 9 being the best ratio)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "ddHostname": {
+                    "description": "Used by Datadog to identify the host submitting the logs.",
+                    "type": "string"
+                  },
+                  "ddSource": {
+                    "description": "This tells Datadog what integration it is",
+                    "type": "string"
+                  },
+                  "ddSourcecategory": {
+                    "description": "Multiple value attribute. Can be used to refine the source attribute",
+                    "type": "string"
+                  },
+                  "ddTags": {
+                    "description": "Custom tags with the following format \"key1:value1, key2:value2\"",
+                    "type": "string"
+                  },
+                  "host": {
+                    "description": "Proxy endpoint when logs are not directly forwarded to Datadog",
+                    "type": "string"
+                  },
+                  "httpProxy": {
+                    "description": "HTTP proxy, only takes effect if HTTP forwarding is enabled (use_http). Defaults to HTTP_PROXY/http_proxy env vars.",
+                    "type": "string"
+                  },
+                  "includeTagKey": {
+                    "description": "Automatically include the Fluentd tag in the record.",
+                    "type": "boolean"
+                  },
+                  "maxBackoff": {
+                    "description": "The maximum time waited between each retry in seconds",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "maxRetries": {
+                    "description": "The number of retries before the output plugin stops. Set to -1 for unlimited retries",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "noSSLValidation": {
+                    "description": "Disable SSL validation (useful for proxy forwarding)",
+                    "type": "boolean"
+                  },
+                  "port": {
+                    "description": "Proxy port when logs are not directly forwarded to Datadog and ssl is not used",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "service": {
+                    "description": "Used by Datadog to correlate between logs, traces and metrics.",
+                    "type": "string"
+                  },
+                  "sslPort": {
+                    "description": "Port used to send logs over a SSL encrypted connection to Datadog. If use_http is disabled, use 10516 for the US region and 443 for the EU region.",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "tagKey": {
+                    "description": "Where to store the Fluentd tag.",
+                    "type": "string"
+                  },
+                  "timestampKey": {
+                    "description": "Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added.",
+                    "type": "string"
+                  },
+                  "useCompression": {
+                    "description": "Enable log compression for HTTP",
+                    "type": "boolean"
+                  },
+                  "useHTTP": {
+                    "description": "Enable HTTP forwarding. If you disable it, make sure to change the port to 10514 or ssl_port to 10516",
+                    "type": "boolean"
+                  },
+                  "useJson": {
+                    "description": "Event format, if true, the event is sent in json format. Othwerwise, in plain text.",
+                    "type": "boolean"
+                  },
+                  "useSSL": {
+                    "description": "If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "elasticsearch": {
+                "description": "out_es plugin",
+                "properties": {
+                  "caFile": {
+                    "description": "Optional, Absolute path to CA certificate file",
+                    "type": "string"
+                  },
+                  "clientCert": {
+                    "description": "Optional, Absolute path to client Certificate file",
+                    "type": "string"
+                  },
+                  "clientKey": {
+                    "description": "Optional, Absolute path to client private Key file",
+                    "type": "string"
+                  },
+                  "clientKeyPassword": {
+                    "description": "Optional, password for ClientKey file",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudAuth": {
+                    "description": "Authenticate towards Elastic Cloud using cloudAuth.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudId": {
+                    "description": "Authenticate towards Elastic Cloud using CloudId. If set, cloudAuth must\nbe set as well and host, port, user and password are ignored.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "enableIlm": {
+                    "description": "Optional, Enable Index Lifecycle Management (ILM)",
+                    "type": "boolean"
+                  },
+                  "failOnPuttingTemplateRetryExceeded": {
+                    "description": "Optional, Indicates whether to fail when max_retry_putting_template is exceeded. If you have multiple output plugin, you could use this property to do not fail on fluentd statup (default: false)",
+                    "type": "boolean"
+                  },
+                  "host": {
+                    "description": "The hostname of your Elasticsearch node (default: localhost).",
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "description": "Hosts defines a list of hosts if you want to connect to more than one Elasticsearch nodes",
+                    "type": "string"
+                  },
+                  "ilmPolicy": {
+                    "description": "Optional, Specify ILM policy contents as Hash",
+                    "type": "string"
+                  },
+                  "ilmPolicyId": {
+                    "description": "Optional, Specify ILM policy id",
+                    "type": "string"
+                  },
+                  "ilmPolicyOverride": {
+                    "description": "Optional, Specify whether overwriting ilm policy or not",
+                    "type": "boolean"
+                  },
+                  "indexName": {
+                    "description": "IndexName defines the placeholder syntax of Fluentd plugin API. See https://docs.fluentd.org/configuration/buffer-section.",
+                    "type": "string"
+                  },
+                  "logEs400Reason": {
+                    "description": "Optional, Enable logging of 400 reason without enabling debug log level",
+                    "type": "boolean"
+                  },
+                  "logstashFormat": {
+                    "description": "If true, Fluentd uses the conventional index name format logstash-%Y.%m.%d (default: false). This option supersedes the index_name option.",
+                    "type": "boolean"
+                  },
+                  "logstashPrefix": {
+                    "description": "LogstashPrefix defines the logstash prefix index name to write events when logstash_format is true (default: logstash).",
+                    "type": "string"
+                  },
+                  "maxRetryPuttingTemplate": {
+                    "description": "Optional, You can specify times of retry putting template (default: 10)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path defines the REST API endpoint of Elasticsearch to post write requests (default: nil).",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "The port number of your Elasticsearch node (default: 9200).",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "reconnectOnError": {
+                    "description": "Optional, Indicates that the plugin should reset connection on any error (reconnect on next send) (default: false)",
+                    "type": "boolean"
+                  },
+                  "reloadConnections": {
+                    "description": "Optional, Automatically reload connection after 10000 documents (default: true)",
+                    "type": "boolean"
+                  },
+                  "reloadOnFailure": {
+                    "description": "Optional, Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the request, this can be useful to quickly remove a dead node from the list of addresses (default: false)",
+                    "type": "boolean"
+                  },
+                  "requestTimeout": {
+                    "description": "Optional, HTTP Timeout (default: 5)",
+                    "pattern": "^\\d+(s|m|h|d)$",
+                    "type": "string"
+                  },
+                  "scheme": {
+                    "description": "Specify https if your Elasticsearch endpoint supports SSL (default: http).",
+                    "type": "string"
+                  },
+                  "sslVerify": {
+                    "description": "Optional, Force certificate validation",
+                    "type": "boolean"
+                  },
+                  "suppressTypeName": {
+                    "description": "Optional, Suppress '[types removal]' warnings on elasticsearch 7.x",
+                    "type": "boolean"
+                  },
+                  "templateOverwrite": {
+                    "description": "Optional, Always update the template, even if it already exists (default: false)",
+                    "type": "boolean"
+                  },
+                  "user": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "elasticsearchDataStream": {
+                "description": "out_es datastreams plugin",
+                "properties": {
+                  "caFile": {
+                    "description": "Optional, Absolute path to CA certificate file",
+                    "type": "string"
+                  },
+                  "clientCert": {
+                    "description": "Optional, Absolute path to client Certificate file",
+                    "type": "string"
+                  },
+                  "clientKey": {
+                    "description": "Optional, Absolute path to client private Key file",
+                    "type": "string"
+                  },
+                  "clientKeyPassword": {
+                    "description": "Optional, password for ClientKey file",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudAuth": {
+                    "description": "Authenticate towards Elastic Cloud using cloudAuth.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cloudId": {
+                    "description": "Authenticate towards Elastic Cloud using CloudId. If set, cloudAuth must\nbe set as well and host, port, user and password are ignored.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "dataStreamIlmName": {
+                    "description": "Optional, You can specify the name of an existing ILM policy, which will be applied to the data stream. If not present, it creates a new ILM default policy (unless data_stream_template_name is defined, in that case the ILM will be set to the one specified in the matching index template)",
+                    "type": "string"
+                  },
+                  "dataStreamIlmPolicy": {
+                    "description": "Optional, You can specify the ILM policy contents as hash. If not present, it will apply the ILM default policy",
+                    "type": "string"
+                  },
+                  "dataStreamIlmPolicyOverwrite": {
+                    "description": "Optional, Specify whether the data stream ILM policy should be overwritten",
+                    "type": "boolean"
+                  },
+                  "dataStreamName": {
+                    "description": "You can specify Elasticsearch data stream name by this parameter. This parameter is mandatory for elasticsearch_data_stream",
+                    "type": "string"
+                  },
+                  "dataStreamTemplateName": {
+                    "description": "Optional, You can specify an existing matching index template for the data stream. If not present, it creates a new matching index template",
+                    "type": "string"
+                  },
+                  "dataStreamTemplateUseIndexPatternsWildcard": {
+                    "description": "Optional, Specify whether index patterns should include a wildcard (*) when creating an index template. This is particularly useful to prevent errors in scenarios where index templates are generated automatically, and multiple services with distinct suffixes are in use",
+                    "type": "boolean"
+                  },
+                  "enableIlm": {
+                    "description": "Optional, Enable Index Lifecycle Management (ILM)",
+                    "type": "boolean"
+                  },
+                  "failOnPuttingTemplateRetryExceeded": {
+                    "description": "Optional, Indicates whether to fail when max_retry_putting_template is exceeded. If you have multiple output plugin, you could use this property to do not fail on fluentd statup (default: false)",
+                    "type": "boolean"
+                  },
+                  "host": {
+                    "description": "The hostname of your Elasticsearch node (default: localhost).",
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "description": "Hosts defines a list of hosts if you want to connect to more than one Elasticsearch nodes",
+                    "type": "string"
+                  },
+                  "ilmPolicy": {
+                    "description": "Optional, Specify ILM policy contents as Hash",
+                    "type": "string"
+                  },
+                  "ilmPolicyId": {
+                    "description": "Optional, Specify ILM policy id",
+                    "type": "string"
+                  },
+                  "ilmPolicyOverride": {
+                    "description": "Optional, Specify whether overwriting ilm policy or not",
+                    "type": "boolean"
+                  },
+                  "logEs400Reason": {
+                    "description": "Optional, Enable logging of 400 reason without enabling debug log level",
+                    "type": "boolean"
+                  },
+                  "maxRetryPuttingTemplate": {
+                    "description": "Optional, You can specify times of retry putting template (default: 10)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "password": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path defines the REST API endpoint of Elasticsearch to post write requests (default: nil).",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "The port number of your Elasticsearch node (default: 9200).",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "reconnectOnError": {
+                    "description": "Optional, Indicates that the plugin should reset connection on any error (reconnect on next send) (default: false)",
+                    "type": "boolean"
+                  },
+                  "reloadConnections": {
+                    "description": "Optional, Automatically reload connection after 10000 documents (default: true)",
+                    "type": "boolean"
+                  },
+                  "reloadOnFailure": {
+                    "description": "Optional, Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the request, this can be useful to quickly remove a dead node from the list of addresses (default: false)",
+                    "type": "boolean"
+                  },
+                  "requestTimeout": {
+                    "description": "Optional, HTTP Timeout (default: 5)",
+                    "pattern": "^\\d+(s|m|h|d)$",
+                    "type": "string"
+                  },
+                  "scheme": {
+                    "description": "Specify https if your Elasticsearch endpoint supports SSL (default: http).",
+                    "type": "string"
+                  },
+                  "sslVerify": {
+                    "description": "Optional, Force certificate validation",
+                    "type": "boolean"
+                  },
+                  "suppressTypeName": {
+                    "description": "Optional, Suppress '[types removal]' warnings on elasticsearch 7.x",
+                    "type": "boolean"
+                  },
+                  "templateOverwrite": {
+                    "description": "Optional, Always update the template, even if it already exists (default: false)",
+                    "type": "boolean"
+                  },
+                  "user": {
+                    "description": "Optional, The login credentials to connect to Elasticsearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "dataStreamName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "format": {
+                "description": "format section",
+                "properties": {
+                  "delimiter": {
+                    "description": "Delimiter for each field.",
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "The @id parameter specifies a unique name for the configuration.",
+                    "type": "string"
+                  },
+                  "localtime": {
+                    "description": "If true, uses local time.",
+                    "type": "boolean"
+                  },
+                  "logLevel": {
+                    "description": "The @log_level parameter specifies the plugin-specific logging level",
+                    "type": "string"
+                  },
+                  "newline": {
+                    "description": "Specify newline characters.",
+                    "enum": [
+                      "lf",
+                      "crlf"
+                    ],
+                    "type": "string"
+                  },
+                  "outputTag": {
+                    "description": "Output tag field if true.",
+                    "type": "boolean"
+                  },
+                  "outputTime": {
+                    "description": "Output time field if true.",
+                    "type": "boolean"
+                  },
+                  "timeFormat": {
+                    "description": "Process value according to the specified format. This is available only when time_type is string",
+                    "type": "string"
+                  },
+                  "timeFormatFallbacks": {
+                    "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                    "type": "string"
+                  },
+                  "timeType": {
+                    "description": "parses/formats value according to this type, default is string",
+                    "enum": [
+                      "float",
+                      "unixtime",
+                      "string",
+                      "mixed"
+                    ],
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "description": "Uses the specified timezone.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "The @type parameter specifies the type of the plugin.",
+                    "enum": [
+                      "out_file",
+                      "json",
+                      "ltsv",
+                      "csv",
+                      "msgpack",
+                      "hash",
+                      "single_value"
+                    ],
+                    "type": "string"
+                  },
+                  "utc": {
+                    "description": "If true, uses UTC.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "forward": {
+                "description": "out_forward plugin",
+                "properties": {
+                  "ackResponseTimeout": {
+                    "description": "This option is used when require_ack_response is true. This default value is based on popular tcp_syn_retries.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "connectTimeout": {
+                    "description": "The connection timeout for the socket. When the connection is timed out during the connection establishment, Errno::ETIMEDOUT error is raised.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "dnsRoundRobin": {
+                    "description": "Enable client-side DNS round robin. Uniform randomly pick an IP address to send data when a hostname has several IP addresses.\nheartbeat_type udp is not available with dns_round_robintrue. Use heartbeat_type tcp or heartbeat_type none.",
+                    "type": "boolean"
+                  },
+                  "expireDnsCache": {
+                    "description": "Sets TTL to expire DNS cache in seconds. Set 0 not to use DNS Cache.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "hardTimeout": {
+                    "description": "The hard timeout used to detect server failure. The default value is equal to the send_timeout parameter.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "heartbeatInterval": {
+                    "description": "The interval of the heartbeat packer.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "heartbeatType": {
+                    "description": "Specifies the transport protocol for heartbeats. Set none to disable.",
+                    "enum": [
+                      "transport",
+                      "tcp",
+                      "udp",
+                      "none"
+                    ],
+                    "type": "string"
+                  },
+                  "ignoreNetworkErrorsAtStartup": {
+                    "description": "Ignores DNS resolution and errors at startup time.",
+                    "type": "boolean"
+                  },
+                  "keepalive": {
+                    "description": "Enables the keepalive connection.",
+                    "type": "boolean"
+                  },
+                  "keepaliveTimeout": {
+                    "description": "Timeout for keepalive. Default value is nil which means to keep the connection alive as long as possible.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "phiFailureDetector": {
+                    "description": "Use the \"Phi accrual failure detector\" to detect server failure.",
+                    "type": "boolean"
+                  },
+                  "phiThreshold": {
+                    "description": "The threshold parameter used to detect server faults.",
+                    "type": "integer"
+                  },
+                  "recoverWait": {
+                    "description": "The wait time before accepting a server fault recovery.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "requireAckResponse": {
+                    "description": "Changes the protocol to at-least-once. The plugin waits the ack from destination's in_forward plugin.",
+                    "type": "boolean"
+                  },
+                  "security": {
+                    "description": "ServiceDiscovery defines the security section",
+                    "properties": {
+                      "allowAnonymousSource": {
+                        "description": "Allows the anonymous source. <client> sections are required, if disabled.",
+                        "type": "string"
+                      },
+                      "selfHostname": {
+                        "description": "The hostname.",
+                        "type": "string"
+                      },
+                      "sharedKey": {
+                        "description": "The shared key for authentication.",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "Defines user section directly.",
+                        "properties": {
+                          "password": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "description": "Secret defines the key of a value.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "userAuth": {
+                        "description": "If true, user-based authentication is used.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "sendTimeout": {
+                    "description": "The timeout time when sending event logs.",
+                    "pattern": "^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$",
+                    "type": "string"
+                  },
+                  "servers": {
+                    "description": "Servers defines the servers section, at least one is required",
+                    "items": {
+                      "description": "Server defines the common parameters for the server plugin",
+                      "properties": {
+                        "host": {
+                          "description": "Host defines the IP address or host name of the server.",
+                          "type": "string"
+                        },
+                        "id": {
+                          "description": "The @id parameter specifies a unique name for the configuration.",
+                          "type": "string"
+                        },
+                        "logLevel": {
+                          "description": "The @log_level parameter specifies the plugin-specific logging level",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name defines the name of the server. Used for logging and certificate verification in TLS transport (when the host is the address).",
+                          "type": "string"
+                        },
+                        "password": {
+                          "description": "Password defines the password for authentication.",
+                          "properties": {
+                            "valueFrom": {
+                              "description": "ValueSource defines how to find a value's key.",
+                              "properties": {
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "port": {
+                          "description": "Port defines the port number of the host. Note that both TCP packets (event stream) and UDP packets (heartbeat messages) are sent to this port.",
+                          "type": "string"
+                        },
+                        "sharedKey": {
+                          "description": "SharedKey defines the shared key per server.",
+                          "type": "string"
+                        },
+                        "standby": {
+                          "description": "Standby marks a node as the standby node for an Active-Standby model between Fluentd nodes.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "The @type parameter specifies the type of the plugin.",
+                          "type": "string"
+                        },
+                        "username": {
+                          "description": "Username defines the username for authentication.",
+                          "properties": {
+                            "valueFrom": {
+                              "description": "ValueSource defines how to find a value's key.",
+                              "properties": {
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "weight": {
+                          "description": "Weight defines the load balancing weight",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "serviceDiscovery": {
+                    "description": "ServiceDiscovery defines the service_discovery section",
+                    "properties": {
+                      "confEncoding": {
+                        "description": "The encoding of the configuration file.",
+                        "type": "string"
+                      },
+                      "dnsLookup": {
+                        "description": "DnsLookup resolves the hostname to IP address of the SRV's Target.",
+                        "type": "string"
+                      },
+                      "dnsServerHost": {
+                        "description": "DnsServerHost defines the hostname of the DNS server to request the SRV record.",
+                        "type": "string"
+                      },
+                      "hostname": {
+                        "description": "The name in RFC2782.",
+                        "type": "string"
+                      },
+                      "id": {
+                        "description": "The @id parameter specifies a unique name for the configuration.",
+                        "type": "string"
+                      },
+                      "interval": {
+                        "description": "Interval defines the interval of sending requests to DNS server.",
+                        "type": "string"
+                      },
+                      "logLevel": {
+                        "description": "The @log_level parameter specifies the plugin-specific logging level",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "The path of the target list. Default is '/etc/fluent/sd.yaml'",
+                        "type": "string"
+                      },
+                      "proto": {
+                        "description": "Proto without the underscore in RFC2782.",
+                        "type": "string"
+                      },
+                      "server": {
+                        "description": "The server section of this plugin",
+                        "properties": {
+                          "host": {
+                            "description": "Host defines the IP address or host name of the server.",
+                            "type": "string"
+                          },
+                          "id": {
+                            "description": "The @id parameter specifies a unique name for the configuration.",
+                            "type": "string"
+                          },
+                          "logLevel": {
+                            "description": "The @log_level parameter specifies the plugin-specific logging level",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name defines the name of the server. Used for logging and certificate verification in TLS transport (when the host is the address).",
+                            "type": "string"
+                          },
+                          "password": {
+                            "description": "Password defines the password for authentication.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "port": {
+                            "description": "Port defines the port number of the host. Note that both TCP packets (event stream) and UDP packets (heartbeat messages) are sent to this port.",
+                            "type": "string"
+                          },
+                          "sharedKey": {
+                            "description": "SharedKey defines the shared key per server.",
+                            "type": "string"
+                          },
+                          "standby": {
+                            "description": "Standby marks a node as the standby node for an Active-Standby model between Fluentd nodes.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "The @type parameter specifies the type of the plugin.",
+                            "type": "string"
+                          },
+                          "username": {
+                            "description": "Username defines the username for authentication.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "ValueSource defines how to find a value's key.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight defines the load balancing weight",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "service": {
+                        "description": "Service without the underscore in RFC2782.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "The @type parameter specifies the type of the plugin.",
+                        "enum": [
+                          "static",
+                          "file",
+                          "srv"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tlsAllowSelfSignedCert": {
+                    "description": "Allows self-signed certificates or not.",
+                    "type": "boolean"
+                  },
+                  "tlsCertLogicalStoreName": {
+                    "description": "The certificate logical store name on Windows system certstore. This parameter is for Windows only.",
+                    "type": "string"
+                  },
+                  "tlsCertPath": {
+                    "description": "The additional CA certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsCertThumbprint": {
+                    "description": "The certificate thumbprint for searching from Windows system certstore. This parameter is for Windows only.",
+                    "type": "string"
+                  },
+                  "tlsCertUseEnterpriseStore": {
+                    "description": "Enables the certificate enterprise store on Windows system certstore. This parameter is for Windows only.",
+                    "type": "boolean"
+                  },
+                  "tlsCiphers": {
+                    "description": "The cipher configuration of TLS transport.",
+                    "type": "string"
+                  },
+                  "tlsClientCertPath": {
+                    "description": "The client certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsClientPrivateKeyPassphrase": {
+                    "description": "The TLS private key passphrase for the client.",
+                    "type": "string"
+                  },
+                  "tlsClientPrivateKeyPath": {
+                    "description": "The client private key path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsInsecureMode": {
+                    "description": "Skips all verification of certificates or not.",
+                    "type": "boolean"
+                  },
+                  "tlsVerifyHostname": {
+                    "description": "Verifies hostname of servers and certificates or not in TLS transport.",
+                    "type": "boolean"
+                  },
+                  "tlsVersion": {
+                    "description": "The default version of TLS transport.",
+                    "enum": [
+                      "TLSv1_1",
+                      "TLSv1_2"
+                    ],
+                    "type": "string"
+                  },
+                  "verifyConnectionAtStartup": {
+                    "description": "Verify that a connection can be made with one of out_forward nodes at the time of startup.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "servers"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "http": {
+                "description": "out_http plugin",
+                "properties": {
+                  "auth": {
+                    "description": "Auth section for this plugin",
+                    "properties": {
+                      "auth": {
+                        "description": "The method for HTTP authentication. Now only basic.",
+                        "type": "string"
+                      },
+                      "password": {
+                        "description": "The password for basic authentication.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "username": {
+                        "description": "The username for basic authentication.",
+                        "properties": {
+                          "valueFrom": {
+                            "description": "ValueSource defines how to find a value's key.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "contentType": {
+                    "description": "ContentType defines Content-Type for HTTP request. out_http automatically set Content-Type for built-in formatters when this parameter is not specified.",
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "description": "Endpoint defines the endpoint for HTTP request. If you want to use HTTPS, use https prefix.",
+                    "type": "string"
+                  },
+                  "errorResponseAsUnrecoverable": {
+                    "description": "Raise UnrecoverableError when the response code is not SUCCESS.",
+                    "type": "boolean"
+                  },
+                  "headers": {
+                    "description": "Headers defines the additional headers for HTTP request.",
+                    "type": "string"
+                  },
+                  "headersFromPlaceholders": {
+                    "description": "Additional placeholder based headers for HTTP request. If you want to use tag or record field, use this parameter instead of headers.",
+                    "type": "string"
+                  },
+                  "httpMethod": {
+                    "description": "HttpMethod defines the method for HTTP request.",
+                    "enum": [
+                      "post",
+                      "put"
+                    ],
+                    "type": "string"
+                  },
+                  "jsonArray": {
+                    "description": "JsonArray defines whether to use the array format of JSON or not",
+                    "type": "boolean"
+                  },
+                  "openTimeout": {
+                    "description": "OpenTimeout defines the connection open timeout in seconds.",
+                    "type": "integer"
+                  },
+                  "proxy": {
+                    "description": "Proxy defines the proxy for HTTP request.",
+                    "type": "string"
+                  },
+                  "readTimeout": {
+                    "description": "ReadTimeout defines the read timeout in seconds.",
+                    "type": "integer"
+                  },
+                  "retryableResponseCodes": {
+                    "description": "The list of retryable response codes. If the response code is included in this list, out_http retries the buffer flush.",
+                    "type": "string"
+                  },
+                  "sslTimeout": {
+                    "description": "SslTimeout defines the TLS timeout in seconds.",
+                    "type": "integer"
+                  },
+                  "tlsCaCertPath": {
+                    "description": "TlsCaCertPath defines the CA certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsCiphers": {
+                    "description": "TlsCiphers defines the cipher suites configuration of TLS.",
+                    "type": "string"
+                  },
+                  "tlsClientCertPath": {
+                    "description": "TlsClientCertPath defines the client certificate path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsPrivateKeyPassphrase": {
+                    "description": "TlsPrivateKeyPassphrase defines the client private key passphrase for TLS.",
+                    "type": "string"
+                  },
+                  "tlsPrivateKeyPath": {
+                    "description": "TlsPrivateKeyPath defines the client private key path for TLS.",
+                    "type": "string"
+                  },
+                  "tlsVerifyMode": {
+                    "description": "TlsVerifyMode defines the verify mode of TLS.",
+                    "enum": [
+                      "peer",
+                      "none"
+                    ],
+                    "type": "string"
+                  },
+                  "tlsVersion": {
+                    "description": "TlsVersion defines the default version of TLS transport.",
+                    "enum": [
+                      "TLSv1_1",
+                      "TLSv1_2"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "inject": {
+                "description": "inject section",
+                "properties": {
+                  "hostname": {
+                    "description": "Hostname value",
+                    "type": "string"
+                  },
+                  "hostnameKey": {
+                    "description": "The field name to inject hostname",
+                    "type": "string"
+                  },
+                  "inline": {
+                    "description": "Time section",
+                    "properties": {
+                      "localtime": {
+                        "description": "If true, uses local time.",
+                        "type": "boolean"
+                      },
+                      "timeFormat": {
+                        "description": "Process value according to the specified format. This is available only when time_type is string",
+                        "type": "string"
+                      },
+                      "timeFormatFallbacks": {
+                        "description": "Uses the specified time format as a fallback in the specified order. You can parse undetermined time format by using time_format_fallbacks. This options is enabled when time_type is mixed.",
+                        "type": "string"
+                      },
+                      "timeType": {
+                        "description": "parses/formats value according to this type, default is string",
+                        "enum": [
+                          "float",
+                          "unixtime",
+                          "string",
+                          "mixed"
+                        ],
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "description": "Uses the specified timezone.",
+                        "type": "string"
+                      },
+                      "utc": {
+                        "description": "If true, uses UTC.",
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tagKey": {
+                    "description": "The field name to inject tag",
+                    "type": "string"
+                  },
+                  "timeKey": {
+                    "description": "The field name to inject time",
+                    "type": "string"
+                  },
+                  "workerIdKey": {
+                    "description": "The field name to inject worker_id",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "kafka": {
+                "description": "out_kafka plugin",
+                "properties": {
+                  "brokers": {
+                    "description": "The list of all seed brokers, with their host and port information. Default: localhost:9092",
+                    "type": "string"
+                  },
+                  "compressionCodec": {
+                    "description": "The codec the producer uses to compress messages (default: nil).",
+                    "enum": [
+                      "gzip",
+                      "snappy"
+                    ],
+                    "type": "string"
+                  },
+                  "defaultTopic": {
+                    "description": "The name of the default topic. (default: nil)",
+                    "type": "string"
+                  },
+                  "requiredAcks": {
+                    "description": "The number of acks required per request.",
+                    "type": "integer"
+                  },
+                  "topicKey": {
+                    "description": "The field name for the target topic. If the field value is app, this plugin writes events to the app topic.",
+                    "type": "string"
+                  },
+                  "useEventTime": {
+                    "description": "Set fluentd event time to Kafka's CreateTime.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "logLevel": {
+                "description": "The @log_level parameter specifies the plugin-specific logging level",
+                "type": "string"
+              },
+              "loki": {
+                "description": "out_loki plugin",
+                "properties": {
+                  "bearerTokenFile": {
+                    "description": "Set path to file with bearer authentication token\nCan be used as alterntative to HTTP basic authentication",
+                    "type": "string"
+                  },
+                  "dropSingleKey": {
+                    "description": "If a record only has 1 key, then just set the log line to the value and discard the key.",
+                    "type": "boolean"
+                  },
+                  "extractKubernetesLabels": {
+                    "description": "If set to true, it will add all Kubernetes labels to the Stream labels.",
+                    "type": "boolean"
+                  },
+                  "httpPassword": {
+                    "description": "Password for user defined in HTTP_User\nSet HTTP basic authentication password",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpUser": {
+                    "description": "Set HTTP basic authentication user name.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "includeThreadLabel": {
+                    "description": "Whether or not to include the fluentd_thread label when multiple threads are used for flushing",
+                    "type": "boolean"
+                  },
+                  "insecure": {
+                    "description": "Disable certificate validation",
+                    "type": "boolean"
+                  },
+                  "labelKeys": {
+                    "description": "Optional list of record keys that will be placed as stream labels.\nThis configuration property is for records key only.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "labels": {
+                    "description": "Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs.\nIn addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "lineFormat": {
+                    "description": "Format to use when flattening the record to a log line. Valid values are json or key_value.\nIf set to json,  the log line sent to Loki will be the Fluentd record dumped as JSON.\nIf set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.",
+                    "enum": [
+                      "json",
+                      "key_value"
+                    ],
+                    "type": "string"
+                  },
+                  "removeKeys": {
+                    "description": "Optional list of record keys that will be removed from stream labels.\nThis configuration property is for records key only.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tenantID": {
+                    "description": "Tenant ID used by default to push logs to Loki.\nIf omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tlsCaCertFile": {
+                    "description": "TlsCaCert defines the CA certificate file for TLS.",
+                    "type": "string"
+                  },
+                  "tlsClientCertFile": {
+                    "description": "TlsClientCert defines the client certificate file for TLS.",
+                    "type": "string"
+                  },
+                  "tlsPrivateKeyFile": {
+                    "description": "TlsPrivateKey defines the client private key file for TLS.",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "Loki URL.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "opensearch": {
+                "description": "out_opensearch plugin",
+                "properties": {
+                  "host": {
+                    "description": "The hostname of your Opensearch node (default: localhost).",
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "description": "Hosts defines a list of hosts if you want to connect to more than one Openearch nodes",
+                    "type": "string"
+                  },
+                  "indexName": {
+                    "description": "IndexName defines the placeholder syntax of Fluentd plugin API. See https://docs.fluentd.org/configuration/buffer-section.",
+                    "type": "string"
+                  },
+                  "logstashFormat": {
+                    "description": "If true, Fluentd uses the conventional index name format logstash-%Y.%m.%d (default: false). This option supersedes the index_name option.",
+                    "type": "boolean"
+                  },
+                  "logstashPrefix": {
+                    "description": "LogstashPrefix defines the logstash prefix index name to write events when logstash_format is true (default: logstash).",
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "Optional, The login credentials to connect to Opensearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "path": {
+                    "description": "Path defines the REST API endpoint of Opensearch to post write requests (default: nil).",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "The port number of your Opensearch node (default: 9200).",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "scheme": {
+                    "description": "Specify https if your Opensearch endpoint supports SSL (default: http).",
+                    "type": "string"
+                  },
+                  "sslVerify": {
+                    "description": "Optional, Force certificate validation",
+                    "type": "boolean"
+                  },
+                  "user": {
+                    "description": "Optional, The login credentials to connect to Opensearch",
+                    "properties": {
+                      "valueFrom": {
+                        "description": "ValueSource defines how to find a value's key.",
+                        "properties": {
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "s3": {
+                "description": "out_s3 plugin",
+                "properties": {
+                  "awsKeyId": {
+                    "description": "The AWS access key id.",
+                    "type": "string"
+                  },
+                  "awsSecKey": {
+                    "description": "The AWS secret key.",
+                    "type": "string"
+                  },
+                  "forcePathStyle": {
+                    "description": "This prevents AWS SDK from breaking endpoint URL",
+                    "type": "boolean"
+                  },
+                  "path": {
+                    "description": "The path prefix of the files on S3.",
+                    "type": "string"
+                  },
+                  "proxyUri": {
+                    "description": "The proxy URL.",
+                    "type": "string"
+                  },
+                  "s3Bucket": {
+                    "description": "The Amazon S3 bucket name.",
+                    "type": "string"
+                  },
+                  "s3Endpoint": {
+                    "description": "The endpoint URL (like \"http://localhost:9000/\")",
+                    "type": "string"
+                  },
+                  "s3ObjectKeyFormat": {
+                    "description": "The actual S3 path. This is interpolated to the actual path.",
+                    "type": "string"
+                  },
+                  "s3Region": {
+                    "description": "The Amazon S3 region name",
+                    "type": "string"
+                  },
+                  "sseCustomerAlgorithm": {
+                    "description": "The AWS KMS enctyption algorithm.",
+                    "type": "string"
+                  },
+                  "sseCustomerKey": {
+                    "description": "The AWS KMS key.",
+                    "type": "string"
+                  },
+                  "sseCustomerKeyMd5": {
+                    "description": "The AWS KMS key MD5.",
+                    "type": "string"
+                  },
+                  "ssekmsKeyId": {
+                    "description": "The AWS KMS key ID.",
+                    "type": "string"
+                  },
+                  "sslVerifyPeer": {
+                    "description": "Verify the SSL certificate of the endpoint.",
+                    "type": "boolean"
+                  },
+                  "storeAs": {
+                    "description": "The compression type.",
+                    "enum": [
+                      "gzip",
+                      "lzo",
+                      "json",
+                      "txt"
+                    ],
+                    "type": "string"
+                  },
+                  "timeSliceFormat": {
+                    "description": "This timestamp is added to each file name",
+                    "type": "string"
+                  },
+                  "useServerSideEncryption": {
+                    "description": "the following parameters are for S3 kms https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdout": {
+                "description": "out_stdout plugin",
+                "type": "object"
+              },
+              "tag": {
+                "description": "Which tag to be matched.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OutputStatus defines the observed state of Output",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/fluentd.fluent.io/output_v1alpha2.json
+++ b/fluentd.fluent.io/output_v1alpha2.json
@@ -1,0 +1,4769 @@
+{
+  "description": "Output is the schema for namespace level output API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OutputSpec defines the desired state of ClusterOutput",
+      "properties": {
+        "alias": {
+          "description": "A user friendly alias name for this output plugin.\nUsed in metrics for distinction of each configured output.",
+          "type": "string"
+        },
+        "azureBlob": {
+          "description": "AzureBlob defines AzureBlob Output Configuration",
+          "properties": {
+            "accountName": {
+              "description": "Azure Storage account name",
+              "type": "string"
+            },
+            "autoCreateContainer": {
+              "description": "Creates container if ContainerName is not set.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "blobType": {
+              "description": "Specify the desired blob type. Must be `appendblob` or `blockblob`",
+              "enum": [
+                "appendblob",
+                "blockblob"
+              ],
+              "type": "string"
+            },
+            "containerName": {
+              "description": "Name of the container that will contain the blobs",
+              "type": "string"
+            },
+            "emulatorMode": {
+              "description": "Optional toggle to use an Azure emulator",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "HTTP Service of the endpoint (if using EmulatorMode)",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Optional path to store the blobs.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the Azure Storage Shared Key to authenticate against the storage account",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Enable/Disable TLS Encryption. Azure services require TLS to be enabled.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "accountName",
+            "containerName",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azureLogAnalytics": {
+          "description": "AzureLogAnalytics defines AzureLogAnalytics Output Configuration",
+          "properties": {
+            "customerID": {
+              "description": "Customer ID or Workspace ID",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logType": {
+              "description": "Name of the event type.",
+              "type": "string"
+            },
+            "sharedKey": {
+              "description": "Specify the primary or the secondary client authentication key",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "timeGenerated": {
+              "description": "If set, overrides the timeKey value with the `time-generated-field` HTTP header value.",
+              "type": "boolean"
+            },
+            "timeKey": {
+              "description": "Specify the name of the key where the timestamp is stored.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "customerID",
+            "sharedKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudWatch": {
+          "description": "CloudWatch defines CloudWatch Output Configuration",
+          "properties": {
+            "autoCreateGroup": {
+              "description": "Automatically create the log group. Defaults to False.",
+              "type": "boolean"
+            },
+            "autoRetryRequests": {
+              "description": "Automatically retry failed requests to CloudWatch once. Defaults to True.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Custom endpoint for CloudWatch logs API",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API.",
+              "type": "string"
+            },
+            "logFormat": {
+              "description": "Optional parameter to tell CloudWatch the format of the data",
+              "type": "string"
+            },
+            "logGroupName": {
+              "description": "Name of Cloudwatch Log Group to send log records to",
+              "type": "string"
+            },
+            "logGroupTemplate": {
+              "description": "Template for Log Group name, overrides LogGroupName if set.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "If set, only the value of the key will be sent to CloudWatch",
+              "type": "string"
+            },
+            "logRetentionDays": {
+              "description": "Number of days logs are retained for",
+              "enum": [
+                1,
+                3,
+                5,
+                7,
+                14,
+                30,
+                60,
+                90,
+                120,
+                150,
+                180,
+                365,
+                400,
+                545,
+                731,
+                1827,
+                3653
+              ],
+              "format": "int32",
+              "type": "integer"
+            },
+            "logStreamName": {
+              "description": "The name of the CloudWatch Log Stream to send log records to",
+              "type": "string"
+            },
+            "logStreamPrefix": {
+              "description": "Prefix for the Log Stream name. Not compatible with LogStreamName setting",
+              "type": "string"
+            },
+            "logStreamTemplate": {
+              "description": "Template for Log Stream name. Overrides LogStreamPrefix and LogStreamName if set.",
+              "type": "string"
+            },
+            "metricDimensions": {
+              "description": "Optional lists of lists for dimension keys to be added to all metrics. Use comma separated strings\nfor one list of dimensions and semicolon separated strings for list of lists dimensions.",
+              "type": "string"
+            },
+            "metricNamespace": {
+              "description": "Optional string to represent the CloudWatch namespace.",
+              "type": "string"
+            },
+            "region": {
+              "description": "AWS Region",
+              "type": "string"
+            },
+            "roleArn": {
+              "description": "Role ARN to use for cross-account access",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom STS endpoint for the AWS STS API",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customPlugin": {
+          "description": "CustomPlugin defines Custom Output configuration.",
+          "properties": {
+            "config": {
+              "description": "Config holds any unsupported plugins classic configurations,\nif ConfigFileFormat is set to yaml, this filed will be ignored",
+              "type": "string"
+            },
+            "yamlConfig": {
+              "description": "YamlConfig holds the unsupported plugins yaml configurations, it only works when the ConfigFileFormat is yaml",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "datadog": {
+          "description": "DataDog defines DataDog Output configuration.",
+          "properties": {
+            "apikey": {
+              "description": "Your Datadog API key.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "compress": {
+              "description": "Compress  the payload in GZIP format.\nDatadog supports and recommends setting this to gzip.",
+              "type": "string"
+            },
+            "dd_message_key": {
+              "description": "By default, the plugin searches for the key 'log' and remap the value to the key 'message'. If the property is set, the plugin will search the property name key.",
+              "type": "string"
+            },
+            "dd_service": {
+              "description": "The human readable name for your service generating the logs.",
+              "type": "string"
+            },
+            "dd_source": {
+              "description": "A human readable name for the underlying technology of your service.",
+              "type": "string"
+            },
+            "dd_tags": {
+              "description": "The tags you want to assign to your logs in Datadog.",
+              "type": "string"
+            },
+            "host": {
+              "description": "Host is the Datadog server where you are sending your logs.",
+              "type": "string"
+            },
+            "include_tag_key": {
+              "description": "If enabled, a tag is appended to output. The key name is used tag_key property.",
+              "type": "boolean"
+            },
+            "json_date_key": {
+              "description": "Date key name for output.",
+              "type": "string"
+            },
+            "provider": {
+              "description": "To activate the remapping, specify configuration flag provider.",
+              "type": "string"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy.",
+              "type": "string"
+            },
+            "tag_key": {
+              "description": "The key name of tag. If include_tag_key is false, This property is ignored.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "TLS controls whether to use end-to-end security communications security protocol.\nDatadog recommends setting this to on.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "es": {
+          "description": "Elasticsearch defines Elasticsearch Output configuration.",
+          "properties": {
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsAuthSecret": {
+              "description": "AWSAuthSecret Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon ES cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the Elasticsearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "cloudAuth": {
+              "description": "Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "type": "string"
+            },
+            "cloudAuthSecret": {
+              "description": "CloudAuthSecret Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cloudID": {
+              "description": "If you are using Elastic's Elasticsearch Service you can specify the cloud_id of the cluster running.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying ES.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Elasticsearch instance",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for Elastic X-Pack access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "Elasticsearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve Elasticsearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "Newer versions of Elasticsearch allows setting up filters called pipelines.\nThis option allows defining which pipeline the database should use.\nFor performance reasons is strongly suggested parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target Elasticsearch instance",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "string"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "file": {
+          "description": "File defines File Output configuration.",
+          "properties": {
+            "delimiter": {
+              "description": "The character to separate each pair. Applicable only if format is csv or ltsv.",
+              "type": "string"
+            },
+            "file": {
+              "description": "Set file name to store the records. If not set, the file name will be the tag associated with the records.",
+              "type": "string"
+            },
+            "format": {
+              "description": "The format of the file content. See also Format section. Default: out_file.",
+              "enum": [
+                "out_file",
+                "plain",
+                "csv",
+                "ltsv",
+                "template"
+              ],
+              "type": "string"
+            },
+            "labelDelimiter": {
+              "description": "The character to separate each pair. Applicable only if format is ltsv.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory.",
+              "type": "string"
+            },
+            "template": {
+              "description": "The format string. Applicable only if format is template.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "firehose": {
+          "description": "Firehose defines Firehose Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues.",
+              "type": "boolean"
+            },
+            "dataKeys": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited.",
+              "type": "string"
+            },
+            "deliveryStream": {
+              "description": "The name of the Kinesis Firehose Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis Firehose API.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Firehose. If you specify a key name with this option, then only the value of that key will be sent to Firehose. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Firehose.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Specify a custom endpoint for the STS API; used to assume your custom role provided with role_arn.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default, the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, %Y-%m-%dT%H *string This option is used with time_key. You can also use %L for milliseconds and %f for microseconds. If you are using ECS FireLens, make sure you are running Amazon ECS Container Agent v1.42.0 or later, otherwise the timestamps associated with your container logs will only have second precision.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "deliveryStream",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "forward": {
+          "description": "Forward defines Forward Output configuration.",
+          "properties": {
+            "emptySharedKey": {
+              "description": "Use this option to connect to Fluentd with a zero-length secret.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "password": {
+              "description": "Specify the password corresponding to the username.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "requireAckResponse": {
+              "description": "Send \"chunk\"-option and wait for \"ack\" response from server.\nEnables at-least-once and receiving server can control rate of traffic.\n(Requires Fluentd v0.14.0+ server)",
+              "type": "boolean"
+            },
+            "selfHostname": {
+              "description": "Default value of the auto-generated certificate common name (CN).",
+              "type": "string"
+            },
+            "sendOptions": {
+              "description": "Always send options (with \"size\"=count of messages)",
+              "type": "boolean"
+            },
+            "sharedKey": {
+              "description": "A key string known by the remote Fluentd used for authorization.",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Overwrite the tag as we transmit. This allows the receiving pipeline start\nfresh, or to attribute source.",
+              "type": "string"
+            },
+            "timeAsInteger": {
+              "description": "Set timestamps in integer format, it enable compatibility mode for Fluentd v0.12 series.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "username": {
+              "description": "Specify the username to present to a Fluentd server that enables user_auth.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gelf": {
+          "description": "Gelf defines GELF Output configuration.",
+          "properties": {
+            "compress": {
+              "description": "If transport protocol is udp, it defines if UDP packets should be compressed.",
+              "type": "boolean"
+            },
+            "fullMessageKey": {
+              "description": "FullMessageKey is the key to use as the long message that can i.e. contain a backtrace.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target Graylog server.",
+              "type": "string"
+            },
+            "hostKey": {
+              "description": "HostKey is the key which its value is used as the name of the host, source or application that sent this message.",
+              "type": "string"
+            },
+            "levelKey": {
+              "description": "LevelKey is the key to be used as the log level.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "The protocol to use (tls, tcp or udp).",
+              "enum": [
+                "tls",
+                "tcp",
+                "udp"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "packetSize": {
+              "description": "If transport protocol is udp, it sets the size of packets to be sent.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "port": {
+              "description": "The port that the target Graylog server is listening on.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "shortMessageKey": {
+              "description": "ShortMessageKey is the key to use as the short message.",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "TimestampKey is the key which its value is used as the timestamp of the message.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "http": {
+          "description": "HTTP defines HTTP Output configuration.",
+          "properties": {
+            "allowDuplicatedHeaders": {
+              "description": "Specify if duplicated headers are allowed.\nIf a duplicated header is found, the latest key/value set is preserved.",
+              "type": "boolean"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. Option available is 'gzip'",
+              "type": "string"
+            },
+            "format": {
+              "description": "Specify the data format to be used in the HTTP request body, by default it uses msgpack.\nOther supported formats are json, json_stream and json_lines and gelf.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_stream",
+                "json_lines",
+                "gelf"
+              ],
+              "type": "string"
+            },
+            "gelfFullMessageKey": {
+              "description": "Specify the key to use for the full message in gelf format",
+              "type": "string"
+            },
+            "gelfHostKey": {
+              "description": "Specify the key to use for the host in gelf format",
+              "type": "string"
+            },
+            "gelfLevelKey": {
+              "description": "Specify the key to use for the level in gelf format",
+              "type": "string"
+            },
+            "gelfShortMessageKey": {
+              "description": "Specify the key to use as the short message in gelf format",
+              "type": "string"
+            },
+            "gelfTimestampKey": {
+              "description": "Specify the key to use for timestamp in gelf format",
+              "type": "string"
+            },
+            "headerTag": {
+              "description": "Specify an optional HTTP header field for the original message tag.",
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Basic Auth Password. Requires HTTP_User to be set",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Server",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://host:port.\nNote that https is not supported yet.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "HTTP output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "influxDB": {
+          "description": "InfluxDB defines InfluxDB Output configuration.",
+          "properties": {
+            "autoTags": {
+              "description": "Automatically tag keys where value is string.",
+              "type": "boolean"
+            },
+            "bucket": {
+              "description": "InfluxDB bucket name where records will be inserted - if specified, database is ignored and v2 of API is used",
+              "type": "string"
+            },
+            "database": {
+              "description": "InfluxDB database name where records will be inserted.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target InfluxDB service.",
+              "format": "ipv6",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpToken": {
+              "description": "Authentication token used with InfluxDB v2 - if specified, both HTTPUser and HTTPPasswd are ignored",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username for HTTP Basic Authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "org": {
+              "description": "InfluxDB organization name where the bucket is (v2 only)",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target InfluxDB service.",
+              "format": "int32",
+              "maximum": 65536,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sequenceTag": {
+              "description": "The name of the tag whose value is incremented for the consecutive simultaneous events.",
+              "type": "string"
+            },
+            "tagKeys": {
+              "description": "List of keys that needs to be tagged",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tagListKey": {
+              "description": "Key of the string array optionally contained within each log record that contains tag keys for that record",
+              "type": "string"
+            },
+            "tagsListEnabled": {
+              "description": "Dynamically tag keys which are in the string array at Tags_List_Key key.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafka": {
+          "description": "Kafka defines Kafka Output configuration.",
+          "properties": {
+            "brokers": {
+              "description": "Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092.",
+              "type": "string"
+            },
+            "dynamicTopic": {
+              "description": "adds unknown topics (found in Topic_Key) to Topics. So in Topics only a default topic needs to be configured",
+              "type": "boolean"
+            },
+            "format": {
+              "description": "Specify data format, options available: json, msgpack.",
+              "type": "string"
+            },
+            "messageKey": {
+              "description": "Optional key to store the message",
+              "type": "string"
+            },
+            "messageKeyField": {
+              "description": "If set, the value of Message_Key_Field in the record will indicate the message key.\nIf not set nor found in the record, Message_Key will be used (if set).",
+              "type": "string"
+            },
+            "queueFullRetries": {
+              "description": "Fluent Bit queues data into rdkafka library,\nif for some reason the underlying library cannot flush the records the queue might fills up blocking new addition of records.\nThe queue_full_retries option set the number of local retries to enqueue the data.\nThe default value is 10 times, the interval between each retry is 1 second.\nSetting the queue_full_retries value to 0 set's an unlimited number of retries.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rdkafka": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "{property} can be any librdkafka properties",
+              "type": "object"
+            },
+            "timestampFormat": {
+              "description": "iso8601 or double",
+              "type": "string"
+            },
+            "timestampKey": {
+              "description": "Set the key to store the record timestamp",
+              "type": "string"
+            },
+            "topicKey": {
+              "description": "If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use.\nE.g: if Topic_Key is router and the record is {\"key1\": 123, \"router\": \"route_2\"},\nFluent Bit will use topic route_2. Note that if the value of Topic_Key is not present in Topics,\nthen by default the first topic in the Topics list will indicate the topic to be used.",
+              "type": "string"
+            },
+            "topics": {
+              "description": "Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka.\nIf only one topic is set, that one will be used for all records.\nInstead if multiple topics exists, the one set in the record by Topic_Key will be used.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kinesis": {
+          "description": "Kinesis defines Kinesis Output configuration.",
+          "properties": {
+            "autoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true.",
+              "type": "boolean"
+            },
+            "endpoint": {
+              "description": "Specify a custom endpoint for the Kinesis API.",
+              "type": "string"
+            },
+            "externalID": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "logKey": {
+              "description": "By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Kinesis.",
+              "type": "string"
+            },
+            "region": {
+              "description": "The AWS region.",
+              "type": "string"
+            },
+            "roleARN": {
+              "description": "ARN of an IAM role to assume (for cross account access).",
+              "type": "string"
+            },
+            "stream": {
+              "description": "The name of the Kinesis Streams Delivery stream that you want log records sent to.",
+              "type": "string"
+            },
+            "stsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond precision with '%3N' and supports nanosecond precision with '%9N' and '%L'; for example, adding '%3N' to support millisecond '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region",
+            "stream"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "description": "Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace, Defaults to the SERVICE section's Log_Level",
+          "enum": [
+            "off",
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "loki": {
+          "description": "Loki defines Loki Output configuration.",
+          "properties": {
+            "autoKubernetesLabels": {
+              "description": "If set to true, it will add all Kubernetes labels to the Stream labels.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "bearerToken": {
+              "description": "Set bearer token authentication token value.\nCan be used as alterntative to HTTP basic authentication",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "dropSingleKey": {
+              "description": "If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format.",
+              "enum": [
+                "on",
+                "off"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Loki hostname or IP address.",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User\nSet HTTP basic authentication password",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Set HTTP basic authentication user name.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "labelKeys": {
+              "description": "Optional list of record keys that will be placed as stream labels.\nThis configuration property is for records key only.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelMapPath": {
+              "description": "Specify the label map file path. The file defines how to extract labels from each record.",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs.\nIn addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "lineFormat": {
+              "description": "Format to use when flattening the record to a log line. Valid values are json or key_value.\nIf set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON.\nIf set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.",
+              "enum": [
+                "json",
+                "key_value"
+              ],
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "Loki TCP port",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "removeKeys": {
+              "description": "Optional list of keys to remove.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "tenantID": {
+              "description": "Tenant ID used by default to push logs to Loki.\nIf omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tenantIDKey": {
+              "description": "Specify the name of the key from the original record that contains the Tenant ID.\nThe value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify a custom HTTP URI. It must start with forward slash.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "A pattern to match against the tags of incoming records.\nIt's case sensitive and support the star (*) character as a wildcard.",
+          "type": "string"
+        },
+        "matchRegex": {
+          "description": "A regular expression to match against the tags of incoming records.\nUse this option if you want to use the full regex syntax.",
+          "type": "string"
+        },
+        "null": {
+          "description": "Null defines Null Output configuration.",
+          "type": "object"
+        },
+        "opensearch": {
+          "description": "OpenSearch defines OpenSearch Output configuration.",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "awsAuth": {
+              "description": "Enable AWS Sigv4 Authentication for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsExternalID": {
+              "description": "External ID for the AWS IAM Role specified with aws_role_arn.",
+              "type": "string"
+            },
+            "awsRegion": {
+              "description": "Specify the AWS region for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "awsRoleARN": {
+              "description": "AWS IAM Role to assume to put records to your Amazon cluster.",
+              "type": "string"
+            },
+            "awsSTSEndpoint": {
+              "description": "Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service.",
+              "type": "string"
+            },
+            "bufferSize": {
+              "description": "Specify the buffer size used to read the response from the OpenSearch HTTP service.\nThis option is useful for debugging purposes where is required to read full responses,\nnote that response size grows depending of the number of records inserted.\nTo set an unlimited amount of memory set this value to False,\notherwise the value must be according to the Unit Size specification.",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "compress": {
+              "enum": [
+                "gzip"
+              ],
+              "type": "string"
+            },
+            "currentTimeIndex": {
+              "description": "Use current time for index generation instead of message record",
+              "type": "boolean"
+            },
+            "generateID": {
+              "description": "When enabled, generate _id for outgoing records.\nThis prevents duplicate records when retrying OpenSearch.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "idKey": {
+              "description": "If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.",
+              "type": "string"
+            },
+            "includeTagKey": {
+              "description": "When enabled, it append the Tag name to the record.",
+              "type": "boolean"
+            },
+            "index": {
+              "description": "Index name",
+              "type": "string"
+            },
+            "logstashDateFormat": {
+              "description": "Time format (based on strftime) to generate the second part of the Index name.",
+              "type": "string"
+            },
+            "logstashFormat": {
+              "description": "Enable Logstash format compatibility.\nThis option takes a boolean value: True/False, On/Off",
+              "type": "boolean"
+            },
+            "logstashPrefix": {
+              "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date,\ne.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'.\nThe last string appended belongs to the date when the data is being generated.",
+              "type": "string"
+            },
+            "logstashPrefixKey": {
+              "description": "Prefix keys with this string",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "path": {
+              "description": "OpenSearch accepts new data on HTTP query path \"/_bulk\".\nBut it is also possible to serve OpenSearch behind a reverse proxy on a subpath.\nThis option defines such path on the fluent-bit side.\nIt simply adds a path prefix in the indexing HTTP POST URI.",
+              "type": "string"
+            },
+            "pipeline": {
+              "description": "OpenSearch allows to setup filters called pipelines.\nThis option allows to define which pipeline the database should use.\nFor performance reasons is strongly suggested to do parsing\nand filtering on Fluent Bit side, avoid pipelines.",
+              "type": "string"
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `9200`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "replaceDots": {
+              "description": "When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.",
+              "type": "boolean"
+            },
+            "suppressTypeName": {
+              "description": "When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.",
+              "type": "boolean"
+            },
+            "tagKey": {
+              "description": "When Include_Tag_Key is enabled, this property defines the key name for the tag.",
+              "type": "string"
+            },
+            "timeKey": {
+              "description": "When Logstash_Format is enabled, each record will get a new timestamp field.\nThe Time_Key property defines the name of that field.",
+              "type": "string"
+            },
+            "timeKeyFormat": {
+              "description": "When Logstash_Format is enabled, this property defines the format of the timestamp.",
+              "type": "string"
+            },
+            "timeKeyNanos": {
+              "description": "When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            },
+            "traceError": {
+              "description": "When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error",
+              "type": "boolean"
+            },
+            "traceOutput": {
+              "description": "When enabled print the elasticsearch API calls to stdout (for diag only)",
+              "type": "boolean"
+            },
+            "type": {
+              "description": "Type name",
+              "type": "string"
+            },
+            "writeOperation": {
+              "description": "Operation to use to write in bulk requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "opentelemetry": {
+          "description": "OpenTelemetry defines OpenTelemetry Output configuration.",
+          "properties": {
+            "addLabel": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields.",
+              "type": "object"
+            },
+            "header": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log.",
+              "type": "boolean"
+            },
+            "logsBodyKeyAttributes": {
+              "description": "If true, remaining unmatched keys are added as attributes.",
+              "type": "boolean"
+            },
+            "logsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for logs, e.g: /v1/logs",
+              "type": "string"
+            },
+            "metricsUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for metrics, e.g: /v1/metrics",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target OpenSearch instance, default `80`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT. Note that HTTPS is not currently supported.\nIt is recommended not to set this and to configure the HTTP proxy environment variables instead as they support both HTTP and HTTPS.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tracesUri": {
+              "description": "Specify an optional HTTP URI for the target web server listening for traces, e.g: /v1/traces",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processors": {
+          "description": "Processors defines the processors configuration",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "prometheusExporter": {
+          "description": "PrometheusExporter_types defines Prometheus exporter configuration to expose metrics from Fluent Bit.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 0.0.0.0",
+              "type": "string"
+            },
+            "port": {
+              "description": "This is the port Fluent Bit will bind to when hosting prometheus metrics.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "prometheusRemoteWrite": {
+          "description": "PrometheusRemoteWrite_types defines Prometheus Remote Write configuration.",
+          "properties": {
+            "addLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This allows you to add custom labels to all metrics exposed through the prometheus exporter. You may have multiple of these fields",
+              "type": "object"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Add a HTTP header key/value pair. Multiple headers can be set.",
+              "type": "object"
+            },
+            "host": {
+              "description": "IP address or hostname of the target HTTP Server, default: 127.0.0.1",
+              "type": "string"
+            },
+            "httpPasswd": {
+              "description": "Basic Auth Password.\nRequires HTTP_user to be se",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Basic Auth Username",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "logResponsePayload": {
+              "description": "Log the response payload within the Fluent Bit log,default: false",
+              "type": "boolean"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target HTTP Serveri, default:80",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "proxy": {
+              "description": "Specify an HTTP Proxy. The expected format of this value is http://HOST:PORT.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "uri": {
+              "description": "Specify an optional HTTP URI for the target web server, e.g: /something ,default: /",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0,default : 2",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "retry_limit": {
+          "description": "RetryLimit represents configuration for the scheduler which can be set independently on each output section.\nThis option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.",
+          "type": "string"
+        },
+        "s3": {
+          "description": "S3 defines S3 Output configuration.",
+          "properties": {
+            "AutoRetryRequests": {
+              "description": "Immediately retry failed requests to AWS services once.",
+              "type": "boolean"
+            },
+            "Bucket": {
+              "description": "S3 Bucket name",
+              "type": "string"
+            },
+            "CannedAcl": {
+              "description": "Predefined Canned ACL Policy for S3 objects.",
+              "type": "string"
+            },
+            "Compression": {
+              "description": "Compression type for S3 objects.",
+              "type": "string"
+            },
+            "ContentType": {
+              "description": "A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header.",
+              "type": "string"
+            },
+            "Endpoint": {
+              "description": "Custom endpoint for the S3 API.",
+              "type": "string"
+            },
+            "ExternalId": {
+              "description": "Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.",
+              "type": "string"
+            },
+            "JsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681)",
+              "type": "string"
+            },
+            "JsonDateKey": {
+              "description": "Specify the name of the time key in the output record. To disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "LogKey": {
+              "description": "By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3.",
+              "type": "string"
+            },
+            "PreserveDataOrdering": {
+              "description": "Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads.",
+              "type": "boolean"
+            },
+            "Profile": {
+              "description": "Option to specify an AWS Profile for credentials.",
+              "type": "string"
+            },
+            "Region": {
+              "description": "The AWS region of your S3 bucket",
+              "type": "string"
+            },
+            "RetryLimit": {
+              "description": "Integer value to set the maximum number of retries allowed.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "RoleArn": {
+              "description": "ARN of an IAM role to assume",
+              "type": "string"
+            },
+            "S3KeyFormat": {
+              "description": "Format string for keys in S3.",
+              "type": "string"
+            },
+            "S3KeyFormatTagDelimiters": {
+              "description": "A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option.",
+              "type": "string"
+            },
+            "SendContentMd5": {
+              "description": "Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled.",
+              "type": "boolean"
+            },
+            "StaticFilePath": {
+              "description": "Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true.",
+              "type": "boolean"
+            },
+            "StorageClass": {
+              "description": "Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class.",
+              "type": "string"
+            },
+            "StoreDir": {
+              "description": "Directory to locally buffer data before sending.",
+              "type": "string"
+            },
+            "StoreDirLimitSize": {
+              "description": "The size of the limitation for disk usage in S3.",
+              "type": "string"
+            },
+            "StsEndpoint": {
+              "description": "Custom endpoint for the STS API.",
+              "type": "string"
+            },
+            "TotalFileSize": {
+              "description": "Specifies the size of files in S3. Minimum size is 1M. With use_put_object On the maximum size is 1G. With multipart upload mode, the maximum size is 50G.",
+              "type": "string"
+            },
+            "UploadChunkSize": {
+              "description": "The size of each 'part' for multipart uploads. Max: 50M",
+              "type": "string"
+            },
+            "UploadTimeout": {
+              "description": "Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour.",
+              "type": "string"
+            },
+            "UsePutObject": {
+              "description": "Use the S3 PutObject API, instead of the multipart upload API.",
+              "type": "boolean"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "Bucket",
+            "Region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "splunk": {
+          "description": "Splunk defines Splunk Output Configuration",
+          "properties": {
+            "Workers": {
+              "description": "Enables dedicated thread(s) for this output. Default value `2` is set since version 1.8.13. For previous versions is 0.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "channel": {
+              "description": "Specify X-Splunk-Request-Channel Header for the HTTP Event Collector interface.",
+              "type": "string"
+            },
+            "compress": {
+              "description": "Set payload compression mechanism. The only available option is gzip.",
+              "type": "string"
+            },
+            "eventFields": {
+              "description": "Set event fields for the record. This option is an array and the format is \"key_name\nrecord_accessor_pattern\".",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "eventHost": {
+              "description": "Specify the key name that contains the host value. This option allows a record accessors pattern.",
+              "type": "string"
+            },
+            "eventIndex": {
+              "description": "The name of the index by which the event data is to be indexed.",
+              "type": "string"
+            },
+            "eventIndexKey": {
+              "description": "Set a record key that will populate the index field. If the key is found, it will have precedence\nover the value set in event_index.",
+              "type": "string"
+            },
+            "eventKey": {
+              "description": "Specify the key name that will be used to send a single value as part of the record.",
+              "type": "string"
+            },
+            "eventSource": {
+              "description": "Set the source value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetype": {
+              "description": "Set the sourcetype value to assign to the event data.",
+              "type": "string"
+            },
+            "eventSourcetypeKey": {
+              "description": "Set a record key that will populate 'sourcetype'. If the key is found, it will have precedence\nover the value set in event_sourcetype.",
+              "type": "string"
+            },
+            "host": {
+              "description": "IP address or hostname of the target OpenSearch instance, default `127.0.0.1`",
+              "type": "string"
+            },
+            "httpBufferSize": {
+              "description": "Buffer size used to receive Splunk HTTP responses: Default `2M`",
+              "pattern": "^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$",
+              "type": "string"
+            },
+            "httpDebugBadRequest": {
+              "description": "If the HTTP server response code is 400 (bad request) and this flag is enabled, it will print the full HTTP request\nand response to the stdout interface. This feature is available for debugging purposes.",
+              "type": "boolean"
+            },
+            "httpPassword": {
+              "description": "Password for user defined in HTTP_User",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpUser": {
+              "description": "Optional username credential for access",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP port of the target Splunk instance, default `8088`",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "splunkSendRaw": {
+              "description": "When enabled, the record keys and values are set in the top level of the map instead of under the event key. Refer to\nthe Sending Raw Events section from the docs more details to make this option work properly.",
+              "type": "boolean"
+            },
+            "splunkToken": {
+              "description": "Specify the Authentication Token for the HTTP Event Collector interface.",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stackdriver": {
+          "description": "Stackdriver defines Stackdriver Output Configuration",
+          "properties": {
+            "autoformatStackdriverTrace": {
+              "description": "Rewrite the trace field to be formatted for use with GCP Cloud Trace",
+              "type": "boolean"
+            },
+            "customK8sRegex": {
+              "description": "A custom regex to extract fields from the local_resource_id of the logs",
+              "type": "string"
+            },
+            "exportToProjectID": {
+              "description": "The GCP Project that should receive the logs",
+              "type": "string"
+            },
+            "googleServiceCredentials": {
+              "description": "Path to GCP Credentials JSON file",
+              "type": "string"
+            },
+            "job": {
+              "description": "Identifier for a grouping of tasks. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "k8sClusterLocation": {
+              "description": "Location of the cluster that contains the pods/nodes. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "k8sClusterName": {
+              "description": "Name of the cluster that the pod is running in. Required if Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Optional list of comma separated of strings for key/value pairs",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labelsKey": {
+              "description": "Used by Stackdriver to find related labels and extract them to LogEntry Labels",
+              "type": "string"
+            },
+            "location": {
+              "description": "GCP/AWS region to store data. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "logNameKey": {
+              "description": "The value of this field is set as the logName field in Stackdriver",
+              "type": "string"
+            },
+            "metadataServer": {
+              "description": "Metadata Server Prefix",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace identifier. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "nodeID": {
+              "description": "Node identifier within the namespace. Required if Resource is generic_node or generic_task",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Set resource types of data",
+              "type": "string"
+            },
+            "resourceLabels": {
+              "description": "Optional list of comma seperated strings. Setting these fields overrides the Stackdriver monitored resource API values",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "serviceAccountEmail": {
+              "description": "Email associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceAccountSecret": {
+              "description": "Private Key associated with the service",
+              "properties": {
+                "valueFrom": {
+                  "description": "ValueSource defines how to find a value's key.",
+                  "properties": {
+                    "secretKeyRef": {
+                      "description": "Selects a key of a secret in the pod's namespace",
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "key"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "severityKey": {
+              "description": "Specify the key that contains the severity information for the logs",
+              "type": "string"
+            },
+            "tagPrefix": {
+              "description": "Used to validate the tags of logs that when the Resource is k8s_container, k8s_node, or k8s_pod",
+              "type": "string"
+            },
+            "taskID": {
+              "description": "Identifier for a task within a namespace. Required if Resource is generic_task",
+              "type": "string"
+            },
+            "workers": {
+              "description": "Number of dedicated threads for the Stackdriver Output Plugin",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "stdout": {
+          "description": "Stdout defines Stdout Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.",
+              "enum": [
+                "double",
+                "iso8601",
+                "epoch"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "Specify the name of the date field in output.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "syslog": {
+          "description": "Syslog defines Syslog Output configuration.",
+          "properties": {
+            "host": {
+              "description": "Host domain or IP address of the remote Syslog server.",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode of the desired transport type, the available options are tcp, tls and udp.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP or UDP port of the remote Syslog server.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "syslogAppnameKey": {
+              "description": "Key name from the original record that contains the application name that generated the message.",
+              "type": "string"
+            },
+            "syslogFacilityKey": {
+              "description": "Key from the original record that contains the Syslog facility number.",
+              "type": "string"
+            },
+            "syslogFormat": {
+              "description": "Syslog protocol format to use, the available options are rfc3164 and rfc5424.",
+              "type": "string"
+            },
+            "syslogHostnameKey": {
+              "description": "Key name from the original record that contains the hostname that generated the message.",
+              "type": "string"
+            },
+            "syslogMaxSize": {
+              "description": "Maximum size allowed per message, in bytes.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "syslogMessageIDKey": {
+              "description": "Key name from the original record that contains the Message ID associated to the message.",
+              "type": "string"
+            },
+            "syslogMessageKey": {
+              "description": "Key key name that contains the message to deliver.",
+              "type": "string"
+            },
+            "syslogProcessIDKey": {
+              "description": "Key name from the original record that contains the Process ID that generated the message.",
+              "type": "string"
+            },
+            "syslogSDKey": {
+              "description": "Key name from the original record that contains the Structured Data (SD) content.",
+              "type": "string"
+            },
+            "syslogSeverityKey": {
+              "description": "Key from the original record that contains the Syslog severity number.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "Syslog output plugin supports TTL/SSL, for more details about the properties available\nand general configuration, please refer to the TLS/SSL section.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "totalLimitSize": {
+              "description": "Limit the maximum number of Chunks in the filesystem for the current output logical destination.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tcp": {
+          "description": "TCP defines TCP Output configuration.",
+          "properties": {
+            "format": {
+              "description": "Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.",
+              "enum": [
+                "msgpack",
+                "json",
+                "json_lines",
+                "json_stream"
+              ],
+              "type": "string"
+            },
+            "host": {
+              "description": "Target host where Fluent-Bit or Fluentd are listening for Forward messages.",
+              "type": "string"
+            },
+            "jsonDateFormat": {
+              "description": "Specify the format of the date. Supported formats are double, epoch\nand iso8601 (eg: 2018-05-30T09:39:52.000681Z)",
+              "enum": [
+                "double",
+                "epoch",
+                "iso8601"
+              ],
+              "type": "string"
+            },
+            "jsonDateKey": {
+              "description": "TSpecify the name of the time key in the output record.\nTo disable the time key just set the value to false.",
+              "type": "string"
+            },
+            "networking": {
+              "description": "Include fluentbit networking options for this output-plugin",
+              "properties": {
+                "DNSMode": {
+                  "description": "Select the primary DNS connection type (TCP or UDP).",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ],
+                  "type": "string"
+                },
+                "DNSPreferIPv4": {
+                  "description": "Prioritize IPv4 DNS results when trying to establish a connection.",
+                  "type": "boolean"
+                },
+                "DNSResolver": {
+                  "description": "Select the primary DNS resolver type (LEGACY or ASYNC).",
+                  "enum": [
+                    "LEGACY",
+                    "ASYNC"
+                  ],
+                  "type": "string"
+                },
+                "connectTimeout": {
+                  "description": "Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "connectTimeoutLogError": {
+                  "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message.",
+                  "type": "boolean"
+                },
+                "keepalive": {
+                  "description": "Enable or disable connection keepalive support. Accepts a boolean value: on / off.",
+                  "enum": [
+                    "on",
+                    "off"
+                  ],
+                  "type": "string"
+                },
+                "keepaliveIdleTimeout": {
+                  "description": "Set maximum time expressed in seconds for an idle keepalive connection.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keepaliveMaxRecycle": {
+                  "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "maxWorkerConnections": {
+                  "description": "Set maximum number of TCP connections that can be established per worker.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "sourceAddress": {
+                  "description": "Specify network address to bind for data traffic.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "description": "TCP Port of the target service.",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tls": {
+              "description": "Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.",
+              "properties": {
+                "caFile": {
+                  "description": "Absolute path to CA certificate file",
+                  "type": "string"
+                },
+                "caPath": {
+                  "description": "Absolute path to scan for certificate files",
+                  "type": "string"
+                },
+                "crtFile": {
+                  "description": "Absolute path to Certificate file",
+                  "type": "string"
+                },
+                "debug": {
+                  "description": "Set TLS debug verbosity level.\nIt accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                  "enum": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "keyFile": {
+                  "description": "Absolute path to private Key file",
+                  "type": "string"
+                },
+                "keyPassword": {
+                  "description": "Optional password for tls.key_file file",
+                  "properties": {
+                    "valueFrom": {
+                      "description": "ValueSource defines how to find a value's key.",
+                      "properties": {
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "verify": {
+                  "description": "Force certificate validation",
+                  "type": "boolean"
+                },
+                "vhost": {
+                  "description": "Hostname to be used for TLS SNI extension",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This PR aims to introduce [fluent-operator](https://github.com/fluent/fluent-operator) [fluent-bit CRDs](https://github.com/fluent/fluent-operator/tree/master/charts/fluent-operator/charts/fluent-bit-crds/crds) and [fluentd CRDs](https://github.com/fluent/fluent-operator/tree/master/charts/fluent-operator/charts/fluentd-crds/crds) from the latest version (v3.2.0) using the following script:

```sh
#!/usr/bin/env bash
# shellcheck disable=SC2064
set -euo pipefail

cleanup_cmd="rm -rf ${PWD}/fluent-operator ${PWD}/openapi2jsonschema.py"
trap "rm -f $cleanup_cmd" 0            # EXIT
trap "rm -f $cleanup_cmd; exit 1" 2    # INT
trap "rm -f $cleanup_cmd; exit 1" 1 15 # HUP TERM

FLUENT_OPERATOR_VERSION=v3.2.0
curl -sO https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py
mkdir -p fluentbit.fluent.io
mkdir -p fluentd.fluent.io

mkdir fluent-operator
git clone --depth 1 --branch "${FLUENT_OPERATOR_VERSION}" https://github.com/fluent/fluent-operator.git fluent-operator
pushd fluent-operator
git checkout ${FLUENT_OPERATOR_VERSION}
popd

pushd fluentbit.fluent.io
for file in ../fluent-operator/charts/fluent-operator/charts/fluent-bit-crds/crds/*; do
  python3 ../openapi2jsonschema.py "${file}"
done
popd

pushd fluentd.fluent.io
for file in ../fluent-operator/charts/fluent-operator/charts/fluentd-crds/crds/*; do
  python3 ../openapi2jsonschema.py "${file}"
done
popd

```