### PR TITLE
chore: update postgres zalando schemas

### DIFF
--- a/acid.zalan.do/operatorconfiguration_v1.json
+++ b/acid.zalan.do/operatorconfiguration_v1.json
@@ -30,7 +30,7 @@
         },
         "docker_image": {
           "type": "string",
-          "default": "ghcr.io/zalando/spilo-16:3.2-p3"
+          "default": "ghcr.io/zalando/spilo-16:3.3-p1"
         },
         "enable_crd_registration": {
           "type": "boolean",
@@ -153,7 +153,7 @@
           "properties": {
             "major_version_upgrade_mode": {
               "type": "string",
-              "default": "off"
+              "default": "manual"
             },
             "major_version_upgrade_team_allow_list": {
               "type": "array",
@@ -228,9 +228,9 @@
               "type": "boolean",
               "default": true
             },
-            "enable_secrets_deletion": {
+            "enable_owner_references": {
               "type": "boolean",
-              "default": true
+              "default": false
             },
             "enable_persistent_volume_claim_deletion": {
               "type": "boolean",
@@ -247,6 +247,10 @@
             "enable_readiness_probe": {
               "type": "boolean",
               "default": false
+            },
+            "enable_secrets_deletion": {
+              "type": "boolean",
+              "default": true
             },
             "enable_sidecars": {
               "type": "boolean",
@@ -592,8 +596,7 @@
               "type": "string"
             },
             "additional_secret_mount_path": {
-              "type": "string",
-              "default": "/meta/credentials"
+              "type": "string"
             },
             "aws_region": {
               "type": "string",
@@ -650,7 +653,7 @@
             },
             "logical_backup_docker_image": {
               "type": "string",
-              "default": "ghcr.io/zalando/postgres-operator/logical-backup:v1.12.2"
+              "default": "ghcr.io/zalando/postgres-operator/logical-backup:v1.13.0"
             },
             "logical_backup_google_application_credentials": {
               "type": "string"

--- a/acid.zalan.do/postgresql_v1.json
+++ b/acid.zalan.do/postgresql_v1.json
@@ -239,7 +239,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^\\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))\\ *$"
+            "pattern": "^\\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))-((2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))\\ *$"
           }
         },
         "masterServiceAnnotations": {
@@ -472,7 +472,6 @@
             "version": {
               "type": "string",
               "enum": [
-                "11",
                 "12",
                 "13",
                 "14",


### PR DESCRIPTION
Identically as in https://github.com/datreeio/CRDs-catalog/pull/336, regenerated the Schemas for the Zalando Postgres Operator after the release of version 1.13.0: https://github.com/zalando/postgres-operator/releases/tag/v1.13.0

Reference: https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator/crds
Source: https://github.com/zalando/postgres-operator/tree/master