### PR TITLE
Update GKE BackendConfig

### DIFF
--- a/cloud.google.com/backendconfig_v1.json
+++ b/cloud.google.com/backendconfig_v1.json
@@ -260,8 +260,7 @@
             }
           },
           "required": [
-            "enabled",
-            "oauthclientCredentials"
+            "enabled"
           ],
           "type": "object",
           "additionalProperties": false

--- a/cloud.google.com/backendconfig_v1beta1.json
+++ b/cloud.google.com/backendconfig_v1beta1.json
@@ -160,8 +160,7 @@
             }
           },
           "required": [
-            "enabled",
-            "oauthclientCredentials"
+            "enabled"
           ],
           "type": "object",
           "additionalProperties": false


### PR DESCRIPTION
Extract BackendConfig from GKE Autopilot, version 1.30.5-gke.1014001.

[Doc](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#enable_with_google_managed_oauth_client) says:

> Starting in GKE 1.29.4-gke.1043000, IAP can be configured to use Google Managed OAuth Client using a BackendConfig.
> To enable IAP with Google Managed OAuth Client, do not provide the OAuthCredentials in the BackendConfig.