### PR TITLE
feat: Add support for namespace regex matching in ClusterSecretStore and SecretStore

### DIFF
--- a/external-secrets.io/clustersecretstore_v1beta1.json
+++ b/external-secrets.io/clustersecretstore_v1beta1.json
@@ -20,6 +20,13 @@
           "items": {
             "description": "ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in\nfor a ClusterSecretStore instance.",
             "properties": {
+              "namespaceRegexes": {
+                "description": "Choose namespaces by using regex matching",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "namespaceSelector": {
                 "description": "Choose namespace using a labelSelector",
                 "properties": {

--- a/external-secrets.io/secretstore_v1beta1.json
+++ b/external-secrets.io/secretstore_v1beta1.json
@@ -20,6 +20,13 @@
           "items": {
             "description": "ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in\nfor a ClusterSecretStore instance.",
             "properties": {
+              "namespaceRegexes": {
+                "description": "Choose namespaces by using regex matching",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "namespaceSelector": {
                 "description": "Choose namespace using a labelSelector",
                 "properties": {


### PR DESCRIPTION
This PR adds the ability to choose namespaces using regex matching in the ClusterSecretStore and SecretStore resources. It introduces a new field called "namespaceRegexes" which accepts an array of regex patterns to match against namespaces. This feature provides more flexibility in selecting namespaces for processing ExternalSecrets.

According to the following PR in External Secrets: https://github.com/external-secrets/external-secrets/pull/2920