### PR TITLE
feat: Update Kyverno CRDs to current v1.13.0

### DIFF
--- a/kyverno.io/cleanuppolicy_v2.json
+++ b/kyverno.io/cleanuppolicy_v2.json
@@ -1,1189 +1,1300 @@
 {
-    "description": "CleanupPolicy defines a rule for resource cleanup.",
-    "properties": {
-      "apiVersion": {
-        "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-        "type": "string"
-      },
-      "kind": {
-        "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-        "type": "string"
-      },
-      "metadata": {
-        "type": "object"
-      },
-      "spec": {
-        "description": "Spec declares policy behaviors.",
-        "properties": {
-          "conditions": {
-            "description": "Conditions defines the conditions used to select the resources which will be cleaned up.",
-            "properties": {
-              "all": {
-                "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass.",
-                "items": {
-                  "properties": {
-                    "key": {
-                      "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "message": {
-                      "description": "Message is an optional display message",
-                      "type": "string"
-                    },
-                    "operator": {
-                      "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
-                      "enum": [
-                        "Equals",
-                        "NotEquals",
-                        "AnyIn",
-                        "AllIn",
-                        "AnyNotIn",
-                        "AllNotIn",
-                        "GreaterThanOrEquals",
-                        "GreaterThan",
-                        "LessThanOrEquals",
-                        "LessThan",
-                        "DurationGreaterThanOrEquals",
-                        "DurationGreaterThan",
-                        "DurationLessThanOrEquals",
-                        "DurationLessThan"
-                      ],
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
+  "description": "CleanupPolicy defines a rule for resource cleanup.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy behaviors.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines the conditions used to select the resources which will be cleaned up.",
+          "properties": {
+            "all": {
+              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
                 },
-                "type": "array"
+                "type": "object",
+                "additionalProperties": false
               },
-              "any": {
-                "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass.",
-                "items": {
-                  "properties": {
-                    "key": {
-                      "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "message": {
-                      "description": "Message is an optional display message",
-                      "type": "string"
-                    },
-                    "operator": {
-                      "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
-                      "enum": [
-                        "Equals",
-                        "NotEquals",
-                        "AnyIn",
-                        "AllIn",
-                        "AnyNotIn",
-                        "AllNotIn",
-                        "GreaterThanOrEquals",
-                        "GreaterThan",
-                        "LessThanOrEquals",
-                        "LessThan",
-                        "DurationGreaterThanOrEquals",
-                        "DurationGreaterThan",
-                        "DurationLessThanOrEquals",
-                        "DurationLessThan"
-                      ],
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
+              "type": "array"
+            },
+            "any": {
+              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
                 },
-                "type": "array"
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "context": {
+          "description": "Context defines variables and data sources that can be used during rule execution.",
+          "items": {
+            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+            "oneOf": [
+              {
+                "required": [
+                  "configMap"
+                ]
+              },
+              {
+                "required": [
+                  "apiCall"
+                ]
+              },
+              {
+                "required": [
+                  "imageRegistry"
+                ]
+              },
+              {
+                "required": [
+                  "variable"
+                ]
+              },
+              {
+                "required": [
+                  "globalReference"
+                ]
+              }
+            ],
+            "properties": {
+              "apiCall": {
+                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                "properties": {
+                  "data": {
+                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                    "items": {
+                      "description": "RequestData contains the HTTP POST data",
+                      "properties": {
+                        "key": {
+                          "description": "Key is a unique identifier for the data value",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the data value",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                    "type": "string"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                    "enum": [
+                      "GET",
+                      "POST"
+                    ],
+                    "type": "string"
+                  },
+                  "service": {
+                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                    "properties": {
+                      "caBundle": {
+                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                        "type": "string"
+                      },
+                      "headers": {
+                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "description": "Key is the header key",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the header value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "url": {
+                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "urlPath": {
+                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "ConfigMap is the ConfigMap reference.",
+                "properties": {
+                  "name": {
+                    "description": "Name is the ConfigMap name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the ConfigMap namespace.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "globalReference": {
+                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                "properties": {
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the global context entry",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageRegistry": {
+                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                "properties": {
+                  "imageRegistryCredentials": {
+                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                    "properties": {
+                      "allowInsecureRegistry": {
+                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                        "type": "boolean"
+                      },
+                      "providers": {
+                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                        "items": {
+                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                          "enum": [
+                            "default",
+                            "amazon",
+                            "azure",
+                            "google",
+                            "github"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "secrets": {
+                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reference"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name is the variable name.",
+                "type": "string"
+              },
+              "variable": {
+                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                "properties": {
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
-          "context": {
-            "description": "Context defines variables and data sources that can be used during rule execution.",
-            "items": {
-              "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
-              "properties": {
-                "apiCall": {
-                  "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
-                  "properties": {
-                    "data": {
-                      "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
-                      "items": {
-                        "description": "RequestData contains the HTTP POST data",
-                        "properties": {
-                          "key": {
-                            "description": "Key is a unique identifier for the data value",
-                            "type": "string"
-                          },
-                          "value": {
-                            "description": "Value is the data value",
-                            "x-kubernetes-preserve-unknown-fields": true
-                          }
-                        },
-                        "required": [
-                          "key",
-                          "value"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    },
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+          "type": "array"
+        },
+        "exclude": {
+          "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
                       "type": "string"
                     },
-                    "method": {
-                      "default": "GET",
-                      "description": "Method is the HTTP request type (GET or POST).",
-                      "enum": [
-                        "GET",
-                        "POST"
-                      ],
-                      "type": "string"
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
                     },
-                    "service": {
-                      "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
-                      "properties": {
-                        "caBundle": {
-                          "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
                           "type": "string"
                         },
-                        "url": {
-                          "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
                           "type": "string"
                         }
                       },
                       "required": [
-                        "url"
+                        "kind",
+                        "name"
                       ],
                       "type": "object",
+                      "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     },
-                    "urlPath": {
-                      "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
+                    "type": "array"
+                  }
                 },
-                "configMap": {
-                  "description": "ConfigMap is the ConfigMap reference.",
-                  "properties": {
-                    "name": {
-                      "description": "Name is the ConfigMap name.",
-                      "type": "string"
-                    },
-                    "namespace": {
-                      "description": "Namespace is the ConfigMap namespace.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "globalReference": {
-                  "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
-                  "properties": {
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
-                      "type": "string"
-                    },
-                    "name": {
-                      "description": "Name of the global context entry",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "imageRegistry": {
-                  "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
-                  "properties": {
-                    "imageRegistryCredentials": {
-                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
-                      "properties": {
-                        "allowInsecureRegistry": {
-                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
-                          "type": "boolean"
-                        },
-                        "providers": {
-                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
-                          "items": {
-                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
-                            "enum": [
-                              "default",
-                              "amazon",
-                              "azure",
-                              "google",
-                              "github"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "secrets": {
-                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
-                      "type": "string"
-                    },
-                    "reference": {
-                      "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "reference"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "name": {
-                  "description": "Name is the variable name.",
-                  "type": "string"
-                },
-                "variable": {
-                  "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
-                  "properties": {
-                    "default": {
-                      "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
+                "type": "object",
+                "additionalProperties": false
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "array"
             },
-            "type": "array"
-          },
-          "exclude": {
-            "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
-            "properties": {
-              "all": {
-                "description": "All allows specifying resources which will be ANDed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
                     },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
                           "type": "string"
                         },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
                       },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
                         "type": "string"
                       },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
                         "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
                           }
                         },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
-                    }
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
                 },
-                "type": "array"
+                "type": "object",
+                "additionalProperties": false
               },
-              "any": {
-                "description": "Any allows specifying resources which will be ORed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
+              "type": "array"
+            }
           },
-          "match": {
-            "description": "MatchResources defines when cleanuppolicy should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-            "properties": {
-              "all": {
-                "description": "All allows specifying resources which will be ANDed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              },
-              "any": {
-                "description": "Any allows specifying resources which will be ORed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
-          },
-          "schedule": {
-            "description": "The schedule in Cron format",
-            "type": "string"
-          }
+          "type": "object",
+          "additionalProperties": false
         },
-        "required": [
-          "schedule"
-        ],
-        "type": "object",
-        "additionalProperties": false
+        "match": {
+          "description": "MatchResources defines when cleanuppolicy should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedule": {
+          "description": "The schedule in Cron format",
+          "type": "string"
+        }
       },
-      "status": {
-        "description": "Status contains policy runtime data.",
-        "properties": {
-          "conditions": {
-            "items": {
-              "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
-              "properties": {
-                "lastTransitionTime": {
-                  "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
-                  "format": "date-time",
-                  "type": "string"
-                },
-                "message": {
-                  "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                  "maxLength": 32768,
-                  "type": "string"
-                },
-                "observedGeneration": {
-                  "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
-                  "format": "int64",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "reason": {
-                  "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                  "maxLength": 1024,
-                  "minLength": 1,
-                  "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
-                  "type": "string"
-                },
-                "status": {
-                  "description": "status of the condition, one of True, False, Unknown.",
-                  "enum": [
-                    "True",
-                    "False",
-                    "Unknown"
-                  ],
-                  "type": "string"
-                },
-                "type": {
-                  "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
-                  "maxLength": 316,
-                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "lastTransitionTime",
-                "message",
-                "reason",
-                "status",
-                "type"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": "array"
-          },
-          "lastExecutionTime": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      }
+      "required": [
+        "match",
+        "schedule"
+      ],
+      "type": "object",
+      "additionalProperties": false
     },
-    "required": [
-      "spec"
-    ],
-    "type": "object"
-  }
-  
+    "status": {
+      "description": "Status contains policy runtime data.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastExecutionTime": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/cleanuppolicy_v2beta1.json
+++ b/kyverno.io/cleanuppolicy_v2beta1.json
@@ -110,6 +110,33 @@
           "description": "Context defines variables and data sources that can be used during rule execution.",
           "items": {
             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+            "oneOf": [
+              {
+                "required": [
+                  "configMap"
+                ]
+              },
+              {
+                "required": [
+                  "apiCall"
+                ]
+              },
+              {
+                "required": [
+                  "imageRegistry"
+                ]
+              },
+              {
+                "required": [
+                  "variable"
+                ]
+              },
+              {
+                "required": [
+                  "globalReference"
+                ]
+              }
+            ],
             "properties": {
               "apiCall": {
                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -137,13 +164,17 @@
                     },
                     "type": "array"
                   },
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "jmesPath": {
                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                     "type": "string"
                   },
                   "method": {
                     "default": "GET",
-                    "description": "Method is the HTTP request type (GET or POST).",
+                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                     "enum": [
                       "GET",
                       "POST"
@@ -156,6 +187,28 @@
                       "caBundle": {
                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                         "type": "string"
+                      },
+                      "headers": {
+                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "description": "Key is the header key",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the header value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "url": {
                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -206,6 +259,9 @@
                     "type": "string"
                   }
                 },
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -284,6 +340,9 @@
                 "additionalProperties": false
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -291,6 +350,12 @@
         },
         "exclude": {
           "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
           "properties": {
             "all": {
               "description": "All allows specifying resources which will be ANDed",
@@ -306,6 +371,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -353,7 +424,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -363,7 +435,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -419,7 +492,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -429,7 +503,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -506,6 +581,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -553,7 +634,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -563,7 +645,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -619,7 +702,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -629,7 +713,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -698,6 +783,12 @@
         },
         "match": {
           "description": "MatchResources defines when cleanuppolicy should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
           "properties": {
             "all": {
               "description": "All allows specifying resources which will be ANDed",
@@ -713,6 +804,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -760,7 +857,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -770,7 +868,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -826,7 +925,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -836,7 +936,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -913,6 +1014,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -960,7 +1067,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -970,7 +1078,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1026,7 +1135,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1036,7 +1146,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1109,6 +1220,7 @@
         }
       },
       "required": [
+        "match",
         "schedule"
       ],
       "type": "object",
@@ -1119,7 +1231,7 @@
       "properties": {
         "conditions": {
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -1154,7 +1266,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/kyverno.io/clustercleanuppolicy_v2.json
+++ b/kyverno.io/clustercleanuppolicy_v2.json
@@ -1,1189 +1,1300 @@
 {
-    "description": "ClusterCleanupPolicy defines rule for resource cleanup.",
-    "properties": {
-      "apiVersion": {
-        "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-        "type": "string"
-      },
-      "kind": {
-        "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-        "type": "string"
-      },
-      "metadata": {
-        "type": "object"
-      },
-      "spec": {
-        "description": "Spec declares policy behaviors.",
-        "properties": {
-          "conditions": {
-            "description": "Conditions defines the conditions used to select the resources which will be cleaned up.",
-            "properties": {
-              "all": {
-                "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass.",
-                "items": {
-                  "properties": {
-                    "key": {
-                      "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "message": {
-                      "description": "Message is an optional display message",
-                      "type": "string"
-                    },
-                    "operator": {
-                      "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
-                      "enum": [
-                        "Equals",
-                        "NotEquals",
-                        "AnyIn",
-                        "AllIn",
-                        "AnyNotIn",
-                        "AllNotIn",
-                        "GreaterThanOrEquals",
-                        "GreaterThan",
-                        "LessThanOrEquals",
-                        "LessThan",
-                        "DurationGreaterThanOrEquals",
-                        "DurationGreaterThan",
-                        "DurationLessThanOrEquals",
-                        "DurationLessThan"
-                      ],
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
+  "description": "ClusterCleanupPolicy defines rule for resource cleanup.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy behaviors.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines the conditions used to select the resources which will be cleaned up.",
+          "properties": {
+            "all": {
+              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
                 },
-                "type": "array"
+                "type": "object",
+                "additionalProperties": false
               },
-              "any": {
-                "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass.",
-                "items": {
-                  "properties": {
-                    "key": {
-                      "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "message": {
-                      "description": "Message is an optional display message",
-                      "type": "string"
-                    },
-                    "operator": {
-                      "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
-                      "enum": [
-                        "Equals",
-                        "NotEquals",
-                        "AnyIn",
-                        "AllIn",
-                        "AnyNotIn",
-                        "AllNotIn",
-                        "GreaterThanOrEquals",
-                        "GreaterThan",
-                        "LessThanOrEquals",
-                        "LessThan",
-                        "DurationGreaterThanOrEquals",
-                        "DurationGreaterThan",
-                        "DurationLessThanOrEquals",
-                        "DurationLessThan"
-                      ],
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
+              "type": "array"
+            },
+            "any": {
+              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
                 },
-                "type": "array"
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "context": {
+          "description": "Context defines variables and data sources that can be used during rule execution.",
+          "items": {
+            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+            "oneOf": [
+              {
+                "required": [
+                  "configMap"
+                ]
+              },
+              {
+                "required": [
+                  "apiCall"
+                ]
+              },
+              {
+                "required": [
+                  "imageRegistry"
+                ]
+              },
+              {
+                "required": [
+                  "variable"
+                ]
+              },
+              {
+                "required": [
+                  "globalReference"
+                ]
+              }
+            ],
+            "properties": {
+              "apiCall": {
+                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                "properties": {
+                  "data": {
+                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                    "items": {
+                      "description": "RequestData contains the HTTP POST data",
+                      "properties": {
+                        "key": {
+                          "description": "Key is a unique identifier for the data value",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the data value",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                    "type": "string"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                    "enum": [
+                      "GET",
+                      "POST"
+                    ],
+                    "type": "string"
+                  },
+                  "service": {
+                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                    "properties": {
+                      "caBundle": {
+                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                        "type": "string"
+                      },
+                      "headers": {
+                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "description": "Key is the header key",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the header value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "url": {
+                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "urlPath": {
+                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "ConfigMap is the ConfigMap reference.",
+                "properties": {
+                  "name": {
+                    "description": "Name is the ConfigMap name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the ConfigMap namespace.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "globalReference": {
+                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                "properties": {
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the global context entry",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageRegistry": {
+                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                "properties": {
+                  "imageRegistryCredentials": {
+                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                    "properties": {
+                      "allowInsecureRegistry": {
+                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                        "type": "boolean"
+                      },
+                      "providers": {
+                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                        "items": {
+                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                          "enum": [
+                            "default",
+                            "amazon",
+                            "azure",
+                            "google",
+                            "github"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "secrets": {
+                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reference"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name is the variable name.",
+                "type": "string"
+              },
+              "variable": {
+                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                "properties": {
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
-          "context": {
-            "description": "Context defines variables and data sources that can be used during rule execution.",
-            "items": {
-              "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
-              "properties": {
-                "apiCall": {
-                  "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
-                  "properties": {
-                    "data": {
-                      "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
-                      "items": {
-                        "description": "RequestData contains the HTTP POST data",
-                        "properties": {
-                          "key": {
-                            "description": "Key is a unique identifier for the data value",
-                            "type": "string"
-                          },
-                          "value": {
-                            "description": "Value is the data value",
-                            "x-kubernetes-preserve-unknown-fields": true
-                          }
-                        },
-                        "required": [
-                          "key",
-                          "value"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    },
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+          "type": "array"
+        },
+        "exclude": {
+          "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
                       "type": "string"
                     },
-                    "method": {
-                      "default": "GET",
-                      "description": "Method is the HTTP request type (GET or POST).",
-                      "enum": [
-                        "GET",
-                        "POST"
-                      ],
-                      "type": "string"
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
                     },
-                    "service": {
-                      "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
-                      "properties": {
-                        "caBundle": {
-                          "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
                           "type": "string"
                         },
-                        "url": {
-                          "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
                           "type": "string"
                         }
                       },
                       "required": [
-                        "url"
+                        "kind",
+                        "name"
                       ],
                       "type": "object",
+                      "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     },
-                    "urlPath": {
-                      "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
+                    "type": "array"
+                  }
                 },
-                "configMap": {
-                  "description": "ConfigMap is the ConfigMap reference.",
-                  "properties": {
-                    "name": {
-                      "description": "Name is the ConfigMap name.",
-                      "type": "string"
-                    },
-                    "namespace": {
-                      "description": "Namespace is the ConfigMap namespace.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "globalReference": {
-                  "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
-                  "properties": {
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
-                      "type": "string"
-                    },
-                    "name": {
-                      "description": "Name of the global context entry",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "imageRegistry": {
-                  "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
-                  "properties": {
-                    "imageRegistryCredentials": {
-                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
-                      "properties": {
-                        "allowInsecureRegistry": {
-                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
-                          "type": "boolean"
-                        },
-                        "providers": {
-                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
-                          "items": {
-                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
-                            "enum": [
-                              "default",
-                              "amazon",
-                              "azure",
-                              "google",
-                              "github"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "secrets": {
-                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
-                      "type": "string"
-                    },
-                    "reference": {
-                      "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "reference"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "name": {
-                  "description": "Name is the variable name.",
-                  "type": "string"
-                },
-                "variable": {
-                  "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
-                  "properties": {
-                    "default": {
-                      "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "jmesPath": {
-                      "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
+                "type": "object",
+                "additionalProperties": false
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "array"
             },
-            "type": "array"
-          },
-          "exclude": {
-            "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
-            "properties": {
-              "all": {
-                "description": "All allows specifying resources which will be ANDed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
                     },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
                           "type": "string"
                         },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
                       },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
                         "type": "string"
                       },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
                         "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
                           }
                         },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
-                    }
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
                 },
-                "type": "array"
+                "type": "object",
+                "additionalProperties": false
               },
-              "any": {
-                "description": "Any allows specifying resources which will be ORed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
+              "type": "array"
+            }
           },
-          "match": {
-            "description": "MatchResources defines when cleanuppolicy should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-            "properties": {
-              "all": {
-                "description": "All allows specifying resources which will be ANDed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              },
-              "any": {
-                "description": "Any allows specifying resources which will be ORed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
-          },
-          "schedule": {
-            "description": "The schedule in Cron format",
-            "type": "string"
-          }
+          "type": "object",
+          "additionalProperties": false
         },
-        "required": [
-          "schedule"
-        ],
-        "type": "object",
-        "additionalProperties": false
+        "match": {
+          "description": "MatchResources defines when cleanuppolicy should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedule": {
+          "description": "The schedule in Cron format",
+          "type": "string"
+        }
       },
-      "status": {
-        "description": "Status contains policy runtime data.",
-        "properties": {
-          "conditions": {
-            "items": {
-              "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
-              "properties": {
-                "lastTransitionTime": {
-                  "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
-                  "format": "date-time",
-                  "type": "string"
-                },
-                "message": {
-                  "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                  "maxLength": 32768,
-                  "type": "string"
-                },
-                "observedGeneration": {
-                  "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
-                  "format": "int64",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "reason": {
-                  "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                  "maxLength": 1024,
-                  "minLength": 1,
-                  "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
-                  "type": "string"
-                },
-                "status": {
-                  "description": "status of the condition, one of True, False, Unknown.",
-                  "enum": [
-                    "True",
-                    "False",
-                    "Unknown"
-                  ],
-                  "type": "string"
-                },
-                "type": {
-                  "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
-                  "maxLength": 316,
-                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "lastTransitionTime",
-                "message",
-                "reason",
-                "status",
-                "type"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": "array"
-          },
-          "lastExecutionTime": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "additionalProperties": false
-      }
+      "required": [
+        "match",
+        "schedule"
+      ],
+      "type": "object",
+      "additionalProperties": false
     },
-    "required": [
-      "spec"
-    ],
-    "type": "object"
-  }
-  
+    "status": {
+      "description": "Status contains policy runtime data.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastExecutionTime": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/clustercleanuppolicy_v2beta1.json
+++ b/kyverno.io/clustercleanuppolicy_v2beta1.json
@@ -110,6 +110,33 @@
           "description": "Context defines variables and data sources that can be used during rule execution.",
           "items": {
             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+            "oneOf": [
+              {
+                "required": [
+                  "configMap"
+                ]
+              },
+              {
+                "required": [
+                  "apiCall"
+                ]
+              },
+              {
+                "required": [
+                  "imageRegistry"
+                ]
+              },
+              {
+                "required": [
+                  "variable"
+                ]
+              },
+              {
+                "required": [
+                  "globalReference"
+                ]
+              }
+            ],
             "properties": {
               "apiCall": {
                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -137,13 +164,17 @@
                     },
                     "type": "array"
                   },
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "jmesPath": {
                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                     "type": "string"
                   },
                   "method": {
                     "default": "GET",
-                    "description": "Method is the HTTP request type (GET or POST).",
+                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                     "enum": [
                       "GET",
                       "POST"
@@ -156,6 +187,28 @@
                       "caBundle": {
                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                         "type": "string"
+                      },
+                      "headers": {
+                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "description": "Key is the header key",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is the header value",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "url": {
                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -206,6 +259,9 @@
                     "type": "string"
                   }
                 },
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -284,6 +340,9 @@
                 "additionalProperties": false
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -291,6 +350,12 @@
         },
         "exclude": {
           "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
           "properties": {
             "all": {
               "description": "All allows specifying resources which will be ANDed",
@@ -306,6 +371,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -353,7 +424,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -363,7 +435,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -419,7 +492,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -429,7 +503,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -506,6 +581,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -553,7 +634,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -563,7 +645,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -619,7 +702,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -629,7 +713,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -698,6 +783,12 @@
         },
         "match": {
           "description": "MatchResources defines when cleanuppolicy should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
           "properties": {
             "all": {
               "description": "All allows specifying resources which will be ANDed",
@@ -713,6 +804,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -760,7 +857,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -770,7 +868,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -826,7 +925,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -836,7 +936,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -913,6 +1014,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -960,7 +1067,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -970,7 +1078,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1026,7 +1135,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1036,7 +1146,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1109,6 +1220,7 @@
         }
       },
       "required": [
+        "match",
         "schedule"
       ],
       "type": "object",
@@ -1119,7 +1231,7 @@
       "properties": {
         "conditions": {
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -1154,7 +1266,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/kyverno.io/clusterephemeralreport_v1.json
+++ b/kyverno.io/clusterephemeralreport_v1.json
@@ -1,0 +1,270 @@
+{
+  "description": "ClusterEphemeralReport is the Schema for the ClusterEphemeralReports API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "owner": {
+          "description": "Owner is a reference to the report owner (e.g. a Deployment, Namespace, or Node)",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "blockOwnerDeletion": {
+              "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then\nthe owner cannot be deleted from the key-value store until this\nreference is removed.\nSee https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion\nfor how the garbage collector interacts with this field and enforces the foreground deletion.\nDefaults to false.\nTo set this field, a user needs \"delete\" permission of the owner,\notherwise 422 (Unprocessable Entity) will be returned.",
+              "type": "boolean"
+            },
+            "controller": {
+              "description": "If true, this reference points to the managing controller.",
+              "type": "boolean"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name",
+            "uid"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "results": {
+          "description": "PolicyReportResult provides result details",
+          "items": {
+            "description": "PolicyReportResult provides the result for an individual policy",
+            "properties": {
+              "category": {
+                "description": "Category indicates policy category",
+                "type": "string"
+              },
+              "message": {
+                "description": "Description is a short user friendly message for the policy rule",
+                "type": "string"
+              },
+              "policy": {
+                "description": "Policy is the name or identifier of the policy",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Properties provides additional information for the policy rule",
+                "type": "object"
+              },
+              "resourceSelector": {
+                "description": "SubjectSelector is an optional label selector for checked Kubernetes resources.\nFor example, a policy result may apply to all pods that match a label.\nEither a Subject or a SubjectSelector can be specified.\nIf neither are provided, the result is assumed to be for the policy report scope.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "resources": {
+                "description": "Subjects is an optional reference to the checked Kubernetes resources",
+                "items": {
+                  "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "result": {
+                "description": "Result indicates the outcome of the policy rule execution",
+                "enum": [
+                  "pass",
+                  "fail",
+                  "warn",
+                  "error",
+                  "skip"
+                ],
+                "type": "string"
+              },
+              "rule": {
+                "description": "Rule is the name or identifier of the rule within the policy",
+                "type": "string"
+              },
+              "scored": {
+                "description": "Scored indicates if this result is scored",
+                "type": "boolean"
+              },
+              "severity": {
+                "description": "Severity indicates policy check result criticality",
+                "enum": [
+                  "critical",
+                  "high",
+                  "low",
+                  "medium",
+                  "info"
+                ],
+                "type": "string"
+              },
+              "source": {
+                "description": "Source is an identifier for the policy engine that manages this report",
+                "type": "string"
+              },
+              "timestamp": {
+                "description": "Timestamp indicates the time the result was found",
+                "properties": {
+                  "nanos": {
+                    "description": "Non-negative fractions of a second at nanosecond resolution. Negative\nsecond values with fractions must still have non-negative nanos values\nthat count forward in time. Must be from 0 to 999,999,999\ninclusive. This field may be limited in precision depending on context.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "seconds": {
+                    "description": "Represents seconds of UTC time since Unix epoch\n1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to\n9999-12-31T23:59:59Z inclusive.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "nanos",
+                  "seconds"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "additionalProperties": false
+            },
+            "required": [
+              "policy"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "summary": {
+          "description": "PolicyReportSummary provides a summary of results",
+          "properties": {
+            "error": {
+              "description": "Error provides the count of policies that could not be evaluated",
+              "type": "integer"
+            },
+            "fail": {
+              "description": "Fail provides the count of policies whose requirements were not met",
+              "type": "integer"
+            },
+            "pass": {
+              "description": "Pass provides the count of policies whose requirements were met",
+              "type": "integer"
+            },
+            "skip": {
+              "description": "Skip indicates the count of policies that were not selected for evaluation",
+              "type": "integer"
+            },
+            "warn": {
+              "description": "Warn provides the count of non-scored policies whose requirements were not met",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "owner"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/clusterpolicy_v1.json
+++ b/kyverno.io/clusterpolicy_v1.json
@@ -33,8 +33,13 @@
           "description": "Background controls if rules are applied to existing resources during a background scan.\nOptional. Default value is \"true\". The value must be set to \"false\" if the policy rule\nuses variables that are only available in the admission review request (e.g. user name).",
           "type": "boolean"
         },
+        "emitWarning": {
+          "default": false,
+          "description": "EmitWarning enables API response warnings for mutate policy rules or validate policy rules with validationFailureAction set to Audit.\nEnabling this option will extend admission request processing times. The default value is \"false\".",
+          "type": "boolean"
+        },
         "failurePolicy": {
-          "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+          "description": "Deprecated, use failurePolicy under the webhookConfiguration instead.",
           "enum": [
             "Ignore",
             "Fail"
@@ -42,7 +47,7 @@
           "type": "string"
         },
         "generateExisting": {
-          "description": "GenerateExisting controls whether to trigger generate rule in existing resources\nIf is set to \"true\" generate rule will be triggered and applied to existing matched resources.\nDefaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting under the generate rule instead",
           "type": "boolean"
         },
         "generateExistingOnPolicyUpdate": {
@@ -50,7 +55,7 @@
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
-          "description": "MutateExistingOnPolicyUpdate controls if a mutateExisting policy is applied on policy events.\nDefault value is \"false\".",
+          "description": "Deprecated, use mutateExistingOnPolicyUpdate under the mutate rule instead",
           "type": "boolean"
         },
         "rules": {
@@ -61,14 +66,14 @@
               "celPreconditions": {
                 "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
                 "items": {
-                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "description": "MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.",
                   "properties": {
                     "expression": {
-                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                       "type": "string"
                     }
                   },
@@ -85,6 +90,33 @@
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                  "oneOf": [
+                    {
+                      "required": [
+                        "configMap"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apiCall"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "imageRegistry"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "variable"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "globalReference"
+                      ]
+                    }
+                  ],
                   "properties": {
                     "apiCall": {
                       "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -112,13 +144,17 @@
                           },
                           "type": "array"
                         },
+                        "default": {
+                          "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                           "type": "string"
                         },
                         "method": {
                           "default": "GET",
-                          "description": "Method is the HTTP request type (GET or POST).",
+                          "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                           "enum": [
                             "GET",
                             "POST"
@@ -131,6 +167,28 @@
                             "caBundle": {
                               "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                               "type": "string"
+                            },
+                            "headers": {
+                              "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the header key",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the header value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "url": {
                               "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -181,6 +239,9 @@
                           "type": "string"
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -259,6 +320,9 @@
                       "additionalProperties": false
                     }
                   },
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -266,6 +330,12 @@
               },
               "exclude": {
                 "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
                 "properties": {
                   "all": {
                     "description": "All allows specifying resources which will be ANDed",
@@ -281,6 +351,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -328,7 +404,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -338,7 +415,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -394,7 +472,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -404,7 +483,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -481,6 +561,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -528,7 +614,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -538,7 +625,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -594,7 +682,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -604,7 +693,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -676,6 +766,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -723,7 +819,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -733,7 +830,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -789,7 +887,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -799,7 +898,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -917,7 +1017,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -927,7 +1028,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -949,678 +1051,125 @@
                     "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "kind": {
-                    "description": "Kind specifies resource kind.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "Name specifies the resource name.",
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "description": "Namespace specifies resource namespace.",
-                    "type": "string"
-                  },
-                  "orphanDownstreamOnPolicyDelete": {
-                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "synchronize": {
-                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "uid": {
-                    "description": "UID specifies the resource uid.",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "imageExtractors": {
-                "additionalProperties": {
-                  "items": {
-                    "properties": {
-                      "jmesPath": {
-                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                        "type": "string"
-                      },
-                      "key": {
-                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                        "type": "string"
-                      },
-                      "path": {
-                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "path"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                "type": "object"
-              },
-              "match": {
-                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                "properties": {
-                  "all": {
-                    "description": "All allows specifying resources which will be ANDed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "any": {
-                    "description": "Any allows specifying resources which will be ORed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "clusterRoles": {
-                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "resources": {
-                    "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
-                    "properties": {
-                      "annotations": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                        "type": "object"
-                      },
-                      "kinds": {
-                        "description": "Kinds is a list of resource kinds.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "name": {
-                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                        "type": "string"
-                      },
-                      "names": {
-                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "namespaceSelector": {
-                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "namespaces": {
-                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "operations": {
-                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                        "items": {
-                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                          "enum": [
-                            "CREATE",
-                            "CONNECT",
-                            "UPDATE",
-                            "DELETE"
-                          ],
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "selector": {
-                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "roles": {
-                    "description": "Roles is the list of namespaced role names for the user.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "subjects": {
-                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                    "items": {
-                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                      "properties": {
-                        "apiGroup": {
-                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                          "type": "string"
-                        },
-                        "kind": {
-                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Name of the object being referenced.",
-                          "type": "string"
-                        },
-                        "namespace": {
-                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "kind",
-                        "name"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "mutate": {
-                "description": "Mutation is used to modify matching resources.",
-                "properties": {
                   "foreach": {
-                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion specifies resource apiVersion.",
+                          "type": "string"
+                        },
+                        "clone": {
+                          "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "properties": {
+                            "name": {
+                              "description": "Name specifies name of the resource.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "cloneList": {
+                          "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                          "properties": {
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1648,13 +1197,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1667,6 +1220,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -1717,6 +1292,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1795,6 +1373,1087 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "data": {
+                          "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "kind": {
+                          "description": "Kind specifies resource kind.",
+                          "type": "string"
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name specifies the resource name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true,
+                          "additionalProperties": false
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "generateExisting": {
+                    "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind specifies resource kind.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name specifies the resource name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace specifies resource namespace.",
+                    "type": "string"
+                  },
+                  "orphanDownstreamOnPolicyDelete": {
+                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "synchronize": {
+                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageExtractors": {
+                "additionalProperties": {
+                  "items": {
+                    "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                "type": "object"
+              },
+              "match": {
+                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
+                "properties": {
+                  "all": {
+                    "description": "All allows specifying resources which will be ANDed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "any": {
+                    "description": "Any allows specifying resources which will be ORed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "mutate": {
+                "description": "Mutation is used to modify matching resources.",
+                "properties": {
+                  "foreach": {
+                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "properties": {
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1928,6 +2587,10 @@
                     },
                     "type": "array"
                   },
+                  "mutateExistingOnPolicyUpdate": {
+                    "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                    "type": "boolean"
+                  },
                   "patchStrategicMerge": {
                     "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                     "x-kubernetes-preserve-unknown-fields": true
@@ -1949,6 +2612,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1976,13 +2666,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1995,6 +2689,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -2045,6 +2761,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2123,6 +2842,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2143,6 +2865,53 @@
                         "preconditions": {
                           "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "selector": {
+                          "description": "Selector allows you to select target resources with their labels.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
                         },
                         "uid": {
                           "description": "UID specifies the resource uid.",
@@ -2167,6 +2936,13 @@
                 "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                 "x-kubernetes-preserve-unknown-fields": true
               },
+              "reportProperties": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                "type": "object"
+              },
               "skipBackgroundRequests": {
                 "default": true,
                 "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
@@ -2175,8 +2951,18 @@
               "validate": {
                 "description": "Validation is used to validate matching resources.",
                 "properties": {
+                  "allowExistingViolations": {
+                    "default": true,
+                    "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                    "type": "boolean"
+                  },
                   "anyPattern": {
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "assert": {
+                    "description": "Assert defines a kyverno-json assertion tree.",
+                    "type": "object",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "cel": {
@@ -2188,11 +2974,11 @@
                           "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                           "properties": {
                             "key": {
-                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                               "type": "string"
                             },
                             "valueExpression": {
-                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                               "type": "string"
                             }
                           },
@@ -2211,7 +2997,7 @@
                           "description": "Validation specifies the CEL expression which is used to apply the validation.",
                           "properties": {
                             "expression": {
-                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                               "type": "string"
                             },
                             "message": {
@@ -2255,19 +3041,19 @@
                         "description": "ParamRef references a parameter resource.",
                         "properties": {
                           "name": {
-                            "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                            "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                             "type": "string"
                           },
                           "parameterNotFoundAction": {
-                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                             "properties": {
                               "matchExpressions": {
                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -2287,7 +3073,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2297,7 +3084,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2319,7 +3107,7 @@
                       "variables": {
                         "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                         "items": {
-                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                           "properties": {
                             "expression": {
                               "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -2335,6 +3123,7 @@
                             "name"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "type": "array"
@@ -2354,6 +3143,87 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "failureAction": {
+                    "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                    "enum": [
+                      "Audit",
+                      "Enforce"
+                    ],
+                    "type": "string"
+                  },
+                  "failureActionOverrides": {
+                    "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                    "items": {
+                      "properties": {
+                        "action": {
+                          "description": "ValidationFailureAction defines the policy validation failure action",
+                          "enum": [
+                            "audit",
+                            "enforce",
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
+                        },
+                        "namespaceSelector": {
+                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
@@ -2367,6 +3237,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -2394,13 +3291,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -2413,6 +3314,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -2463,6 +3386,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2541,6 +3467,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2729,6 +3658,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2777,6 +3710,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2784,6 +3721,10 @@
                                       },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
+                                        "type": "string"
+                                      },
+                                      "issuerRegExp": {
+                                        "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
@@ -2812,6 +3753,10 @@
                                       "subject": {
                                         "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
+                                      },
+                                      "subjectRegExp": {
+                                        "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -2829,6 +3774,10 @@
                                           },
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                             "type": "string"
                                           }
                                         },
@@ -2883,7 +3832,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                        "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                         "type": "string"
                                       }
                                     },
@@ -2892,6 +3841,11 @@
                                   },
                                   "repository": {
                                     "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                    "type": "string"
+                                  },
+                                  "signatureAlgorithm": {
+                                    "default": "sha256",
+                                    "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                     "type": "string"
                                   }
                                 },
@@ -3135,6 +4089,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -3183,6 +4141,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -3190,6 +4152,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -3218,6 +4184,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -3235,6 +4205,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -3289,7 +4263,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -3298,6 +4272,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -3413,6 +4392,10 @@
                             },
                             "type": "array"
                           },
+                          "name": {
+                            "description": "Name is the variable name.",
+                            "type": "string"
+                          },
                           "predicateType": {
                             "description": "Deprecated in favour of 'Type', to be removed soon",
                             "type": "string"
@@ -3472,6 +4455,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3520,6 +4507,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3527,6 +4518,10 @@
                                     },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
+                                      "type": "string"
+                                    },
+                                    "issuerRegExp": {
+                                      "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
@@ -3555,6 +4550,10 @@
                                     "subject": {
                                       "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
+                                    },
+                                    "subjectRegExp": {
+                                      "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                      "type": "string"
                                     }
                                   },
                                   "type": "object",
@@ -3572,6 +4571,10 @@
                                         },
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                           "type": "string"
                                         }
                                       },
@@ -3626,7 +4629,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                      "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                       "type": "string"
                                     }
                                   },
@@ -3635,6 +4638,11 @@
                                 },
                                 "repository": {
                                   "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                  "type": "string"
+                                },
+                                "signatureAlgorithm": {
+                                  "default": "sha256",
+                                  "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                   "type": "string"
                                 }
                               },
@@ -3648,6 +4656,18 @@
                         "additionalProperties": false
                       },
                       "type": "array"
+                    },
+                    "cosignOCI11": {
+                      "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "failureAction": {
+                      "description": "Allowed values are Audit or Enforce.",
+                      "enum": [
+                        "Audit",
+                        "Enforce"
+                      ],
+                      "type": "string"
                     },
                     "image": {
                       "description": "Deprecated. Use ImageReferences instead.",
@@ -3731,9 +4751,10 @@
                       "type": "string"
                     },
                     "type": {
-                      "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
+                      "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
                       "enum": [
                         "Cosign",
+                        "SigstoreBundle",
                         "Notary"
                       ],
                       "type": "string"
@@ -3742,6 +4763,28 @@
                       "default": true,
                       "description": "UseCache enables caching of image verify responses for this rule.",
                       "type": "boolean"
+                    },
+                    "validate": {
+                      "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                      "properties": {
+                        "deny": {
+                          "description": "Deny defines conditions used to pass or fail a validation rule.",
+                          "properties": {
+                            "conditions": {
+                              "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "message": {
+                          "description": "Message specifies a custom message to be displayed on failure.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "verifyDigest": {
                       "default": true,
@@ -3756,6 +4799,7 @@
               }
             },
             "required": [
+              "match",
               "name"
             ],
             "type": "object",
@@ -3773,7 +4817,7 @@
         },
         "validationFailureAction": {
           "default": "Audit",
-          "description": "ValidationFailureAction defines if a validation policy rule violation should block\nthe admission review request (enforce), or allow (audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are audit or enforce. The default value is \"Audit\".",
+          "description": "Deprecated, use validationFailureAction under the validate rule instead.",
           "enum": [
             "audit",
             "enforce",
@@ -3783,7 +4827,7 @@
           "type": "string"
         },
         "validationFailureActionOverrides": {
-          "description": "ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction\nnamespace-wise. It overrides ValidationFailureAction for the specified namespaces.",
+          "description": "Deprecated, use validationFailureActionOverrides under the validate rule instead.",
           "items": {
             "properties": {
               "action": {
@@ -3817,7 +4861,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -3827,7 +4872,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -3854,19 +4900,27 @@
           "type": "array"
         },
         "webhookConfiguration": {
-          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.\nRequires Kubernetes 1.27 or later.",
+          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.",
           "properties": {
+            "failurePolicy": {
+              "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+              "enum": [
+                "Ignore",
+                "Fail"
+              ],
+              "type": "string"
+            },
             "matchConditions": {
-              "description": "MatchCondition configures admission webhook matchConditions.",
+              "description": "MatchCondition configures admission webhook matchConditions.\nRequires Kubernetes 1.27 or later.",
               "items": {
                 "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
                 "properties": {
                   "expression": {
-                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                     "type": "string"
                   }
                 },
@@ -3878,13 +4932,18 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "timeoutSeconds": {
+              "description": "TimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+              "format": "int32",
+              "type": "integer"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "webhookTimeoutSeconds": {
-          "description": "WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+          "description": "Deprecated, use webhookTimeoutSeconds under webhookConfiguration instead.",
           "format": "int32",
           "type": "integer"
         }
@@ -3906,14 +4965,14 @@
                   "celPreconditions": {
                     "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
                     "items": {
-                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "description": "MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.",
                       "properties": {
                         "expression": {
-                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                           "type": "string"
                         }
                       },
@@ -3930,6 +4989,33 @@
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "configMap"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apiCall"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "imageRegistry"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "variable"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "globalReference"
+                          ]
+                        }
+                      ],
                       "properties": {
                         "apiCall": {
                           "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -3957,13 +5043,17 @@
                               },
                               "type": "array"
                             },
+                            "default": {
+                              "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                               "type": "string"
                             },
                             "method": {
                               "default": "GET",
-                              "description": "Method is the HTTP request type (GET or POST).",
+                              "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                               "enum": [
                                 "GET",
                                 "POST"
@@ -3976,6 +5066,28 @@
                                 "caBundle": {
                                   "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                   "type": "string"
+                                },
+                                "headers": {
+                                  "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the header key",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the header value",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
                                 },
                                 "url": {
                                   "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -4026,6 +5138,9 @@
                               "type": "string"
                             }
                           },
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -4104,6 +5219,9 @@
                           "additionalProperties": false
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -4111,6 +5229,12 @@
                   },
                   "exclude": {
                     "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
                     "properties": {
                       "all": {
                         "description": "All allows specifying resources which will be ANDed",
@@ -4126,6 +5250,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -4173,7 +5303,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4183,7 +5314,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4239,7 +5371,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4249,7 +5382,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4326,6 +5460,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -4373,7 +5513,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4383,7 +5524,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4439,7 +5581,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4449,7 +5592,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4521,6 +5665,12 @@
                       },
                       "resources": {
                         "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
                         "properties": {
                           "annotations": {
                             "additionalProperties": {
@@ -4568,7 +5718,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4578,7 +5729,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4634,7 +5786,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4644,7 +5797,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4762,7 +5916,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4772,7 +5927,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4794,678 +5950,125 @@
                         "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
-                      "kind": {
-                        "description": "Kind specifies resource kind.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name specifies the resource name.",
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "description": "Namespace specifies resource namespace.",
-                        "type": "string"
-                      },
-                      "orphanDownstreamOnPolicyDelete": {
-                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "synchronize": {
-                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "uid": {
-                        "description": "UID specifies the resource uid.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "imageExtractors": {
-                    "additionalProperties": {
-                      "items": {
-                        "properties": {
-                          "jmesPath": {
-                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                            "type": "string"
-                          },
-                          "key": {
-                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                            "type": "string"
-                          },
-                          "path": {
-                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                            "type": "string"
-                          },
-                          "value": {
-                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "path"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    },
-                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                    "type": "object"
-                  },
-                  "match": {
-                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                    "properties": {
-                      "all": {
-                        "description": "All allows specifying resources which will be ANDed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "any": {
-                        "description": "Any allows specifying resources which will be ORed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "clusterRoles": {
-                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "resources": {
-                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
-                        "properties": {
-                          "annotations": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                            "type": "object"
-                          },
-                          "kinds": {
-                            "description": "Kinds is a list of resource kinds.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "name": {
-                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                            "type": "string"
-                          },
-                          "names": {
-                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "namespaceSelector": {
-                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "namespaces": {
-                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "operations": {
-                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                            "items": {
-                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                              "enum": [
-                                "CREATE",
-                                "CONNECT",
-                                "UPDATE",
-                                "DELETE"
-                              ],
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "selector": {
-                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "roles": {
-                        "description": "Roles is the list of namespaced role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "subjects": {
-                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                        "items": {
-                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                          "properties": {
-                            "apiGroup": {
-                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                              "type": "string"
-                            },
-                            "kind": {
-                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "Name of the object being referenced.",
-                              "type": "string"
-                            },
-                            "namespace": {
-                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "kind",
-                            "name"
-                          ],
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "mutate": {
-                    "description": "Mutation is used to modify matching resources.",
-                    "properties": {
                       "foreach": {
-                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
+                            "apiVersion": {
+                              "description": "APIVersion specifies resource apiVersion.",
+                              "type": "string"
+                            },
+                            "clone": {
+                              "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies name of the resource.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "cloneList": {
+                              "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                              "properties": {
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5493,13 +6096,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5512,6 +6119,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5562,6 +6191,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5640,6 +6272,1087 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "data": {
+                              "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "kind": {
+                              "description": "Kind specifies resource kind.",
+                              "type": "string"
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name specifies the resource name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true,
+                              "additionalProperties": false
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "generateExisting": {
+                        "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind specifies resource kind.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name specifies the resource name.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies resource namespace.",
+                        "type": "string"
+                      },
+                      "orphanDownstreamOnPolicyDelete": {
+                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "synchronize": {
+                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "imageExtractors": {
+                    "additionalProperties": {
+                      "items": {
+                        "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                    "type": "object"
+                  },
+                  "match": {
+                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
+                    "properties": {
+                      "all": {
+                        "description": "All allows specifying resources which will be ANDed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "any": {
+                        "description": "Any allows specifying resources which will be ORed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "clusterRoles": {
+                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                            "type": "object"
+                          },
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                            "type": "string"
+                          },
+                          "names": {
+                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespaceSelector": {
+                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "roles": {
+                        "description": "Roles is the list of namespaced role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "subjects": {
+                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                        "items": {
+                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the object being referenced.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "mutate": {
+                    "description": "Mutation is used to modify matching resources.",
+                    "properties": {
+                      "foreach": {
+                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "properties": {
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5773,6 +7486,10 @@
                         },
                         "type": "array"
                       },
+                      "mutateExistingOnPolicyUpdate": {
+                        "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                        "type": "boolean"
+                      },
                       "patchStrategicMerge": {
                         "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                         "x-kubernetes-preserve-unknown-fields": true
@@ -5794,6 +7511,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5821,13 +7565,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5840,6 +7588,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5890,6 +7660,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5968,6 +7741,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5988,6 +7764,53 @@
                             "preconditions": {
                               "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                               "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "selector": {
+                              "description": "Selector allows you to select target resources with their labels.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "uid": {
                               "description": "UID specifies the resource uid.",
@@ -6012,6 +7835,13 @@
                     "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "reportProperties": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                    "type": "object"
+                  },
                   "skipBackgroundRequests": {
                     "default": true,
                     "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
@@ -6020,8 +7850,18 @@
                   "validate": {
                     "description": "Validation is used to validate matching resources.",
                     "properties": {
+                      "allowExistingViolations": {
+                        "default": true,
+                        "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                        "type": "boolean"
+                      },
                       "anyPattern": {
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "assert": {
+                        "description": "Assert defines a kyverno-json assertion tree.",
+                        "type": "object",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
                       "cel": {
@@ -6033,11 +7873,11 @@
                               "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                               "properties": {
                                 "key": {
-                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                                   "type": "string"
                                 },
                                 "valueExpression": {
-                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                                   "type": "string"
                                 }
                               },
@@ -6056,7 +7896,7 @@
                               "description": "Validation specifies the CEL expression which is used to apply the validation.",
                               "properties": {
                                 "expression": {
-                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                                   "type": "string"
                                 },
                                 "message": {
@@ -6100,19 +7940,19 @@
                             "description": "ParamRef references a parameter resource.",
                             "properties": {
                               "name": {
-                                "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                                "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                                 "type": "string"
                               },
                               "parameterNotFoundAction": {
-                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                                 "type": "string"
                               },
                               "selector": {
-                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                                 "properties": {
                                   "matchExpressions": {
                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -6132,7 +7972,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -6142,7 +7983,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -6164,7 +8006,7 @@
                           "variables": {
                             "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                             "items": {
-                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                               "properties": {
                                 "expression": {
                                   "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -6180,6 +8022,7 @@
                                 "name"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "type": "array"
@@ -6199,6 +8042,87 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "failureAction": {
+                        "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                        "enum": [
+                          "Audit",
+                          "Enforce"
+                        ],
+                        "type": "string"
+                      },
+                      "failureActionOverrides": {
+                        "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "description": "ValidationFailureAction defines the policy validation failure action",
+                              "enum": [
+                                "audit",
+                                "enforce",
+                                "Audit",
+                                "Enforce"
+                              ],
+                              "type": "string"
+                            },
+                            "namespaceSelector": {
+                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
@@ -6212,6 +8136,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -6239,13 +8190,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -6258,6 +8213,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -6308,6 +8285,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -6386,6 +8366,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -6574,6 +8557,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6622,6 +8609,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6629,6 +8620,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -6657,6 +8652,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -6674,6 +8673,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -6728,7 +8731,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -6737,6 +8740,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -6980,6 +8988,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -7028,6 +9040,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -7035,6 +9051,10 @@
                                               },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
+                                                "type": "string"
+                                              },
+                                              "issuerRegExp": {
+                                                "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
@@ -7063,6 +9083,10 @@
                                               "subject": {
                                                 "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
+                                              },
+                                              "subjectRegExp": {
+                                                "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -7080,6 +9104,10 @@
                                                   },
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -7134,7 +9162,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                                "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                                 "type": "string"
                                               }
                                             },
@@ -7143,6 +9171,11 @@
                                           },
                                           "repository": {
                                             "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                            "type": "string"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -7258,6 +9291,10 @@
                                 },
                                 "type": "array"
                               },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
                               "predicateType": {
                                 "description": "Deprecated in favour of 'Type', to be removed soon",
                                 "type": "string"
@@ -7317,6 +9354,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7365,6 +9406,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7372,6 +9417,10 @@
                                         },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
+                                          "type": "string"
+                                        },
+                                        "issuerRegExp": {
+                                          "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
@@ -7400,6 +9449,10 @@
                                         "subject": {
                                           "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
+                                        },
+                                        "subjectRegExp": {
+                                          "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -7417,6 +9470,10 @@
                                             },
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                               "type": "string"
                                             }
                                           },
@@ -7471,7 +9528,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                          "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                           "type": "string"
                                         }
                                       },
@@ -7480,6 +9537,11 @@
                                     },
                                     "repository": {
                                       "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                      "type": "string"
+                                    },
+                                    "signatureAlgorithm": {
+                                      "default": "sha256",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -7493,6 +9555,18 @@
                             "additionalProperties": false
                           },
                           "type": "array"
+                        },
+                        "cosignOCI11": {
+                          "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "failureAction": {
+                          "description": "Allowed values are Audit or Enforce.",
+                          "enum": [
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
                         },
                         "image": {
                           "description": "Deprecated. Use ImageReferences instead.",
@@ -7576,9 +9650,10 @@
                           "type": "string"
                         },
                         "type": {
-                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
                           "enum": [
                             "Cosign",
+                            "SigstoreBundle",
                             "Notary"
                           ],
                           "type": "string"
@@ -7587,6 +9662,28 @@
                           "default": true,
                           "description": "UseCache enables caching of image verify responses for this rule.",
                           "type": "boolean"
+                        },
+                        "validate": {
+                          "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                          "properties": {
+                            "deny": {
+                              "description": "Deny defines conditions used to pass or fail a validation rule.",
+                              "properties": {
+                                "conditions": {
+                                  "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "message": {
+                              "description": "Message specifies a custom message to be displayed on failure.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "verifyDigest": {
                           "default": true,
@@ -7601,6 +9698,7 @@
                   }
                 },
                 "required": [
+                  "match",
                   "name"
                 ],
                 "type": "object",
@@ -7614,7 +9712,7 @@
         },
         "conditions": {
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -7649,7 +9747,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"
@@ -7720,9 +9818,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "ready"
-      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/kyverno.io/clusterpolicy_v2beta1.json
+++ b/kyverno.io/clusterpolicy_v2beta1.json
@@ -34,7 +34,7 @@
           "type": "boolean"
         },
         "failurePolicy": {
-          "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+          "description": "Deprecated, use failurePolicy under the webhookConfiguration instead.",
           "enum": [
             "Ignore",
             "Fail"
@@ -42,7 +42,7 @@
           "type": "string"
         },
         "generateExisting": {
-          "description": "GenerateExisting controls whether to trigger generate rule in existing resources\nIf is set to \"true\" generate rule will be triggered and applied to existing matched resources.\nDefaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting under the generate rule instead",
           "type": "boolean"
         },
         "generateExistingOnPolicyUpdate": {
@@ -50,7 +50,7 @@
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
-          "description": "MutateExistingOnPolicyUpdate controls if a mutateExisting policy is applied on policy events.\nDefault value is \"false\".",
+          "description": "Deprecated, use mutateExistingOnPolicyUpdate under the mutate rule instead",
           "type": "boolean"
         },
         "rules": {
@@ -64,11 +64,11 @@
                   "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
                   "properties": {
                     "expression": {
-                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                       "type": "string"
                     }
                   },
@@ -85,6 +85,33 @@
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                  "oneOf": [
+                    {
+                      "required": [
+                        "configMap"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apiCall"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "imageRegistry"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "variable"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "globalReference"
+                      ]
+                    }
+                  ],
                   "properties": {
                     "apiCall": {
                       "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -112,13 +139,17 @@
                           },
                           "type": "array"
                         },
+                        "default": {
+                          "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                           "type": "string"
                         },
                         "method": {
                           "default": "GET",
-                          "description": "Method is the HTTP request type (GET or POST).",
+                          "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                           "enum": [
                             "GET",
                             "POST"
@@ -131,6 +162,28 @@
                             "caBundle": {
                               "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                               "type": "string"
+                            },
+                            "headers": {
+                              "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the header key",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the header value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "url": {
                               "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -181,6 +234,9 @@
                           "type": "string"
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -259,6 +315,9 @@
                       "additionalProperties": false
                     }
                   },
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -266,6 +325,12 @@
               },
               "exclude": {
                 "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
                 "properties": {
                   "all": {
                     "description": "All allows specifying resources which will be ANDed",
@@ -281,6 +346,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -328,7 +399,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -338,7 +410,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -394,7 +467,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -404,7 +478,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -481,6 +556,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -528,7 +609,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -538,7 +620,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -594,7 +677,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -604,7 +688,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -728,7 +813,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -738,7 +824,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -760,489 +847,125 @@
                     "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "kind": {
-                    "description": "Kind specifies resource kind.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "Name specifies the resource name.",
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "description": "Namespace specifies resource namespace.",
-                    "type": "string"
-                  },
-                  "orphanDownstreamOnPolicyDelete": {
-                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "synchronize": {
-                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "uid": {
-                    "description": "UID specifies the resource uid.",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "imageExtractors": {
-                "additionalProperties": {
-                  "items": {
-                    "properties": {
-                      "jmesPath": {
-                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                        "type": "string"
-                      },
-                      "key": {
-                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                        "type": "string"
-                      },
-                      "path": {
-                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "path"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                "type": "object"
-              },
-              "match": {
-                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                "properties": {
-                  "all": {
-                    "description": "All allows specifying resources which will be ANDed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "any": {
-                    "description": "Any allows specifying resources which will be ORed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "mutate": {
-                "description": "Mutation is used to modify matching resources.",
-                "properties": {
                   "foreach": {
-                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion specifies resource apiVersion.",
+                          "type": "string"
+                        },
+                        "clone": {
+                          "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "properties": {
+                            "name": {
+                              "description": "Name specifies name of the resource.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "cloneList": {
+                          "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                          "properties": {
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1270,13 +993,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1289,6 +1016,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -1339,6 +1088,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1417,6 +1169,888 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "data": {
+                          "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "kind": {
+                          "description": "Kind specifies resource kind.",
+                          "type": "string"
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name specifies the resource name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true,
+                          "additionalProperties": false
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "generateExisting": {
+                    "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind specifies resource kind.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name specifies the resource name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace specifies resource namespace.",
+                    "type": "string"
+                  },
+                  "orphanDownstreamOnPolicyDelete": {
+                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "synchronize": {
+                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageExtractors": {
+                "additionalProperties": {
+                  "items": {
+                    "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                "type": "object"
+              },
+              "match": {
+                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
+                "properties": {
+                  "all": {
+                    "description": "All allows specifying resources which will be ANDed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "any": {
+                    "description": "Any allows specifying resources which will be ORed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "mutate": {
+                "description": "Mutation is used to modify matching resources.",
+                "properties": {
+                  "foreach": {
+                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "properties": {
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1550,6 +2184,10 @@
                     },
                     "type": "array"
                   },
+                  "mutateExistingOnPolicyUpdate": {
+                    "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                    "type": "boolean"
+                  },
                   "patchStrategicMerge": {
                     "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                     "x-kubernetes-preserve-unknown-fields": true
@@ -1571,6 +2209,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1598,13 +2263,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1617,6 +2286,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -1667,6 +2358,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1745,6 +2439,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1765,6 +2462,53 @@
                         "preconditions": {
                           "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "selector": {
+                          "description": "Selector allows you to select target resources with their labels.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
                         },
                         "uid": {
                           "description": "UID specifies the resource uid.",
@@ -1888,6 +2632,11 @@
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "assert": {
+                    "description": "Assert defines a kyverno-json assertion tree.",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "cel": {
                     "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
                     "properties": {
@@ -1897,11 +2646,11 @@
                           "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                           "properties": {
                             "key": {
-                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                               "type": "string"
                             },
                             "valueExpression": {
-                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                               "type": "string"
                             }
                           },
@@ -1920,7 +2669,7 @@
                           "description": "Validation specifies the CEL expression which is used to apply the validation.",
                           "properties": {
                             "expression": {
-                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                               "type": "string"
                             },
                             "message": {
@@ -1964,19 +2713,19 @@
                         "description": "ParamRef references a parameter resource.",
                         "properties": {
                           "name": {
-                            "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                            "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                             "type": "string"
                           },
                           "parameterNotFoundAction": {
-                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                             "properties": {
                               "matchExpressions": {
                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -1996,7 +2745,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2006,7 +2756,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2028,7 +2779,7 @@
                       "variables": {
                         "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                         "items": {
-                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                           "properties": {
                             "expression": {
                               "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -2044,6 +2795,7 @@
                             "name"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "type": "array"
@@ -2150,6 +2902,87 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "failureAction": {
+                    "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                    "enum": [
+                      "Audit",
+                      "Enforce"
+                    ],
+                    "type": "string"
+                  },
+                  "failureActionOverrides": {
+                    "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                    "items": {
+                      "properties": {
+                        "action": {
+                          "description": "ValidationFailureAction defines the policy validation failure action",
+                          "enum": [
+                            "audit",
+                            "enforce",
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
+                        },
+                        "namespaceSelector": {
+                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
@@ -2163,6 +2996,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -2190,13 +3050,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -2209,6 +3073,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -2259,6 +3145,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2337,6 +3226,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2525,6 +3417,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2573,6 +3469,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2580,6 +3480,10 @@
                                       },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
+                                        "type": "string"
+                                      },
+                                      "issuerRegExp": {
+                                        "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
@@ -2608,6 +3512,10 @@
                                       "subject": {
                                         "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
+                                      },
+                                      "subjectRegExp": {
+                                        "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -2625,6 +3533,10 @@
                                           },
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                             "type": "string"
                                           }
                                         },
@@ -2679,7 +3591,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                        "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                         "type": "string"
                                       }
                                     },
@@ -2688,6 +3600,11 @@
                                   },
                                   "repository": {
                                     "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                    "type": "string"
+                                  },
+                                  "signatureAlgorithm": {
+                                    "default": "sha256",
+                                    "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                     "type": "string"
                                   }
                                 },
@@ -2917,6 +3834,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -2965,6 +3886,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -2972,6 +3897,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -3000,6 +3929,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -3017,6 +3950,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -3071,7 +4008,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -3080,6 +4017,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -3195,6 +4137,10 @@
                             },
                             "type": "array"
                           },
+                          "name": {
+                            "description": "Name is the variable name.",
+                            "type": "string"
+                          },
                           "predicateType": {
                             "description": "Deprecated in favour of 'Type', to be removed soon",
                             "type": "string"
@@ -3254,6 +4200,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3302,6 +4252,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3309,6 +4263,10 @@
                                     },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
+                                      "type": "string"
+                                    },
+                                    "issuerRegExp": {
+                                      "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
@@ -3337,6 +4295,10 @@
                                     "subject": {
                                       "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
+                                    },
+                                    "subjectRegExp": {
+                                      "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                      "type": "string"
                                     }
                                   },
                                   "type": "object",
@@ -3354,6 +4316,10 @@
                                         },
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                           "type": "string"
                                         }
                                       },
@@ -3408,7 +4374,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                      "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                       "type": "string"
                                     }
                                   },
@@ -3417,6 +4383,11 @@
                                 },
                                 "repository": {
                                   "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                  "type": "string"
+                                },
+                                "signatureAlgorithm": {
+                                  "default": "sha256",
+                                  "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                   "type": "string"
                                 }
                               },
@@ -3430,6 +4401,14 @@
                         "additionalProperties": false
                       },
                       "type": "array"
+                    },
+                    "failureAction": {
+                      "description": "Allowed values are Audit or Enforce.",
+                      "enum": [
+                        "Audit",
+                        "Enforce"
+                      ],
+                      "type": "string"
                     },
                     "imageReferences": {
                       "description": "ImageReferences is a list of matching image reference patterns. At least one pattern in the\nlist must match the image for the rule to apply. Each image reference consists of a registry\naddress (defaults to docker.io), repository, image, and tag (defaults to latest).\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
@@ -3496,6 +4475,7 @@
                       "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
                       "enum": [
                         "Cosign",
+                        "SigstoreBundle",
                         "Notary"
                       ],
                       "type": "string"
@@ -3504,6 +4484,28 @@
                       "default": true,
                       "description": "UseCache enables caching of image verify responses for this rule",
                       "type": "boolean"
+                    },
+                    "validate": {
+                      "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                      "properties": {
+                        "deny": {
+                          "description": "Deny defines conditions used to pass or fail a validation rule.",
+                          "properties": {
+                            "conditions": {
+                              "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "message": {
+                          "description": "Message specifies a custom message to be displayed on failure.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "verifyDigest": {
                       "default": true,
@@ -3518,6 +4520,7 @@
               }
             },
             "required": [
+              "match",
               "name"
             ],
             "type": "object",
@@ -3535,7 +4538,7 @@
         },
         "validationFailureAction": {
           "default": "Audit",
-          "description": "ValidationFailureAction defines if a validation policy rule violation should block\nthe admission review request (enforce), or allow (audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are audit or enforce. The default value is \"Audit\".",
+          "description": "Deprecated, use validationFailureAction under the validate rule instead.",
           "enum": [
             "audit",
             "enforce",
@@ -3545,7 +4548,7 @@
           "type": "string"
         },
         "validationFailureActionOverrides": {
-          "description": "ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction\nnamespace-wise. It overrides ValidationFailureAction for the specified namespaces.",
+          "description": "Deprecated, use validationFailureActionOverrides under the validate rule instead.",
           "items": {
             "properties": {
               "action": {
@@ -3579,7 +4582,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -3589,7 +4593,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -3616,19 +4621,27 @@
           "type": "array"
         },
         "webhookConfiguration": {
-          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.\nRequires Kubernetes 1.27 or later.",
+          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.",
           "properties": {
+            "failurePolicy": {
+              "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+              "enum": [
+                "Ignore",
+                "Fail"
+              ],
+              "type": "string"
+            },
             "matchConditions": {
-              "description": "MatchCondition configures admission webhook matchConditions.",
+              "description": "MatchCondition configures admission webhook matchConditions.\nRequires Kubernetes 1.27 or later.",
               "items": {
                 "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
                 "properties": {
                   "expression": {
-                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                     "type": "string"
                   }
                 },
@@ -3640,13 +4653,18 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "timeoutSeconds": {
+              "description": "TimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+              "format": "int32",
+              "type": "integer"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "webhookTimeoutSeconds": {
-          "description": "WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+          "description": "Deprecated, use webhookTimeoutSeconds under webhookConfiguration instead.",
           "format": "int32",
           "type": "integer"
         }
@@ -3668,14 +4686,14 @@
                   "celPreconditions": {
                     "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
                     "items": {
-                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "description": "MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.",
                       "properties": {
                         "expression": {
-                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                           "type": "string"
                         }
                       },
@@ -3692,6 +4710,33 @@
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "configMap"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apiCall"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "imageRegistry"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "variable"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "globalReference"
+                          ]
+                        }
+                      ],
                       "properties": {
                         "apiCall": {
                           "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -3719,13 +4764,17 @@
                               },
                               "type": "array"
                             },
+                            "default": {
+                              "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                               "type": "string"
                             },
                             "method": {
                               "default": "GET",
-                              "description": "Method is the HTTP request type (GET or POST).",
+                              "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                               "enum": [
                                 "GET",
                                 "POST"
@@ -3738,6 +4787,28 @@
                                 "caBundle": {
                                   "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                   "type": "string"
+                                },
+                                "headers": {
+                                  "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the header key",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the header value",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
                                 },
                                 "url": {
                                   "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -3788,6 +4859,9 @@
                               "type": "string"
                             }
                           },
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -3866,6 +4940,9 @@
                           "additionalProperties": false
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -3873,6 +4950,12 @@
                   },
                   "exclude": {
                     "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
                     "properties": {
                       "all": {
                         "description": "All allows specifying resources which will be ANDed",
@@ -3888,6 +4971,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -3935,7 +5024,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3945,7 +5035,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4001,7 +5092,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4011,7 +5103,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4088,6 +5181,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -4135,7 +5234,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4145,7 +5245,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4201,7 +5302,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4211,7 +5313,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4283,6 +5386,12 @@
                       },
                       "resources": {
                         "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
                         "properties": {
                           "annotations": {
                             "additionalProperties": {
@@ -4330,7 +5439,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4340,7 +5450,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4396,7 +5507,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4406,7 +5518,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4524,7 +5637,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4534,7 +5648,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4556,678 +5671,125 @@
                         "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
-                      "kind": {
-                        "description": "Kind specifies resource kind.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name specifies the resource name.",
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "description": "Namespace specifies resource namespace.",
-                        "type": "string"
-                      },
-                      "orphanDownstreamOnPolicyDelete": {
-                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "synchronize": {
-                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "uid": {
-                        "description": "UID specifies the resource uid.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "imageExtractors": {
-                    "additionalProperties": {
-                      "items": {
-                        "properties": {
-                          "jmesPath": {
-                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                            "type": "string"
-                          },
-                          "key": {
-                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                            "type": "string"
-                          },
-                          "path": {
-                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                            "type": "string"
-                          },
-                          "value": {
-                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "path"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    },
-                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                    "type": "object"
-                  },
-                  "match": {
-                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                    "properties": {
-                      "all": {
-                        "description": "All allows specifying resources which will be ANDed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "any": {
-                        "description": "Any allows specifying resources which will be ORed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "clusterRoles": {
-                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "resources": {
-                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
-                        "properties": {
-                          "annotations": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                            "type": "object"
-                          },
-                          "kinds": {
-                            "description": "Kinds is a list of resource kinds.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "name": {
-                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                            "type": "string"
-                          },
-                          "names": {
-                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "namespaceSelector": {
-                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "namespaces": {
-                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "operations": {
-                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                            "items": {
-                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                              "enum": [
-                                "CREATE",
-                                "CONNECT",
-                                "UPDATE",
-                                "DELETE"
-                              ],
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "selector": {
-                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "roles": {
-                        "description": "Roles is the list of namespaced role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "subjects": {
-                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                        "items": {
-                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                          "properties": {
-                            "apiGroup": {
-                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                              "type": "string"
-                            },
-                            "kind": {
-                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "Name of the object being referenced.",
-                              "type": "string"
-                            },
-                            "namespace": {
-                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "kind",
-                            "name"
-                          ],
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "mutate": {
-                    "description": "Mutation is used to modify matching resources.",
-                    "properties": {
                       "foreach": {
-                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
+                            "apiVersion": {
+                              "description": "APIVersion specifies resource apiVersion.",
+                              "type": "string"
+                            },
+                            "clone": {
+                              "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies name of the resource.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "cloneList": {
+                              "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                              "properties": {
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5255,13 +5817,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5274,6 +5840,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5324,6 +5912,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5402,6 +5993,1087 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "data": {
+                              "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "kind": {
+                              "description": "Kind specifies resource kind.",
+                              "type": "string"
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name specifies the resource name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true,
+                              "additionalProperties": false
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "generateExisting": {
+                        "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind specifies resource kind.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name specifies the resource name.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies resource namespace.",
+                        "type": "string"
+                      },
+                      "orphanDownstreamOnPolicyDelete": {
+                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "synchronize": {
+                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "imageExtractors": {
+                    "additionalProperties": {
+                      "items": {
+                        "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                    "type": "object"
+                  },
+                  "match": {
+                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
+                    "properties": {
+                      "all": {
+                        "description": "All allows specifying resources which will be ANDed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "any": {
+                        "description": "Any allows specifying resources which will be ORed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "clusterRoles": {
+                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                            "type": "object"
+                          },
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                            "type": "string"
+                          },
+                          "names": {
+                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespaceSelector": {
+                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "roles": {
+                        "description": "Roles is the list of namespaced role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "subjects": {
+                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                        "items": {
+                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the object being referenced.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "mutate": {
+                    "description": "Mutation is used to modify matching resources.",
+                    "properties": {
+                      "foreach": {
+                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "properties": {
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5535,6 +7207,10 @@
                         },
                         "type": "array"
                       },
+                      "mutateExistingOnPolicyUpdate": {
+                        "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                        "type": "boolean"
+                      },
                       "patchStrategicMerge": {
                         "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                         "x-kubernetes-preserve-unknown-fields": true
@@ -5556,6 +7232,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5583,13 +7286,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5602,6 +7309,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5652,6 +7381,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5730,6 +7462,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5750,6 +7485,53 @@
                             "preconditions": {
                               "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                               "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "selector": {
+                              "description": "Selector allows you to select target resources with their labels.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "uid": {
                               "description": "UID specifies the resource uid.",
@@ -5774,6 +7556,13 @@
                     "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "reportProperties": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                    "type": "object"
+                  },
                   "skipBackgroundRequests": {
                     "default": true,
                     "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
@@ -5782,8 +7571,18 @@
                   "validate": {
                     "description": "Validation is used to validate matching resources.",
                     "properties": {
+                      "allowExistingViolations": {
+                        "default": true,
+                        "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                        "type": "boolean"
+                      },
                       "anyPattern": {
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "assert": {
+                        "description": "Assert defines a kyverno-json assertion tree.",
+                        "type": "object",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
                       "cel": {
@@ -5795,11 +7594,11 @@
                               "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                               "properties": {
                                 "key": {
-                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                                   "type": "string"
                                 },
                                 "valueExpression": {
-                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                                   "type": "string"
                                 }
                               },
@@ -5818,7 +7617,7 @@
                               "description": "Validation specifies the CEL expression which is used to apply the validation.",
                               "properties": {
                                 "expression": {
-                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                                   "type": "string"
                                 },
                                 "message": {
@@ -5862,19 +7661,19 @@
                             "description": "ParamRef references a parameter resource.",
                             "properties": {
                               "name": {
-                                "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                                "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                                 "type": "string"
                               },
                               "parameterNotFoundAction": {
-                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                                 "type": "string"
                               },
                               "selector": {
-                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                                 "properties": {
                                   "matchExpressions": {
                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5894,7 +7693,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -5904,7 +7704,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -5926,7 +7727,7 @@
                           "variables": {
                             "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                             "items": {
-                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                               "properties": {
                                 "expression": {
                                   "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -5942,6 +7743,7 @@
                                 "name"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "type": "array"
@@ -5961,6 +7763,87 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "failureAction": {
+                        "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                        "enum": [
+                          "Audit",
+                          "Enforce"
+                        ],
+                        "type": "string"
+                      },
+                      "failureActionOverrides": {
+                        "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "description": "ValidationFailureAction defines the policy validation failure action",
+                              "enum": [
+                                "audit",
+                                "enforce",
+                                "Audit",
+                                "Enforce"
+                              ],
+                              "type": "string"
+                            },
+                            "namespaceSelector": {
+                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
@@ -5974,6 +7857,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -6001,13 +7911,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -6020,6 +7934,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -6070,6 +8006,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -6148,6 +8087,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -6336,6 +8278,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6384,6 +8330,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6391,6 +8341,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -6419,6 +8373,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -6436,6 +8394,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -6490,7 +8452,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -6499,6 +8461,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -6742,6 +8709,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -6790,6 +8761,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -6797,6 +8772,10 @@
                                               },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
+                                                "type": "string"
+                                              },
+                                              "issuerRegExp": {
+                                                "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
@@ -6825,6 +8804,10 @@
                                               "subject": {
                                                 "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
+                                              },
+                                              "subjectRegExp": {
+                                                "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6842,6 +8825,10 @@
                                                   },
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -6896,7 +8883,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                                "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                                 "type": "string"
                                               }
                                             },
@@ -6905,6 +8892,11 @@
                                           },
                                           "repository": {
                                             "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                            "type": "string"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -7020,6 +9012,10 @@
                                 },
                                 "type": "array"
                               },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
                               "predicateType": {
                                 "description": "Deprecated in favour of 'Type', to be removed soon",
                                 "type": "string"
@@ -7079,6 +9075,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7127,6 +9127,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7134,6 +9138,10 @@
                                         },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
+                                          "type": "string"
+                                        },
+                                        "issuerRegExp": {
+                                          "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
@@ -7162,6 +9170,10 @@
                                         "subject": {
                                           "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
+                                        },
+                                        "subjectRegExp": {
+                                          "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -7179,6 +9191,10 @@
                                             },
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                               "type": "string"
                                             }
                                           },
@@ -7233,7 +9249,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                          "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                           "type": "string"
                                         }
                                       },
@@ -7242,6 +9258,11 @@
                                     },
                                     "repository": {
                                       "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                      "type": "string"
+                                    },
+                                    "signatureAlgorithm": {
+                                      "default": "sha256",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -7255,6 +9276,18 @@
                             "additionalProperties": false
                           },
                           "type": "array"
+                        },
+                        "cosignOCI11": {
+                          "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "failureAction": {
+                          "description": "Allowed values are Audit or Enforce.",
+                          "enum": [
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
                         },
                         "image": {
                           "description": "Deprecated. Use ImageReferences instead.",
@@ -7338,9 +9371,10 @@
                           "type": "string"
                         },
                         "type": {
-                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
                           "enum": [
                             "Cosign",
+                            "SigstoreBundle",
                             "Notary"
                           ],
                           "type": "string"
@@ -7349,6 +9383,28 @@
                           "default": true,
                           "description": "UseCache enables caching of image verify responses for this rule.",
                           "type": "boolean"
+                        },
+                        "validate": {
+                          "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                          "properties": {
+                            "deny": {
+                              "description": "Deny defines conditions used to pass or fail a validation rule.",
+                              "properties": {
+                                "conditions": {
+                                  "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "message": {
+                              "description": "Message specifies a custom message to be displayed on failure.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "verifyDigest": {
                           "default": true,
@@ -7363,6 +9419,7 @@
                   }
                 },
                 "required": [
+                  "match",
                   "name"
                 ],
                 "type": "object",
@@ -7376,7 +9433,7 @@
         },
         "conditions": {
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -7411,7 +9468,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"
@@ -7482,9 +9539,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "ready"
-      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/kyverno.io/clusterpolicyreport_v1alpha2.json
+++ b/kyverno.io/clusterpolicyreport_v1alpha2.json
@@ -57,7 +57,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -67,7 +68,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "matchLabels": {
                 "additionalProperties": {
@@ -84,14 +86,14 @@
           "resources": {
             "description": "Subjects is an optional reference to the checked Kubernetes resources",
             "items": {
-              "description": "ObjectReference contains enough information to let you inspect or modify the referred object.\n---\nNew uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.\n 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.\n 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular\n    restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".\n    Those cannot be well described when embedded.\n 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.\n 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity\n    during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple\n    and the version of the actual struct is irrelevant.\n 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type\n    will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.\n\n\nInstead of using this type, create a locally provided and used type that is well-focused on your reference.\nFor example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+              "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
               "properties": {
                 "apiVersion": {
                   "description": "API version of the referent.",
                   "type": "string"
                 },
                 "fieldPath": {
-                  "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+                  "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
                   "type": "string"
                 },
                 "kind": {
@@ -194,7 +196,7 @@
           "type": "string"
         },
         "fieldPath": {
-          "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+          "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
           "type": "string"
         },
         "kind": {
@@ -243,7 +245,8 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               }
             },
             "required": [
@@ -253,7 +256,8 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "matchLabels": {
           "additionalProperties": {

--- a/kyverno.io/ephemeralreport_v1.json
+++ b/kyverno.io/ephemeralreport_v1.json
@@ -1,0 +1,270 @@
+{
+  "description": "EphemeralReport is the Schema for the EphemeralReports API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "owner": {
+          "description": "Owner is a reference to the report owner (e.g. a Deployment, Namespace, or Node)",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "blockOwnerDeletion": {
+              "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then\nthe owner cannot be deleted from the key-value store until this\nreference is removed.\nSee https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion\nfor how the garbage collector interacts with this field and enforces the foreground deletion.\nDefaults to false.\nTo set this field, a user needs \"delete\" permission of the owner,\notherwise 422 (Unprocessable Entity) will be returned.",
+              "type": "boolean"
+            },
+            "controller": {
+              "description": "If true, this reference points to the managing controller.",
+              "type": "boolean"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiVersion",
+            "kind",
+            "name",
+            "uid"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "results": {
+          "description": "PolicyReportResult provides result details",
+          "items": {
+            "description": "PolicyReportResult provides the result for an individual policy",
+            "properties": {
+              "category": {
+                "description": "Category indicates policy category",
+                "type": "string"
+              },
+              "message": {
+                "description": "Description is a short user friendly message for the policy rule",
+                "type": "string"
+              },
+              "policy": {
+                "description": "Policy is the name or identifier of the policy",
+                "type": "string"
+              },
+              "properties": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Properties provides additional information for the policy rule",
+                "type": "object"
+              },
+              "resourceSelector": {
+                "description": "SubjectSelector is an optional label selector for checked Kubernetes resources.\nFor example, a policy result may apply to all pods that match a label.\nEither a Subject or a SubjectSelector can be specified.\nIf neither are provided, the result is assumed to be for the policy report scope.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "resources": {
+                "description": "Subjects is an optional reference to the checked Kubernetes resources",
+                "items": {
+                  "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "result": {
+                "description": "Result indicates the outcome of the policy rule execution",
+                "enum": [
+                  "pass",
+                  "fail",
+                  "warn",
+                  "error",
+                  "skip"
+                ],
+                "type": "string"
+              },
+              "rule": {
+                "description": "Rule is the name or identifier of the rule within the policy",
+                "type": "string"
+              },
+              "scored": {
+                "description": "Scored indicates if this result is scored",
+                "type": "boolean"
+              },
+              "severity": {
+                "description": "Severity indicates policy check result criticality",
+                "enum": [
+                  "critical",
+                  "high",
+                  "low",
+                  "medium",
+                  "info"
+                ],
+                "type": "string"
+              },
+              "source": {
+                "description": "Source is an identifier for the policy engine that manages this report",
+                "type": "string"
+              },
+              "timestamp": {
+                "description": "Timestamp indicates the time the result was found",
+                "properties": {
+                  "nanos": {
+                    "description": "Non-negative fractions of a second at nanosecond resolution. Negative\nsecond values with fractions must still have non-negative nanos values\nthat count forward in time. Must be from 0 to 999,999,999\ninclusive. This field may be limited in precision depending on context.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "seconds": {
+                    "description": "Represents seconds of UTC time since Unix epoch\n1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to\n9999-12-31T23:59:59Z inclusive.",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "nanos",
+                  "seconds"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "additionalProperties": false
+            },
+            "required": [
+              "policy"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "summary": {
+          "description": "PolicyReportSummary provides a summary of results",
+          "properties": {
+            "error": {
+              "description": "Error provides the count of policies that could not be evaluated",
+              "type": "integer"
+            },
+            "fail": {
+              "description": "Fail provides the count of policies whose requirements were not met",
+              "type": "integer"
+            },
+            "pass": {
+              "description": "Pass provides the count of policies whose requirements were met",
+              "type": "integer"
+            },
+            "skip": {
+              "description": "Skip indicates the count of policies that were not selected for evaluation",
+              "type": "integer"
+            },
+            "warn": {
+              "description": "Warn provides the count of non-scored policies whose requirements were not met",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "owner"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/globalcontextentry_v2alpha1.json
+++ b/kyverno.io/globalcontextentry_v2alpha1.json
@@ -1,0 +1,232 @@
+{
+  "description": "GlobalContextEntry declares resources to be cached.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy exception behaviors.",
+      "oneOf": [
+        {
+          "required": [
+            "kubernetesResource"
+          ]
+        },
+        {
+          "required": [
+            "apiCall"
+          ]
+        }
+      ],
+      "properties": {
+        "apiCall": {
+          "description": "Stores results from an API call which will be cached.\nMutually exclusive with KubernetesResource.\nThis can be used to make calls to external (non-Kubernetes API server) services.\nIt can also be used to make calls to the Kubernetes API server in such cases:\n1. A POST is needed to create a resource.\n2. Finer-grained control is needed. Example: To restrict the number of resources cached.",
+          "properties": {
+            "data": {
+              "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+              "items": {
+                "description": "RequestData contains the HTTP POST data",
+                "properties": {
+                  "key": {
+                    "description": "Key is a unique identifier for the data value",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the data value",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "method": {
+              "default": "GET",
+              "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+              "enum": [
+                "GET",
+                "POST"
+              ],
+              "type": "string"
+            },
+            "refreshInterval": {
+              "default": "10m",
+              "description": "RefreshInterval defines the interval in duration at which to poll the APICall.\nThe duration is a sequence of decimal numbers, each with optional fraction and a unit suffix,\nsuch as \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"\u00b5s\"), \"ms\", \"s\", \"m\", \"h\".",
+              "format": "duration",
+              "type": "string"
+            },
+            "retryLimit": {
+              "default": 3,
+              "description": "RetryLimit defines the number of times the APICall should be retried in case of failure.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "service": {
+              "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+              "properties": {
+                "caBundle": {
+                  "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                  "type": "string"
+                },
+                "headers": {
+                  "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "description": "Key is the header key",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is the header value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "url": {
+                  "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "urlPath": {
+              "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubernetesResource": {
+          "description": "Stores a list of Kubernetes resources which will be cached.\nMutually exclusive with APICall.",
+          "properties": {
+            "group": {
+              "description": "Group defines the group of the resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace defines the namespace of the resource. Leave empty for cluster scoped resources.\nIf left empty for namespaced resources, all resources from all namespaces will be cached.",
+              "type": "string"
+            },
+            "resource": {
+              "description": "Resource defines the type of the resource.\nRequires the pluralized form of the resource kind in lowercase. (Ex., \"deployments\")",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version defines the version of the resource.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "resource",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status contains globalcontextentry runtime data.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastRefreshTime": {
+          "description": "Indicates the time when the globalcontextentry was last refreshed successfully for the API Call",
+          "format": "date-time",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Deprecated in favor of Conditions",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/policy_v1.json
+++ b/kyverno.io/policy_v1.json
@@ -33,8 +33,13 @@
           "description": "Background controls if rules are applied to existing resources during a background scan.\nOptional. Default value is \"true\". The value must be set to \"false\" if the policy rule\nuses variables that are only available in the admission review request (e.g. user name).",
           "type": "boolean"
         },
+        "emitWarning": {
+          "default": false,
+          "description": "EmitWarning enables API response warnings for mutate policy rules or validate policy rules with validationFailureAction set to Audit.\nEnabling this option will extend admission request processing times. The default value is \"false\".",
+          "type": "boolean"
+        },
         "failurePolicy": {
-          "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+          "description": "Deprecated, use failurePolicy under the webhookConfiguration instead.",
           "enum": [
             "Ignore",
             "Fail"
@@ -42,7 +47,7 @@
           "type": "string"
         },
         "generateExisting": {
-          "description": "GenerateExisting controls whether to trigger generate rule in existing resources\nIf is set to \"true\" generate rule will be triggered and applied to existing matched resources.\nDefaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting under the generate rule instead",
           "type": "boolean"
         },
         "generateExistingOnPolicyUpdate": {
@@ -50,7 +55,7 @@
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
-          "description": "MutateExistingOnPolicyUpdate controls if a mutateExisting policy is applied on policy events.\nDefault value is \"false\".",
+          "description": "Deprecated, use mutateExistingOnPolicyUpdate under the mutate rule instead",
           "type": "boolean"
         },
         "rules": {
@@ -61,14 +66,14 @@
               "celPreconditions": {
                 "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
                 "items": {
-                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "description": "MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.",
                   "properties": {
                     "expression": {
-                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                       "type": "string"
                     }
                   },
@@ -85,6 +90,33 @@
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                  "oneOf": [
+                    {
+                      "required": [
+                        "configMap"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apiCall"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "imageRegistry"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "variable"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "globalReference"
+                      ]
+                    }
+                  ],
                   "properties": {
                     "apiCall": {
                       "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -112,13 +144,17 @@
                           },
                           "type": "array"
                         },
+                        "default": {
+                          "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                           "type": "string"
                         },
                         "method": {
                           "default": "GET",
-                          "description": "Method is the HTTP request type (GET or POST).",
+                          "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                           "enum": [
                             "GET",
                             "POST"
@@ -131,6 +167,28 @@
                             "caBundle": {
                               "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                               "type": "string"
+                            },
+                            "headers": {
+                              "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the header key",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the header value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "url": {
                               "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -181,6 +239,9 @@
                           "type": "string"
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -259,6 +320,9 @@
                       "additionalProperties": false
                     }
                   },
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -266,6 +330,12 @@
               },
               "exclude": {
                 "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
                 "properties": {
                   "all": {
                     "description": "All allows specifying resources which will be ANDed",
@@ -281,6 +351,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -328,7 +404,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -338,7 +415,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -394,7 +472,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -404,7 +483,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -481,6 +561,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -528,7 +614,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -538,7 +625,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -594,7 +682,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -604,7 +693,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -676,6 +766,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -723,7 +819,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -733,7 +830,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -789,7 +887,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -799,7 +898,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -917,7 +1017,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -927,7 +1028,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -949,678 +1051,125 @@
                     "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "kind": {
-                    "description": "Kind specifies resource kind.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "Name specifies the resource name.",
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "description": "Namespace specifies resource namespace.",
-                    "type": "string"
-                  },
-                  "orphanDownstreamOnPolicyDelete": {
-                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "synchronize": {
-                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "uid": {
-                    "description": "UID specifies the resource uid.",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "imageExtractors": {
-                "additionalProperties": {
-                  "items": {
-                    "properties": {
-                      "jmesPath": {
-                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                        "type": "string"
-                      },
-                      "key": {
-                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                        "type": "string"
-                      },
-                      "path": {
-                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "path"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                "type": "object"
-              },
-              "match": {
-                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                "properties": {
-                  "all": {
-                    "description": "All allows specifying resources which will be ANDed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "any": {
-                    "description": "Any allows specifying resources which will be ORed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "clusterRoles": {
-                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "resources": {
-                    "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
-                    "properties": {
-                      "annotations": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                        "type": "object"
-                      },
-                      "kinds": {
-                        "description": "Kinds is a list of resource kinds.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "name": {
-                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                        "type": "string"
-                      },
-                      "names": {
-                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "namespaceSelector": {
-                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "namespaces": {
-                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "operations": {
-                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                        "items": {
-                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                          "enum": [
-                            "CREATE",
-                            "CONNECT",
-                            "UPDATE",
-                            "DELETE"
-                          ],
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "selector": {
-                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "roles": {
-                    "description": "Roles is the list of namespaced role names for the user.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "subjects": {
-                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                    "items": {
-                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                      "properties": {
-                        "apiGroup": {
-                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                          "type": "string"
-                        },
-                        "kind": {
-                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Name of the object being referenced.",
-                          "type": "string"
-                        },
-                        "namespace": {
-                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "kind",
-                        "name"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "mutate": {
-                "description": "Mutation is used to modify matching resources.",
-                "properties": {
                   "foreach": {
-                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion specifies resource apiVersion.",
+                          "type": "string"
+                        },
+                        "clone": {
+                          "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "properties": {
+                            "name": {
+                              "description": "Name specifies name of the resource.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "cloneList": {
+                          "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                          "properties": {
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1648,13 +1197,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1667,6 +1220,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -1717,6 +1292,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1795,6 +1373,1087 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "data": {
+                          "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "kind": {
+                          "description": "Kind specifies resource kind.",
+                          "type": "string"
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name specifies the resource name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true,
+                          "additionalProperties": false
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "generateExisting": {
+                    "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind specifies resource kind.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name specifies the resource name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace specifies resource namespace.",
+                    "type": "string"
+                  },
+                  "orphanDownstreamOnPolicyDelete": {
+                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "synchronize": {
+                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageExtractors": {
+                "additionalProperties": {
+                  "items": {
+                    "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                "type": "object"
+              },
+              "match": {
+                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
+                "properties": {
+                  "all": {
+                    "description": "All allows specifying resources which will be ANDed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "any": {
+                    "description": "Any allows specifying resources which will be ORed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "mutate": {
+                "description": "Mutation is used to modify matching resources.",
+                "properties": {
+                  "foreach": {
+                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "properties": {
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1928,6 +2587,10 @@
                     },
                     "type": "array"
                   },
+                  "mutateExistingOnPolicyUpdate": {
+                    "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                    "type": "boolean"
+                  },
                   "patchStrategicMerge": {
                     "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                     "x-kubernetes-preserve-unknown-fields": true
@@ -1949,6 +2612,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1976,13 +2666,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1995,6 +2689,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -2045,6 +2761,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2123,6 +2842,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2143,6 +2865,53 @@
                         "preconditions": {
                           "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "selector": {
+                          "description": "Selector allows you to select target resources with their labels.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
                         },
                         "uid": {
                           "description": "UID specifies the resource uid.",
@@ -2167,6 +2936,13 @@
                 "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                 "x-kubernetes-preserve-unknown-fields": true
               },
+              "reportProperties": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                "type": "object"
+              },
               "skipBackgroundRequests": {
                 "default": true,
                 "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
@@ -2175,8 +2951,18 @@
               "validate": {
                 "description": "Validation is used to validate matching resources.",
                 "properties": {
+                  "allowExistingViolations": {
+                    "default": true,
+                    "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                    "type": "boolean"
+                  },
                   "anyPattern": {
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "assert": {
+                    "description": "Assert defines a kyverno-json assertion tree.",
+                    "type": "object",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "cel": {
@@ -2188,11 +2974,11 @@
                           "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                           "properties": {
                             "key": {
-                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                               "type": "string"
                             },
                             "valueExpression": {
-                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                               "type": "string"
                             }
                           },
@@ -2211,7 +2997,7 @@
                           "description": "Validation specifies the CEL expression which is used to apply the validation.",
                           "properties": {
                             "expression": {
-                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                               "type": "string"
                             },
                             "message": {
@@ -2255,19 +3041,19 @@
                         "description": "ParamRef references a parameter resource.",
                         "properties": {
                           "name": {
-                            "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                            "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                             "type": "string"
                           },
                           "parameterNotFoundAction": {
-                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                             "properties": {
                               "matchExpressions": {
                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -2287,7 +3073,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2297,7 +3084,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2319,7 +3107,7 @@
                       "variables": {
                         "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                         "items": {
-                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                           "properties": {
                             "expression": {
                               "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -2335,6 +3123,7 @@
                             "name"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "type": "array"
@@ -2354,6 +3143,87 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "failureAction": {
+                    "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                    "enum": [
+                      "Audit",
+                      "Enforce"
+                    ],
+                    "type": "string"
+                  },
+                  "failureActionOverrides": {
+                    "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                    "items": {
+                      "properties": {
+                        "action": {
+                          "description": "ValidationFailureAction defines the policy validation failure action",
+                          "enum": [
+                            "audit",
+                            "enforce",
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
+                        },
+                        "namespaceSelector": {
+                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
@@ -2367,6 +3237,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -2394,13 +3291,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -2413,6 +3314,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -2463,6 +3386,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2541,6 +3467,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2729,6 +3658,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2777,6 +3710,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2784,6 +3721,10 @@
                                       },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
+                                        "type": "string"
+                                      },
+                                      "issuerRegExp": {
+                                        "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
@@ -2812,6 +3753,10 @@
                                       "subject": {
                                         "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
+                                      },
+                                      "subjectRegExp": {
+                                        "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -2829,6 +3774,10 @@
                                           },
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                             "type": "string"
                                           }
                                         },
@@ -2883,7 +3832,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                        "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                         "type": "string"
                                       }
                                     },
@@ -2892,6 +3841,11 @@
                                   },
                                   "repository": {
                                     "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                    "type": "string"
+                                  },
+                                  "signatureAlgorithm": {
+                                    "default": "sha256",
+                                    "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                     "type": "string"
                                   }
                                 },
@@ -3135,6 +4089,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -3183,6 +4141,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -3190,6 +4152,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -3218,6 +4184,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -3235,6 +4205,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -3289,7 +4263,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -3298,6 +4272,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -3413,6 +4392,10 @@
                             },
                             "type": "array"
                           },
+                          "name": {
+                            "description": "Name is the variable name.",
+                            "type": "string"
+                          },
                           "predicateType": {
                             "description": "Deprecated in favour of 'Type', to be removed soon",
                             "type": "string"
@@ -3472,6 +4455,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3520,6 +4507,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3527,6 +4518,10 @@
                                     },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
+                                      "type": "string"
+                                    },
+                                    "issuerRegExp": {
+                                      "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
@@ -3555,6 +4550,10 @@
                                     "subject": {
                                       "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
+                                    },
+                                    "subjectRegExp": {
+                                      "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                      "type": "string"
                                     }
                                   },
                                   "type": "object",
@@ -3572,6 +4571,10 @@
                                         },
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                           "type": "string"
                                         }
                                       },
@@ -3626,7 +4629,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                      "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                       "type": "string"
                                     }
                                   },
@@ -3635,6 +4638,11 @@
                                 },
                                 "repository": {
                                   "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                  "type": "string"
+                                },
+                                "signatureAlgorithm": {
+                                  "default": "sha256",
+                                  "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                   "type": "string"
                                 }
                               },
@@ -3648,6 +4656,18 @@
                         "additionalProperties": false
                       },
                       "type": "array"
+                    },
+                    "cosignOCI11": {
+                      "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "failureAction": {
+                      "description": "Allowed values are Audit or Enforce.",
+                      "enum": [
+                        "Audit",
+                        "Enforce"
+                      ],
+                      "type": "string"
                     },
                     "image": {
                       "description": "Deprecated. Use ImageReferences instead.",
@@ -3731,9 +4751,10 @@
                       "type": "string"
                     },
                     "type": {
-                      "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
+                      "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
                       "enum": [
                         "Cosign",
+                        "SigstoreBundle",
                         "Notary"
                       ],
                       "type": "string"
@@ -3742,6 +4763,28 @@
                       "default": true,
                       "description": "UseCache enables caching of image verify responses for this rule.",
                       "type": "boolean"
+                    },
+                    "validate": {
+                      "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                      "properties": {
+                        "deny": {
+                          "description": "Deny defines conditions used to pass or fail a validation rule.",
+                          "properties": {
+                            "conditions": {
+                              "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "message": {
+                          "description": "Message specifies a custom message to be displayed on failure.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "verifyDigest": {
                       "default": true,
@@ -3756,6 +4799,7 @@
               }
             },
             "required": [
+              "match",
               "name"
             ],
             "type": "object",
@@ -3773,7 +4817,7 @@
         },
         "validationFailureAction": {
           "default": "Audit",
-          "description": "ValidationFailureAction defines if a validation policy rule violation should block\nthe admission review request (enforce), or allow (audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are audit or enforce. The default value is \"Audit\".",
+          "description": "Deprecated, use validationFailureAction under the validate rule instead.",
           "enum": [
             "audit",
             "enforce",
@@ -3783,7 +4827,7 @@
           "type": "string"
         },
         "validationFailureActionOverrides": {
-          "description": "ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction\nnamespace-wise. It overrides ValidationFailureAction for the specified namespaces.",
+          "description": "Deprecated, use validationFailureActionOverrides under the validate rule instead.",
           "items": {
             "properties": {
               "action": {
@@ -3817,7 +4861,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -3827,7 +4872,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -3854,19 +4900,27 @@
           "type": "array"
         },
         "webhookConfiguration": {
-          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.\nRequires Kubernetes 1.27 or later.",
+          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.",
           "properties": {
+            "failurePolicy": {
+              "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+              "enum": [
+                "Ignore",
+                "Fail"
+              ],
+              "type": "string"
+            },
             "matchConditions": {
-              "description": "MatchCondition configures admission webhook matchConditions.",
+              "description": "MatchCondition configures admission webhook matchConditions.\nRequires Kubernetes 1.27 or later.",
               "items": {
                 "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
                 "properties": {
                   "expression": {
-                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                     "type": "string"
                   }
                 },
@@ -3878,13 +4932,18 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "timeoutSeconds": {
+              "description": "TimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+              "format": "int32",
+              "type": "integer"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "webhookTimeoutSeconds": {
-          "description": "WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+          "description": "Deprecated, use webhookTimeoutSeconds under webhookConfiguration instead.",
           "format": "int32",
           "type": "integer"
         }
@@ -3906,14 +4965,14 @@
                   "celPreconditions": {
                     "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
                     "items": {
-                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "description": "MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.",
                       "properties": {
                         "expression": {
-                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                           "type": "string"
                         }
                       },
@@ -3930,6 +4989,33 @@
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "configMap"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apiCall"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "imageRegistry"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "variable"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "globalReference"
+                          ]
+                        }
+                      ],
                       "properties": {
                         "apiCall": {
                           "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -3957,13 +5043,17 @@
                               },
                               "type": "array"
                             },
+                            "default": {
+                              "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                               "type": "string"
                             },
                             "method": {
                               "default": "GET",
-                              "description": "Method is the HTTP request type (GET or POST).",
+                              "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                               "enum": [
                                 "GET",
                                 "POST"
@@ -3976,6 +5066,28 @@
                                 "caBundle": {
                                   "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                   "type": "string"
+                                },
+                                "headers": {
+                                  "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the header key",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the header value",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
                                 },
                                 "url": {
                                   "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -4026,6 +5138,9 @@
                               "type": "string"
                             }
                           },
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -4104,6 +5219,9 @@
                           "additionalProperties": false
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -4111,6 +5229,12 @@
                   },
                   "exclude": {
                     "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
                     "properties": {
                       "all": {
                         "description": "All allows specifying resources which will be ANDed",
@@ -4126,6 +5250,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -4173,7 +5303,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4183,7 +5314,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4239,7 +5371,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4249,7 +5382,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4326,6 +5460,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -4373,7 +5513,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4383,7 +5524,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4439,7 +5581,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4449,7 +5592,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4521,6 +5665,12 @@
                       },
                       "resources": {
                         "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
                         "properties": {
                           "annotations": {
                             "additionalProperties": {
@@ -4568,7 +5718,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4578,7 +5729,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4634,7 +5786,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4644,7 +5797,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4762,7 +5916,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4772,7 +5927,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4794,678 +5950,125 @@
                         "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
-                      "kind": {
-                        "description": "Kind specifies resource kind.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name specifies the resource name.",
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "description": "Namespace specifies resource namespace.",
-                        "type": "string"
-                      },
-                      "orphanDownstreamOnPolicyDelete": {
-                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "synchronize": {
-                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "uid": {
-                        "description": "UID specifies the resource uid.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "imageExtractors": {
-                    "additionalProperties": {
-                      "items": {
-                        "properties": {
-                          "jmesPath": {
-                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                            "type": "string"
-                          },
-                          "key": {
-                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                            "type": "string"
-                          },
-                          "path": {
-                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                            "type": "string"
-                          },
-                          "value": {
-                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "path"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    },
-                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                    "type": "object"
-                  },
-                  "match": {
-                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                    "properties": {
-                      "all": {
-                        "description": "All allows specifying resources which will be ANDed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "any": {
-                        "description": "Any allows specifying resources which will be ORed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "clusterRoles": {
-                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "resources": {
-                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
-                        "properties": {
-                          "annotations": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                            "type": "object"
-                          },
-                          "kinds": {
-                            "description": "Kinds is a list of resource kinds.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "name": {
-                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                            "type": "string"
-                          },
-                          "names": {
-                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "namespaceSelector": {
-                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "namespaces": {
-                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "operations": {
-                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                            "items": {
-                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                              "enum": [
-                                "CREATE",
-                                "CONNECT",
-                                "UPDATE",
-                                "DELETE"
-                              ],
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "selector": {
-                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "roles": {
-                        "description": "Roles is the list of namespaced role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "subjects": {
-                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                        "items": {
-                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                          "properties": {
-                            "apiGroup": {
-                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                              "type": "string"
-                            },
-                            "kind": {
-                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "Name of the object being referenced.",
-                              "type": "string"
-                            },
-                            "namespace": {
-                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "kind",
-                            "name"
-                          ],
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "mutate": {
-                    "description": "Mutation is used to modify matching resources.",
-                    "properties": {
                       "foreach": {
-                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
+                            "apiVersion": {
+                              "description": "APIVersion specifies resource apiVersion.",
+                              "type": "string"
+                            },
+                            "clone": {
+                              "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies name of the resource.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "cloneList": {
+                              "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                              "properties": {
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5493,13 +6096,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5512,6 +6119,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5562,6 +6191,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5640,6 +6272,1087 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "data": {
+                              "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "kind": {
+                              "description": "Kind specifies resource kind.",
+                              "type": "string"
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name specifies the resource name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true,
+                              "additionalProperties": false
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "generateExisting": {
+                        "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind specifies resource kind.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name specifies the resource name.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies resource namespace.",
+                        "type": "string"
+                      },
+                      "orphanDownstreamOnPolicyDelete": {
+                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "synchronize": {
+                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "imageExtractors": {
+                    "additionalProperties": {
+                      "items": {
+                        "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                    "type": "object"
+                  },
+                  "match": {
+                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
+                    "properties": {
+                      "all": {
+                        "description": "All allows specifying resources which will be ANDed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "any": {
+                        "description": "Any allows specifying resources which will be ORed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "clusterRoles": {
+                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                            "type": "object"
+                          },
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                            "type": "string"
+                          },
+                          "names": {
+                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespaceSelector": {
+                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "roles": {
+                        "description": "Roles is the list of namespaced role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "subjects": {
+                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                        "items": {
+                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the object being referenced.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "mutate": {
+                    "description": "Mutation is used to modify matching resources.",
+                    "properties": {
+                      "foreach": {
+                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "properties": {
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5773,6 +7486,10 @@
                         },
                         "type": "array"
                       },
+                      "mutateExistingOnPolicyUpdate": {
+                        "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                        "type": "boolean"
+                      },
                       "patchStrategicMerge": {
                         "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                         "x-kubernetes-preserve-unknown-fields": true
@@ -5794,6 +7511,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5821,13 +7565,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5840,6 +7588,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5890,6 +7660,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5968,6 +7741,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5988,6 +7764,53 @@
                             "preconditions": {
                               "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                               "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "selector": {
+                              "description": "Selector allows you to select target resources with their labels.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "uid": {
                               "description": "UID specifies the resource uid.",
@@ -6012,6 +7835,13 @@
                     "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "reportProperties": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                    "type": "object"
+                  },
                   "skipBackgroundRequests": {
                     "default": true,
                     "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
@@ -6020,8 +7850,18 @@
                   "validate": {
                     "description": "Validation is used to validate matching resources.",
                     "properties": {
+                      "allowExistingViolations": {
+                        "default": true,
+                        "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                        "type": "boolean"
+                      },
                       "anyPattern": {
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "assert": {
+                        "description": "Assert defines a kyverno-json assertion tree.",
+                        "type": "object",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
                       "cel": {
@@ -6033,11 +7873,11 @@
                               "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                               "properties": {
                                 "key": {
-                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                                   "type": "string"
                                 },
                                 "valueExpression": {
-                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                                   "type": "string"
                                 }
                               },
@@ -6056,7 +7896,7 @@
                               "description": "Validation specifies the CEL expression which is used to apply the validation.",
                               "properties": {
                                 "expression": {
-                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                                   "type": "string"
                                 },
                                 "message": {
@@ -6100,19 +7940,19 @@
                             "description": "ParamRef references a parameter resource.",
                             "properties": {
                               "name": {
-                                "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                                "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                                 "type": "string"
                               },
                               "parameterNotFoundAction": {
-                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                                 "type": "string"
                               },
                               "selector": {
-                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                                 "properties": {
                                   "matchExpressions": {
                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -6132,7 +7972,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -6142,7 +7983,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -6164,7 +8006,7 @@
                           "variables": {
                             "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                             "items": {
-                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                               "properties": {
                                 "expression": {
                                   "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -6180,6 +8022,7 @@
                                 "name"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "type": "array"
@@ -6199,6 +8042,87 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "failureAction": {
+                        "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                        "enum": [
+                          "Audit",
+                          "Enforce"
+                        ],
+                        "type": "string"
+                      },
+                      "failureActionOverrides": {
+                        "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "description": "ValidationFailureAction defines the policy validation failure action",
+                              "enum": [
+                                "audit",
+                                "enforce",
+                                "Audit",
+                                "Enforce"
+                              ],
+                              "type": "string"
+                            },
+                            "namespaceSelector": {
+                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
@@ -6212,6 +8136,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -6239,13 +8190,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -6258,6 +8213,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -6308,6 +8285,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -6386,6 +8366,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -6574,6 +8557,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6622,6 +8609,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6629,6 +8620,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -6657,6 +8652,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -6674,6 +8673,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -6728,7 +8731,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -6737,6 +8740,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -6980,6 +8988,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -7028,6 +9040,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -7035,6 +9051,10 @@
                                               },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
+                                                "type": "string"
+                                              },
+                                              "issuerRegExp": {
+                                                "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
@@ -7063,6 +9083,10 @@
                                               "subject": {
                                                 "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
+                                              },
+                                              "subjectRegExp": {
+                                                "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -7080,6 +9104,10 @@
                                                   },
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -7134,7 +9162,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                                "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                                 "type": "string"
                                               }
                                             },
@@ -7143,6 +9171,11 @@
                                           },
                                           "repository": {
                                             "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                            "type": "string"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -7258,6 +9291,10 @@
                                 },
                                 "type": "array"
                               },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
                               "predicateType": {
                                 "description": "Deprecated in favour of 'Type', to be removed soon",
                                 "type": "string"
@@ -7317,6 +9354,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7365,6 +9406,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7372,6 +9417,10 @@
                                         },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
+                                          "type": "string"
+                                        },
+                                        "issuerRegExp": {
+                                          "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
@@ -7400,6 +9449,10 @@
                                         "subject": {
                                           "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
+                                        },
+                                        "subjectRegExp": {
+                                          "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -7417,6 +9470,10 @@
                                             },
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                               "type": "string"
                                             }
                                           },
@@ -7471,7 +9528,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                          "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                           "type": "string"
                                         }
                                       },
@@ -7480,6 +9537,11 @@
                                     },
                                     "repository": {
                                       "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                      "type": "string"
+                                    },
+                                    "signatureAlgorithm": {
+                                      "default": "sha256",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -7493,6 +9555,18 @@
                             "additionalProperties": false
                           },
                           "type": "array"
+                        },
+                        "cosignOCI11": {
+                          "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "failureAction": {
+                          "description": "Allowed values are Audit or Enforce.",
+                          "enum": [
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
                         },
                         "image": {
                           "description": "Deprecated. Use ImageReferences instead.",
@@ -7576,9 +9650,10 @@
                           "type": "string"
                         },
                         "type": {
-                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
                           "enum": [
                             "Cosign",
+                            "SigstoreBundle",
                             "Notary"
                           ],
                           "type": "string"
@@ -7587,6 +9662,28 @@
                           "default": true,
                           "description": "UseCache enables caching of image verify responses for this rule.",
                           "type": "boolean"
+                        },
+                        "validate": {
+                          "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                          "properties": {
+                            "deny": {
+                              "description": "Deny defines conditions used to pass or fail a validation rule.",
+                              "properties": {
+                                "conditions": {
+                                  "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "message": {
+                              "description": "Message specifies a custom message to be displayed on failure.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "verifyDigest": {
                           "default": true,
@@ -7601,6 +9698,7 @@
                   }
                 },
                 "required": [
+                  "match",
                   "name"
                 ],
                 "type": "object",
@@ -7614,7 +9712,7 @@
         },
         "conditions": {
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -7649,7 +9747,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"
@@ -7720,9 +9818,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "ready"
-      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/kyverno.io/policy_v2beta1.json
+++ b/kyverno.io/policy_v2beta1.json
@@ -34,7 +34,7 @@
           "type": "boolean"
         },
         "failurePolicy": {
-          "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+          "description": "Deprecated, use failurePolicy under the webhookConfiguration instead.",
           "enum": [
             "Ignore",
             "Fail"
@@ -42,7 +42,7 @@
           "type": "string"
         },
         "generateExisting": {
-          "description": "GenerateExisting controls whether to trigger generate rule in existing resources\nIf is set to \"true\" generate rule will be triggered and applied to existing matched resources.\nDefaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting under the generate rule instead",
           "type": "boolean"
         },
         "generateExistingOnPolicyUpdate": {
@@ -50,7 +50,7 @@
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
-          "description": "MutateExistingOnPolicyUpdate controls if a mutateExisting policy is applied on policy events.\nDefault value is \"false\".",
+          "description": "Deprecated, use mutateExistingOnPolicyUpdate under the mutate rule instead",
           "type": "boolean"
         },
         "rules": {
@@ -64,11 +64,11 @@
                   "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
                   "properties": {
                     "expression": {
-                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                       "type": "string"
                     },
                     "name": {
-                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                       "type": "string"
                     }
                   },
@@ -85,6 +85,33 @@
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                  "oneOf": [
+                    {
+                      "required": [
+                        "configMap"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apiCall"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "imageRegistry"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "variable"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "globalReference"
+                      ]
+                    }
+                  ],
                   "properties": {
                     "apiCall": {
                       "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -112,13 +139,17 @@
                           },
                           "type": "array"
                         },
+                        "default": {
+                          "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                           "type": "string"
                         },
                         "method": {
                           "default": "GET",
-                          "description": "Method is the HTTP request type (GET or POST).",
+                          "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                           "enum": [
                             "GET",
                             "POST"
@@ -131,6 +162,28 @@
                             "caBundle": {
                               "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                               "type": "string"
+                            },
+                            "headers": {
+                              "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the header key",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the header value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "url": {
                               "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -181,6 +234,9 @@
                           "type": "string"
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -259,6 +315,9 @@
                       "additionalProperties": false
                     }
                   },
+                  "required": [
+                    "name"
+                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -266,6 +325,12 @@
               },
               "exclude": {
                 "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
                 "properties": {
                   "all": {
                     "description": "All allows specifying resources which will be ANDed",
@@ -281,6 +346,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -328,7 +399,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -338,7 +410,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -394,7 +467,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -404,7 +478,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -481,6 +556,12 @@
                         },
                         "resources": {
                           "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
                           "properties": {
                             "annotations": {
                               "additionalProperties": {
@@ -528,7 +609,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -538,7 +620,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -594,7 +677,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -604,7 +688,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -728,7 +813,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -738,7 +824,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -760,489 +847,125 @@
                     "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
-                  "kind": {
-                    "description": "Kind specifies resource kind.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "Name specifies the resource name.",
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "description": "Namespace specifies resource namespace.",
-                    "type": "string"
-                  },
-                  "orphanDownstreamOnPolicyDelete": {
-                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "synchronize": {
-                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                    "type": "boolean"
-                  },
-                  "uid": {
-                    "description": "UID specifies the resource uid.",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "imageExtractors": {
-                "additionalProperties": {
-                  "items": {
-                    "properties": {
-                      "jmesPath": {
-                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                        "type": "string"
-                      },
-                      "key": {
-                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                        "type": "string"
-                      },
-                      "path": {
-                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "path"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                "type": "object"
-              },
-              "match": {
-                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                "properties": {
-                  "all": {
-                    "description": "All allows specifying resources which will be ANDed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  },
-                  "any": {
-                    "description": "Any allows specifying resources which will be ORed",
-                    "items": {
-                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                      "properties": {
-                        "clusterRoles": {
-                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "resources": {
-                          "description": "ResourceDescription contains information about the resource being created or modified.",
-                          "properties": {
-                            "annotations": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                              "type": "object"
-                            },
-                            "kinds": {
-                              "description": "Kinds is a list of resource kinds.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "name": {
-                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                              "type": "string"
-                            },
-                            "names": {
-                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "namespaceSelector": {
-                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "namespaces": {
-                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "operations": {
-                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                              "items": {
-                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                "enum": [
-                                  "CREATE",
-                                  "CONNECT",
-                                  "UPDATE",
-                                  "DELETE"
-                                ],
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "selector": {
-                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                    "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
-                                        "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                        "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "roles": {
-                          "description": "Roles is the list of namespaced role names for the user.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "subjects": {
-                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                          "items": {
-                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name of the object being referenced.",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "type": "array"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "mutate": {
-                "description": "Mutation is used to modify matching resources.",
-                "properties": {
                   "foreach": {
-                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion specifies resource apiVersion.",
+                          "type": "string"
+                        },
+                        "clone": {
+                          "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "properties": {
+                            "name": {
+                              "description": "Name specifies name of the resource.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "cloneList": {
+                          "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                          "properties": {
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1270,13 +993,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1289,6 +1016,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -1339,6 +1088,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1417,6 +1169,888 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "data": {
+                          "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "kind": {
+                          "description": "Kind specifies resource kind.",
+                          "type": "string"
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name specifies the resource name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true,
+                          "additionalProperties": false
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "generateExisting": {
+                    "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind specifies resource kind.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name specifies the resource name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace specifies resource namespace.",
+                    "type": "string"
+                  },
+                  "orphanDownstreamOnPolicyDelete": {
+                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "synchronize": {
+                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageExtractors": {
+                "additionalProperties": {
+                  "items": {
+                    "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                "type": "object"
+              },
+              "match": {
+                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
+                "properties": {
+                  "all": {
+                    "description": "All allows specifying resources which will be ANDed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "any": {
+                    "description": "Any allows specifying resources which will be ORed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "mutate": {
+                "description": "Mutation is used to modify matching resources.",
+                "properties": {
+                  "foreach": {
+                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "properties": {
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1550,6 +2184,10 @@
                     },
                     "type": "array"
                   },
+                  "mutateExistingOnPolicyUpdate": {
+                    "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                    "type": "boolean"
+                  },
                   "patchStrategicMerge": {
                     "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                     "x-kubernetes-preserve-unknown-fields": true
@@ -1571,6 +2209,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -1598,13 +2263,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -1617,6 +2286,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -1667,6 +2358,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1745,6 +2439,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -1765,6 +2462,53 @@
                         "preconditions": {
                           "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "selector": {
+                          "description": "Selector allows you to select target resources with their labels.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
                         },
                         "uid": {
                           "description": "UID specifies the resource uid.",
@@ -1888,6 +2632,11 @@
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "assert": {
+                    "description": "Assert defines a kyverno-json assertion tree.",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "cel": {
                     "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
                     "properties": {
@@ -1897,11 +2646,11 @@
                           "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                           "properties": {
                             "key": {
-                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                               "type": "string"
                             },
                             "valueExpression": {
-                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                               "type": "string"
                             }
                           },
@@ -1920,7 +2669,7 @@
                           "description": "Validation specifies the CEL expression which is used to apply the validation.",
                           "properties": {
                             "expression": {
-                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                               "type": "string"
                             },
                             "message": {
@@ -1964,19 +2713,19 @@
                         "description": "ParamRef references a parameter resource.",
                         "properties": {
                           "name": {
-                            "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                            "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                             "type": "string"
                           },
                           "parameterNotFoundAction": {
-                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                             "properties": {
                               "matchExpressions": {
                                 "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -1996,7 +2745,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2006,7 +2756,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2028,7 +2779,7 @@
                       "variables": {
                         "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                         "items": {
-                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                           "properties": {
                             "expression": {
                               "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -2044,6 +2795,7 @@
                             "name"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "type": "array"
@@ -2150,6 +2902,87 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "failureAction": {
+                    "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                    "enum": [
+                      "Audit",
+                      "Enforce"
+                    ],
+                    "type": "string"
+                  },
+                  "failureActionOverrides": {
+                    "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                    "items": {
+                      "properties": {
+                        "action": {
+                          "description": "ValidationFailureAction defines the policy validation failure action",
+                          "enum": [
+                            "audit",
+                            "enforce",
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
+                        },
+                        "namespaceSelector": {
+                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
@@ -2163,6 +2996,33 @@
                           "description": "Context defines variables and data sources that can be used during rule execution.",
                           "items": {
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "apiCall": {
                                 "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -2190,13 +3050,17 @@
                                     },
                                     "type": "array"
                                   },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                     "type": "string"
                                   },
                                   "method": {
                                     "default": "GET",
-                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                     "enum": [
                                       "GET",
                                       "POST"
@@ -2209,6 +3073,28 @@
                                       "caBundle": {
                                         "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                         "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
                                       },
                                       "url": {
                                         "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -2259,6 +3145,9 @@
                                     "type": "string"
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -2337,6 +3226,9 @@
                                 "additionalProperties": false
                               }
                             },
+                            "required": [
+                              "name"
+                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -2525,6 +3417,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2573,6 +3469,10 @@
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                             "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -2580,6 +3480,10 @@
                                       },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
+                                        "type": "string"
+                                      },
+                                      "issuerRegExp": {
+                                        "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
@@ -2608,6 +3512,10 @@
                                       "subject": {
                                         "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
+                                      },
+                                      "subjectRegExp": {
+                                        "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -2625,6 +3533,10 @@
                                           },
                                           "pubkey": {
                                             "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                             "type": "string"
                                           }
                                         },
@@ -2679,7 +3591,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                        "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                         "type": "string"
                                       }
                                     },
@@ -2688,6 +3600,11 @@
                                   },
                                   "repository": {
                                     "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                    "type": "string"
+                                  },
+                                  "signatureAlgorithm": {
+                                    "default": "sha256",
+                                    "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                     "type": "string"
                                   }
                                 },
@@ -2917,6 +3834,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -2965,6 +3886,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -2972,6 +3897,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -3000,6 +3929,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -3017,6 +3950,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -3071,7 +4008,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -3080,6 +4017,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -3195,6 +4137,10 @@
                             },
                             "type": "array"
                           },
+                          "name": {
+                            "description": "Name is the variable name.",
+                            "type": "string"
+                          },
                           "predicateType": {
                             "description": "Deprecated in favour of 'Type', to be removed soon",
                             "type": "string"
@@ -3254,6 +4200,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3302,6 +4252,10 @@
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                           "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -3309,6 +4263,10 @@
                                     },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
+                                      "type": "string"
+                                    },
+                                    "issuerRegExp": {
+                                      "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
@@ -3337,6 +4295,10 @@
                                     "subject": {
                                       "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
+                                    },
+                                    "subjectRegExp": {
+                                      "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                      "type": "string"
                                     }
                                   },
                                   "type": "object",
@@ -3354,6 +4316,10 @@
                                         },
                                         "pubkey": {
                                           "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                           "type": "string"
                                         }
                                       },
@@ -3408,7 +4374,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                      "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                       "type": "string"
                                     }
                                   },
@@ -3417,6 +4383,11 @@
                                 },
                                 "repository": {
                                   "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                  "type": "string"
+                                },
+                                "signatureAlgorithm": {
+                                  "default": "sha256",
+                                  "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                   "type": "string"
                                 }
                               },
@@ -3430,6 +4401,14 @@
                         "additionalProperties": false
                       },
                       "type": "array"
+                    },
+                    "failureAction": {
+                      "description": "Allowed values are Audit or Enforce.",
+                      "enum": [
+                        "Audit",
+                        "Enforce"
+                      ],
+                      "type": "string"
                     },
                     "imageReferences": {
                       "description": "ImageReferences is a list of matching image reference patterns. At least one pattern in the\nlist must match the image for the rule to apply. Each image reference consists of a registry\naddress (defaults to docker.io), repository, image, and tag (defaults to latest).\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
@@ -3496,6 +4475,7 @@
                       "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
                       "enum": [
                         "Cosign",
+                        "SigstoreBundle",
                         "Notary"
                       ],
                       "type": "string"
@@ -3504,6 +4484,28 @@
                       "default": true,
                       "description": "UseCache enables caching of image verify responses for this rule",
                       "type": "boolean"
+                    },
+                    "validate": {
+                      "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                      "properties": {
+                        "deny": {
+                          "description": "Deny defines conditions used to pass or fail a validation rule.",
+                          "properties": {
+                            "conditions": {
+                              "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "message": {
+                          "description": "Message specifies a custom message to be displayed on failure.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "verifyDigest": {
                       "default": true,
@@ -3518,6 +4520,7 @@
               }
             },
             "required": [
+              "match",
               "name"
             ],
             "type": "object",
@@ -3535,7 +4538,7 @@
         },
         "validationFailureAction": {
           "default": "Audit",
-          "description": "ValidationFailureAction defines if a validation policy rule violation should block\nthe admission review request (enforce), or allow (audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are audit or enforce. The default value is \"Audit\".",
+          "description": "Deprecated, use validationFailureAction under the validate rule instead.",
           "enum": [
             "audit",
             "enforce",
@@ -3545,7 +4548,7 @@
           "type": "string"
         },
         "validationFailureActionOverrides": {
-          "description": "ValidationFailureActionOverrides is a Cluster Policy attribute that specifies ValidationFailureAction\nnamespace-wise. It overrides ValidationFailureAction for the specified namespaces.",
+          "description": "Deprecated, use validationFailureActionOverrides under the validate rule instead.",
           "items": {
             "properties": {
               "action": {
@@ -3579,7 +4582,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -3589,7 +4593,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -3616,19 +4621,27 @@
           "type": "array"
         },
         "webhookConfiguration": {
-          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.\nRequires Kubernetes 1.27 or later.",
+          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.",
           "properties": {
+            "failurePolicy": {
+              "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+              "enum": [
+                "Ignore",
+                "Fail"
+              ],
+              "type": "string"
+            },
             "matchConditions": {
-              "description": "MatchCondition configures admission webhook matchConditions.",
+              "description": "MatchCondition configures admission webhook matchConditions.\nRequires Kubernetes 1.27 or later.",
               "items": {
                 "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
                 "properties": {
                   "expression": {
-                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                     "type": "string"
                   }
                 },
@@ -3640,13 +4653,18 @@
                 "additionalProperties": false
               },
               "type": "array"
+            },
+            "timeoutSeconds": {
+              "description": "TimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+              "format": "int32",
+              "type": "integer"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "webhookTimeoutSeconds": {
-          "description": "WebhookTimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+          "description": "Deprecated, use webhookTimeoutSeconds under webhookConfiguration instead.",
           "format": "int32",
           "type": "integer"
         }
@@ -3668,14 +4686,14 @@
                   "celPreconditions": {
                     "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
                     "items": {
-                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "description": "MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.",
                       "properties": {
                         "expression": {
-                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\n\nRequired.",
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\n\nRequired.",
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
                           "type": "string"
                         }
                       },
@@ -3692,6 +4710,33 @@
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "configMap"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apiCall"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "imageRegistry"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "variable"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "globalReference"
+                          ]
+                        }
+                      ],
                       "properties": {
                         "apiCall": {
                           "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -3719,13 +4764,17 @@
                               },
                               "type": "array"
                             },
+                            "default": {
+                              "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                               "type": "string"
                             },
                             "method": {
                               "default": "GET",
-                              "description": "Method is the HTTP request type (GET or POST).",
+                              "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                               "enum": [
                                 "GET",
                                 "POST"
@@ -3738,6 +4787,28 @@
                                 "caBundle": {
                                   "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                   "type": "string"
+                                },
+                                "headers": {
+                                  "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the header key",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the header value",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
                                 },
                                 "url": {
                                   "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -3788,6 +4859,9 @@
                               "type": "string"
                             }
                           },
+                          "required": [
+                            "name"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -3866,6 +4940,9 @@
                           "additionalProperties": false
                         }
                       },
+                      "required": [
+                        "name"
+                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -3873,6 +4950,12 @@
                   },
                   "exclude": {
                     "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
                     "properties": {
                       "all": {
                         "description": "All allows specifying resources which will be ANDed",
@@ -3888,6 +4971,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -3935,7 +5024,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3945,7 +5035,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4001,7 +5092,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4011,7 +5103,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4088,6 +5181,12 @@
                             },
                             "resources": {
                               "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
                               "properties": {
                                 "annotations": {
                                   "additionalProperties": {
@@ -4135,7 +5234,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4145,7 +5245,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4201,7 +5302,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4211,7 +5313,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4283,6 +5386,12 @@
                       },
                       "resources": {
                         "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
                         "properties": {
                           "annotations": {
                             "additionalProperties": {
@@ -4330,7 +5439,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4340,7 +5450,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4396,7 +5507,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4406,7 +5518,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4524,7 +5637,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4534,7 +5648,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4556,678 +5671,125 @@
                         "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
-                      "kind": {
-                        "description": "Kind specifies resource kind.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Name specifies the resource name.",
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "description": "Namespace specifies resource namespace.",
-                        "type": "string"
-                      },
-                      "orphanDownstreamOnPolicyDelete": {
-                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "synchronize": {
-                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
-                        "type": "boolean"
-                      },
-                      "uid": {
-                        "description": "UID specifies the resource uid.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "imageExtractors": {
-                    "additionalProperties": {
-                      "items": {
-                        "properties": {
-                          "jmesPath": {
-                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
-                            "type": "string"
-                          },
-                          "key": {
-                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
-                            "type": "string"
-                          },
-                          "path": {
-                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
-                            "type": "string"
-                          },
-                          "value": {
-                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "path"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    },
-                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
-                    "type": "object"
-                  },
-                  "match": {
-                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
-                    "properties": {
-                      "all": {
-                        "description": "All allows specifying resources which will be ANDed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "any": {
-                        "description": "Any allows specifying resources which will be ORed",
-                        "items": {
-                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                          "properties": {
-                            "clusterRoles": {
-                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "resources": {
-                              "description": "ResourceDescription contains information about the resource being created or modified.",
-                              "properties": {
-                                "annotations": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                                  "type": "object"
-                                },
-                                "kinds": {
-                                  "description": "Kinds is a list of resource kinds.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "name": {
-                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                                  "type": "string"
-                                },
-                                "names": {
-                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "namespaceSelector": {
-                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                },
-                                "namespaces": {
-                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "operations": {
-                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                                  "items": {
-                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                                    "enum": [
-                                      "CREATE",
-                                      "CONNECT",
-                                      "UPDATE",
-                                      "DELETE"
-                                    ],
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                },
-                                "selector": {
-                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                                  "properties": {
-                                    "matchExpressions": {
-                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                      "items": {
-                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                        "properties": {
-                                          "key": {
-                                            "description": "key is the label key that the selector applies to.",
-                                            "type": "string"
-                                          },
-                                          "operator": {
-                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                            "type": "string"
-                                          },
-                                          "values": {
-                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                            "items": {
-                                              "type": "string"
-                                            },
-                                            "type": "array"
-                                          }
-                                        },
-                                        "required": [
-                                          "key",
-                                          "operator"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                      },
-                                      "type": "array"
-                                    },
-                                    "matchLabels": {
-                                      "additionalProperties": {
-                                        "type": "string"
-                                      },
-                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                      "type": "object"
-                                    }
-                                  },
-                                  "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "roles": {
-                              "description": "Roles is the list of namespaced role names for the user.",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "subjects": {
-                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                              "items": {
-                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                                "properties": {
-                                  "apiGroup": {
-                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                                    "type": "string"
-                                  },
-                                  "kind": {
-                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the object being referenced.",
-                                    "type": "string"
-                                  },
-                                  "namespace": {
-                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "kind",
-                                  "name"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      },
-                      "clusterRoles": {
-                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "resources": {
-                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
-                        "properties": {
-                          "annotations": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                            "type": "object"
-                          },
-                          "kinds": {
-                            "description": "Kinds is a list of resource kinds.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "name": {
-                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                            "type": "string"
-                          },
-                          "names": {
-                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "namespaceSelector": {
-                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "namespaces": {
-                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "operations": {
-                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                            "items": {
-                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                              "enum": [
-                                "CREATE",
-                                "CONNECT",
-                                "UPDATE",
-                                "DELETE"
-                              ],
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "selector": {
-                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "roles": {
-                        "description": "Roles is the list of namespaced role names for the user.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "subjects": {
-                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                        "items": {
-                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                          "properties": {
-                            "apiGroup": {
-                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                              "type": "string"
-                            },
-                            "kind": {
-                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "Name of the object being referenced.",
-                              "type": "string"
-                            },
-                            "namespace": {
-                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "kind",
-                            "name"
-                          ],
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "type": "array"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "mutate": {
-                    "description": "Mutation is used to modify matching resources.",
-                    "properties": {
                       "foreach": {
-                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
+                            "apiVersion": {
+                              "description": "APIVersion specifies resource apiVersion.",
+                              "type": "string"
+                            },
+                            "clone": {
+                              "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies name of the resource.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "cloneList": {
+                              "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                              "properties": {
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5255,13 +5817,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5274,6 +5840,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5324,6 +5912,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5402,6 +5993,1087 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "data": {
+                              "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "kind": {
+                              "description": "Kind specifies resource kind.",
+                              "type": "string"
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name specifies the resource name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true,
+                              "additionalProperties": false
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "generateExisting": {
+                        "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind specifies resource kind.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name specifies the resource name.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies resource namespace.",
+                        "type": "string"
+                      },
+                      "orphanDownstreamOnPolicyDelete": {
+                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "synchronize": {
+                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "imageExtractors": {
+                    "additionalProperties": {
+                      "items": {
+                        "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                    "type": "object"
+                  },
+                  "match": {
+                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
+                    "properties": {
+                      "all": {
+                        "description": "All allows specifying resources which will be ANDed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "any": {
+                        "description": "Any allows specifying resources which will be ORed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "clusterRoles": {
+                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                            "type": "object"
+                          },
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                            "type": "string"
+                          },
+                          "names": {
+                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespaceSelector": {
+                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "roles": {
+                        "description": "Roles is the list of namespaced role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "subjects": {
+                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                        "items": {
+                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the object being referenced.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "mutate": {
+                    "description": "Mutation is used to modify matching resources.",
+                    "properties": {
+                      "foreach": {
+                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "properties": {
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5535,6 +7207,10 @@
                         },
                         "type": "array"
                       },
+                      "mutateExistingOnPolicyUpdate": {
+                        "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                        "type": "boolean"
+                      },
                       "patchStrategicMerge": {
                         "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                         "x-kubernetes-preserve-unknown-fields": true
@@ -5556,6 +7232,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -5583,13 +7286,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -5602,6 +7309,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -5652,6 +7381,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -5730,6 +7462,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -5750,6 +7485,53 @@
                             "preconditions": {
                               "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                               "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "selector": {
+                              "description": "Selector allows you to select target resources with their labels.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "uid": {
                               "description": "UID specifies the resource uid.",
@@ -5774,6 +7556,13 @@
                     "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "reportProperties": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                    "type": "object"
+                  },
                   "skipBackgroundRequests": {
                     "default": true,
                     "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
@@ -5782,8 +7571,18 @@
                   "validate": {
                     "description": "Validation is used to validate matching resources.",
                     "properties": {
+                      "allowExistingViolations": {
+                        "default": true,
+                        "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                        "type": "boolean"
+                      },
                       "anyPattern": {
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "assert": {
+                        "description": "Assert defines a kyverno-json assertion tree.",
+                        "type": "object",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
                       "cel": {
@@ -5795,11 +7594,11 @@
                               "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
                               "properties": {
                                 "key": {
-                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\n\nRequired.",
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
                                   "type": "string"
                                 },
                                 "valueExpression": {
-                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\n\nRequired.",
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
                                   "type": "string"
                                 }
                               },
@@ -5818,7 +7617,7 @@
                               "description": "Validation specifies the CEL expression which is used to apply the validation.",
                               "properties": {
                                 "expression": {
-                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
                                   "type": "string"
                                 },
                                 "message": {
@@ -5862,19 +7661,19 @@
                             "description": "ParamRef references a parameter resource.",
                             "properties": {
                               "name": {
-                                "description": "`name` is the name of the resource being referenced.\n\n\n`name` and `selector` are mutually exclusive properties. If one is set,\nthe other must be unset.",
+                                "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
                                 "type": "string"
                               },
                               "parameterNotFoundAction": {
-                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\n\nAllowed values are `Allow` or `Deny`\nDefault to `Deny`",
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
                                 "type": "string"
                               },
                               "selector": {
-                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
                                 "properties": {
                                   "matchExpressions": {
                                     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -5894,7 +7693,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -5904,7 +7704,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -5926,7 +7727,7 @@
                           "variables": {
                             "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
                             "items": {
-                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
                               "properties": {
                                 "expression": {
                                   "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
@@ -5942,6 +7743,7 @@
                                 "name"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "type": "array"
@@ -5961,6 +7763,87 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "failureAction": {
+                        "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                        "enum": [
+                          "Audit",
+                          "Enforce"
+                        ],
+                        "type": "string"
+                      },
+                      "failureActionOverrides": {
+                        "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "description": "ValidationFailureAction defines the policy validation failure action",
+                              "enum": [
+                                "audit",
+                                "enforce",
+                                "Audit",
+                                "Enforce"
+                              ],
+                              "type": "string"
+                            },
+                            "namespaceSelector": {
+                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "namespaces": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
@@ -5974,6 +7857,33 @@
                               "description": "Context defines variables and data sources that can be used during rule execution.",
                               "items": {
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
                                 "properties": {
                                   "apiCall": {
                                     "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
@@ -6001,13 +7911,17 @@
                                         },
                                         "type": "array"
                                       },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
                                         "type": "string"
                                       },
                                       "method": {
                                         "default": "GET",
-                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
                                         "enum": [
                                           "GET",
                                           "POST"
@@ -6020,6 +7934,28 @@
                                           "caBundle": {
                                             "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
                                             "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
                                           },
                                           "url": {
                                             "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
@@ -6070,6 +8006,9 @@
                                         "type": "string"
                                       }
                                     },
+                                    "required": [
+                                      "name"
+                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -6148,6 +8087,9 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "required": [
+                                  "name"
+                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -6336,6 +8278,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6384,6 +8330,10 @@
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                 "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6391,6 +8341,10 @@
                                           },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
@@ -6419,6 +8373,10 @@
                                           "subject": {
                                             "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
                                           }
                                         },
                                         "type": "object",
@@ -6436,6 +8394,10 @@
                                               },
                                               "pubkey": {
                                                 "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                 "type": "string"
                                               }
                                             },
@@ -6490,7 +8452,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                             "type": "string"
                                           }
                                         },
@@ -6499,6 +8461,11 @@
                                       },
                                       "repository": {
                                         "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -6742,6 +8709,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -6790,6 +8761,10 @@
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                                     "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "type": "object",
@@ -6797,6 +8772,10 @@
                                               },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
+                                                "type": "string"
+                                              },
+                                              "issuerRegExp": {
+                                                "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
@@ -6825,6 +8804,10 @@
                                               "subject": {
                                                 "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
+                                              },
+                                              "subjectRegExp": {
+                                                "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                                "type": "string"
                                               }
                                             },
                                             "type": "object",
@@ -6842,6 +8825,10 @@
                                                   },
                                                   "pubkey": {
                                                     "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -6896,7 +8883,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                                "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                                 "type": "string"
                                               }
                                             },
@@ -6905,6 +8892,11 @@
                                           },
                                           "repository": {
                                             "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                            "type": "string"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -7020,6 +9012,10 @@
                                 },
                                 "type": "array"
                               },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
                               "predicateType": {
                                 "description": "Deprecated in favour of 'Type', to be removed soon",
                                 "type": "string"
@@ -7079,6 +9075,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7127,6 +9127,10 @@
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
                                               "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -7134,6 +9138,10 @@
                                         },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
+                                          "type": "string"
+                                        },
+                                        "issuerRegExp": {
+                                          "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
@@ -7162,6 +9170,10 @@
                                         "subject": {
                                           "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
+                                        },
+                                        "subjectRegExp": {
+                                          "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                          "type": "string"
                                         }
                                       },
                                       "type": "object",
@@ -7179,6 +9191,10 @@
                                             },
                                             "pubkey": {
                                               "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
                                               "type": "string"
                                             }
                                           },
@@ -7233,7 +9249,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                          "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
                                           "type": "string"
                                         }
                                       },
@@ -7242,6 +9258,11 @@
                                     },
                                     "repository": {
                                       "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                      "type": "string"
+                                    },
+                                    "signatureAlgorithm": {
+                                      "default": "sha256",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -7255,6 +9276,18 @@
                             "additionalProperties": false
                           },
                           "type": "array"
+                        },
+                        "cosignOCI11": {
+                          "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "failureAction": {
+                          "description": "Allowed values are Audit or Enforce.",
+                          "enum": [
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
                         },
                         "image": {
                           "description": "Deprecated. Use ImageReferences instead.",
@@ -7338,9 +9371,10 @@
                           "type": "string"
                         },
                         "type": {
-                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
                           "enum": [
                             "Cosign",
+                            "SigstoreBundle",
                             "Notary"
                           ],
                           "type": "string"
@@ -7349,6 +9383,28 @@
                           "default": true,
                           "description": "UseCache enables caching of image verify responses for this rule.",
                           "type": "boolean"
+                        },
+                        "validate": {
+                          "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                          "properties": {
+                            "deny": {
+                              "description": "Deny defines conditions used to pass or fail a validation rule.",
+                              "properties": {
+                                "conditions": {
+                                  "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "message": {
+                              "description": "Message specifies a custom message to be displayed on failure.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "verifyDigest": {
                           "default": true,
@@ -7363,6 +9419,7 @@
                   }
                 },
                 "required": [
+                  "match",
                   "name"
                 ],
                 "type": "object",
@@ -7376,7 +9433,7 @@
         },
         "conditions": {
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -7411,7 +9468,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"
@@ -7482,9 +9539,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "ready"
-      ],
       "type": "object",
       "additionalProperties": false
     }

--- a/kyverno.io/policyexception_v2.json
+++ b/kyverno.io/policyexception_v2.json
@@ -1,613 +1,638 @@
 {
-    "description": "PolicyException declares resources to be excluded from specified policies.",
-    "properties": {
-      "apiVersion": {
-        "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-        "type": "string"
-      },
-      "kind": {
-        "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-        "type": "string"
-      },
-      "metadata": {
-        "type": "object"
-      },
-      "spec": {
-        "description": "Spec declares policy exception behaviors.",
-        "properties": {
-          "background": {
-            "description": "Background controls if exceptions are applied to existing policies during a background scan.\nOptional. Default value is \"true\". The value must be set to \"false\" if the policy rule\nuses variables that are only available in the admission review request (e.g. user name).",
-            "type": "boolean"
-          },
-          "conditions": {
-            "description": "Conditions are used to determine if a resource applies to the exception by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.",
-            "properties": {
-              "all": {
-                "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass.",
-                "items": {
-                  "properties": {
-                    "key": {
-                      "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "message": {
-                      "description": "Message is an optional display message",
-                      "type": "string"
-                    },
-                    "operator": {
-                      "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
-                      "enum": [
-                        "Equals",
-                        "NotEquals",
-                        "AnyIn",
-                        "AllIn",
-                        "AnyNotIn",
-                        "AllNotIn",
-                        "GreaterThanOrEquals",
-                        "GreaterThan",
-                        "LessThanOrEquals",
-                        "LessThan",
-                        "DurationGreaterThanOrEquals",
-                        "DurationGreaterThan",
-                        "DurationLessThanOrEquals",
-                        "DurationLessThan"
-                      ],
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              },
-              "any": {
-                "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass.",
-                "items": {
-                  "properties": {
-                    "key": {
-                      "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    },
-                    "message": {
-                      "description": "Message is an optional display message",
-                      "type": "string"
-                    },
-                    "operator": {
-                      "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
-                      "enum": [
-                        "Equals",
-                        "NotEquals",
-                        "AnyIn",
-                        "AllIn",
-                        "AnyNotIn",
-                        "AllNotIn",
-                        "GreaterThanOrEquals",
-                        "GreaterThan",
-                        "LessThanOrEquals",
-                        "LessThan",
-                        "DurationGreaterThanOrEquals",
-                        "DurationGreaterThan",
-                        "DurationLessThanOrEquals",
-                        "DurationLessThan"
-                      ],
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
-                      "x-kubernetes-preserve-unknown-fields": true
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
-          },
-          "exceptions": {
-            "description": "Exceptions is a list policy/rules to be excluded",
-            "items": {
-              "description": "Exception stores infos about a policy and rules",
-              "properties": {
-                "policyName": {
-                  "description": "PolicyName identifies the policy to which the exception is applied.\nThe policy name uses the format <namespace>/<name> unless it\nreferences a ClusterPolicy.",
-                  "type": "string"
-                },
-                "ruleNames": {
-                  "description": "RuleNames identifies the rules to which the exception is applied.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              },
-              "required": [
-                "policyName",
-                "ruleNames"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": "array"
-          },
-          "match": {
-            "description": "Match defines match clause used to check if a resource applies to the exception",
-            "properties": {
-              "all": {
-                "description": "All allows specifying resources which will be ANDed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              },
-              "any": {
-                "description": "Any allows specifying resources which will be ORed",
-                "items": {
-                  "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
-                  "properties": {
-                    "clusterRoles": {
-                      "description": "ClusterRoles is the list of cluster-wide role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "resources": {
-                      "description": "ResourceDescription contains information about the resource being created or modified.",
-                      "properties": {
-                        "annotations": {
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
-                          "type": "object"
-                        },
-                        "kinds": {
-                          "description": "Kinds is a list of resource kinds.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
-                          "type": "string"
-                        },
-                        "names": {
-                          "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "namespaceSelector": {
-                          "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "namespaces": {
-                          "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "operations": {
-                          "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
-                          "items": {
-                            "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
-                            "enum": [
-                              "CREATE",
-                              "CONNECT",
-                              "UPDATE",
-                              "DELETE"
-                            ],
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "selector": {
-                          "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
-                          "properties": {
-                            "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                              "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the label key that the selector applies to.",
-                                    "type": "string"
-                                  },
-                                  "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                    "type": "string"
-                                  },
-                                  "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "operator"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                              },
-                              "type": "array"
-                            },
-                            "matchLabels": {
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                              "type": "object"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "roles": {
-                      "description": "Roles is the list of namespaced role names for the user.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "subjects": {
-                      "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
-                      "items": {
-                        "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
-                        "properties": {
-                          "apiGroup": {
-                            "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
-                            "type": "string"
-                          },
-                          "kind": {
-                            "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-                            "type": "string"
-                          },
-                          "name": {
-                            "description": "Name of the object being referenced.",
-                            "type": "string"
-                          },
-                          "namespace": {
-                            "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "name"
-                        ],
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "type": "array"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
-          },
-          "podSecurity": {
-            "description": "PodSecurity specifies the Pod Security Standard controls to be excluded.\nApplicable only to policies that have validate.podSecurity subrule.",
-            "items": {
-              "description": "PodSecurityStandard specifies the Pod Security Standard controls to be excluded.",
-              "properties": {
-                "controlName": {
-                  "description": "ControlName specifies the name of the Pod Security Standard control.\nSee: https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-                  "enum": [
-                    "HostProcess",
-                    "Host Namespaces",
-                    "Privileged Containers",
-                    "Capabilities",
-                    "HostPath Volumes",
-                    "Host Ports",
-                    "AppArmor",
-                    "SELinux",
-                    "/proc Mount Type",
-                    "Seccomp",
-                    "Sysctls",
-                    "Volume Types",
-                    "Privilege Escalation",
-                    "Running as Non-root",
-                    "Running as Non-root user"
-                  ],
-                  "type": "string"
-                },
-                "images": {
-                  "description": "Images selects matching containers and applies the container level PSS.\nEach image is the image name consisting of the registry address, repository, image, and tag.\nEmpty list matches no containers, PSS checks are applied at the pod level only.\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "restrictedField": {
-                  "description": "RestrictedField selects the field for the given Pod Security Standard control.\nWhen not set, all restricted fields for the control are selected.",
-                  "type": "string"
-                },
-                "values": {
-                  "description": "Values defines the allowed values that can be excluded.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              },
-              "required": [
-                "controlName"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "exceptions",
-          "match"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      }
+  "description": "PolicyException declares resources to be excluded from specified policies.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
     },
-    "required": [
-      "spec"
-    ],
-    "type": "object"
-  }
-  
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy exception behaviors.",
+      "properties": {
+        "background": {
+          "description": "Background controls if exceptions are applied to existing policies during a background scan.\nOptional. Default value is \"true\". The value must be set to \"false\" if the policy rule\nuses variables that are only available in the admission review request (e.g. user name).",
+          "type": "boolean"
+        },
+        "conditions": {
+          "description": "Conditions are used to determine if a resource applies to the exception by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.",
+          "properties": {
+            "all": {
+              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "exceptions": {
+          "description": "Exceptions is a list policy/rules to be excluded",
+          "items": {
+            "description": "Exception stores infos about a policy and rules",
+            "properties": {
+              "policyName": {
+                "description": "PolicyName identifies the policy to which the exception is applied.\nThe policy name uses the format <namespace>/<name> unless it\nreferences a ClusterPolicy.",
+                "type": "string"
+              },
+              "ruleNames": {
+                "description": "RuleNames identifies the rules to which the exception is applied.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "policyName",
+              "ruleNames"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "match": {
+          "description": "Match defines match clause used to check if a resource applies to the exception",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podSecurity": {
+          "description": "PodSecurity specifies the Pod Security Standard controls to be excluded.\nApplicable only to policies that have validate.podSecurity subrule.",
+          "items": {
+            "description": "PodSecurityStandard specifies the Pod Security Standard controls to be excluded.",
+            "properties": {
+              "controlName": {
+                "description": "ControlName specifies the name of the Pod Security Standard control.\nSee: https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+                "enum": [
+                  "HostProcess",
+                  "Host Namespaces",
+                  "Privileged Containers",
+                  "Capabilities",
+                  "HostPath Volumes",
+                  "Host Ports",
+                  "AppArmor",
+                  "SELinux",
+                  "/proc Mount Type",
+                  "Seccomp",
+                  "Sysctls",
+                  "Volume Types",
+                  "Privilege Escalation",
+                  "Running as Non-root",
+                  "Running as Non-root user"
+                ],
+                "type": "string"
+              },
+              "images": {
+                "description": "Images selects matching containers and applies the container level PSS.\nEach image is the image name consisting of the registry address, repository, image, and tag.\nEmpty list matches no containers, PSS checks are applied at the pod level only.\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "restrictedField": {
+                "description": "RestrictedField selects the field for the given Pod Security Standard control.\nWhen not set, all restricted fields for the control are selected.",
+                "type": "string"
+              },
+              "values": {
+                "description": "Values defines the allowed values that can be excluded.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "controlName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "exceptions",
+        "match"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/policyexception_v2beta1.json
+++ b/kyverno.io/policyexception_v2beta1.json
@@ -138,6 +138,12 @@
         },
         "match": {
           "description": "Match defines match clause used to check if a resource applies to the exception",
+          "not": {
+            "required": [
+              "any",
+              "all"
+            ]
+          },
           "properties": {
             "all": {
               "description": "All allows specifying resources which will be ANDed",
@@ -153,6 +159,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -200,7 +212,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -210,7 +223,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -266,7 +280,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -276,7 +291,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -353,6 +369,12 @@
                   },
                   "resources": {
                     "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
                     "properties": {
                       "annotations": {
                         "additionalProperties": {
@@ -400,7 +422,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -410,7 +433,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -466,7 +490,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -476,7 +501,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {

--- a/kyverno.io/policyreport_v1alpha2.json
+++ b/kyverno.io/policyreport_v1alpha2.json
@@ -57,7 +57,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -67,7 +68,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "matchLabels": {
                 "additionalProperties": {
@@ -84,14 +86,14 @@
           "resources": {
             "description": "Subjects is an optional reference to the checked Kubernetes resources",
             "items": {
-              "description": "ObjectReference contains enough information to let you inspect or modify the referred object.\n---\nNew uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.\n 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.\n 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular\n    restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".\n    Those cannot be well described when embedded.\n 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.\n 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity\n    during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple\n    and the version of the actual struct is irrelevant.\n 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type\n    will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.\n\n\nInstead of using this type, create a locally provided and used type that is well-focused on your reference.\nFor example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+              "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
               "properties": {
                 "apiVersion": {
                   "description": "API version of the referent.",
                   "type": "string"
                 },
                 "fieldPath": {
-                  "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+                  "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
                   "type": "string"
                 },
                 "kind": {
@@ -194,7 +196,7 @@
           "type": "string"
         },
         "fieldPath": {
-          "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+          "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
           "type": "string"
         },
         "kind": {
@@ -243,7 +245,8 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               }
             },
             "required": [
@@ -253,7 +256,8 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "matchLabels": {
           "additionalProperties": {

--- a/kyverno.io/updaterequest_v1beta1.json
+++ b/kyverno.io/updaterequest_v1beta1.json
@@ -77,7 +77,7 @@
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "requestKind": {
-                      "description": "RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale).\nIf this is specified and differs from the value in \"kind\", an equivalent match and conversion was performed.\n\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `kind: {group:\"apps\", version:\"v1\", kind:\"Deployment\"}` (matching the rule the webhook registered for),\nand `requestKind: {group:\"apps\", version:\"v1beta1\", kind:\"Deployment\"}` (indicating the kind of the original API request).\n\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type for more details.",
+                      "description": "RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale).\nIf this is specified and differs from the value in \"kind\", an equivalent match and conversion was performed.\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `kind: {group:\"apps\", version:\"v1\", kind:\"Deployment\"}` (matching the rule the webhook registered for),\nand `requestKind: {group:\"apps\", version:\"v1beta1\", kind:\"Deployment\"}` (indicating the kind of the original API request).\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type for more details.",
                       "properties": {
                         "group": {
                           "type": "string"
@@ -98,7 +98,7 @@
                       "additionalProperties": false
                     },
                     "requestResource": {
-                      "description": "RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).\nIf this is specified and differs from the value in \"resource\", an equivalent match and conversion was performed.\n\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `resource: {group:\"apps\", version:\"v1\", resource:\"deployments\"}` (matching the resource the webhook registered for),\nand `requestResource: {group:\"apps\", version:\"v1beta1\", resource:\"deployments\"}` (indicating the resource of the original API request).\n\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type.",
+                      "description": "RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).\nIf this is specified and differs from the value in \"resource\", an equivalent match and conversion was performed.\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `resource: {group:\"apps\", version:\"v1\", resource:\"deployments\"}` (matching the resource the webhook registered for),\nand `requestResource: {group:\"apps\", version:\"v1beta1\", resource:\"deployments\"}` (indicating the resource of the original API request).\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type.",
                       "properties": {
                         "group": {
                           "type": "string"
@@ -170,7 +170,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "uid": {
                           "description": "A unique value that identifies this user across time. If this user is\ndeleted and another user by the same name is added, they will have\ndifferent UIDs.",
@@ -241,7 +242,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "uid": {
                       "description": "A unique value that identifies this user across time. If this user is\ndeleted and another user by the same name is added, they will have\ndifferent UIDs.",

--- a/kyverno.io/updaterequest_v2.json
+++ b/kyverno.io/updaterequest_v2.json
@@ -1,286 +1,392 @@
 {
-    "description": "UpdateRequest is a request to process mutate and generate rules in background.",
-    "properties": {
-      "apiVersion": {
-        "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-        "type": "string"
-      },
-      "kind": {
-        "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-        "type": "string"
-      },
-      "metadata": {
-        "type": "object"
-      },
-      "spec": {
-        "description": "ResourceSpec is the information to identify the trigger resource.",
-        "properties": {
-          "context": {
-            "description": "Context ...",
-            "properties": {
-              "admissionRequestInfo": {
-                "description": "AdmissionRequestInfoObject stores the admission request and operation details",
-                "properties": {
-                  "admissionRequest": {
-                    "description": "AdmissionRequest describes the admission.Attributes for the admission request.",
-                    "properties": {
-                      "dryRun": {
-                        "description": "DryRun indicates that modifications will definitely not be persisted for this request.\nDefaults to false.",
-                        "type": "boolean"
-                      },
-                      "kind": {
-                        "description": "Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)",
-                        "properties": {
-                          "group": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          }
+  "description": "UpdateRequest is a request to process mutate and generate rules in background.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ResourceSpec is the information to identify the trigger resource.",
+      "properties": {
+        "context": {
+          "description": "Context represents admission request context.\nIt is used upon admission review only and is shared across rules within the same UR.",
+          "properties": {
+            "admissionRequestInfo": {
+              "description": "AdmissionRequestInfoObject stores the admission request and operation details",
+              "properties": {
+                "admissionRequest": {
+                  "description": "AdmissionRequest describes the admission.Attributes for the admission request.",
+                  "properties": {
+                    "dryRun": {
+                      "description": "DryRun indicates that modifications will definitely not be persisted for this request.\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "description": "Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)",
+                      "properties": {
+                        "group": {
+                          "type": "string"
                         },
-                        "required": [
-                          "group",
-                          "kind",
-                          "version"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "name": {
-                        "description": "Name is the name of the object as presented in the request.  On a CREATE operation, the client may omit name and\nrely on the server to generate the name.  If that is the case, this field will contain an empty string.",
-                        "type": "string"
-                      },
-                      "namespace": {
-                        "description": "Namespace is the namespace associated with the request (if any).",
-                        "type": "string"
-                      },
-                      "object": {
-                        "description": "Object is the object from the incoming request.",
-                        "type": "object",
-                        "x-kubernetes-preserve-unknown-fields": true
-                      },
-                      "oldObject": {
-                        "description": "OldObject is the existing object. Only populated for DELETE and UPDATE requests.",
-                        "type": "object",
-                        "x-kubernetes-preserve-unknown-fields": true
-                      },
-                      "operation": {
-                        "description": "Operation is the operation being performed. This may be different than the operation\nrequested. e.g. a patch can result in either a CREATE or UPDATE Operation.",
-                        "type": "string"
-                      },
-                      "options": {
-                        "description": "Options is the operation option structure of the operation being performed.\ne.g. `meta.k8s.io/v1.DeleteOptions` or `meta.k8s.io/v1.CreateOptions`. This may be\ndifferent than the options the caller provided. e.g. for a patch request the performed\nOperation might be a CREATE, in which case the Options will a\n`meta.k8s.io/v1.CreateOptions` even though the caller provided `meta.k8s.io/v1.PatchOptions`.",
-                        "type": "object",
-                        "x-kubernetes-preserve-unknown-fields": true
-                      },
-                      "requestKind": {
-                        "description": "RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale).\nIf this is specified and differs from the value in \"kind\", an equivalent match and conversion was performed.\n\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `kind: {group:\"apps\", version:\"v1\", kind:\"Deployment\"}` (matching the rule the webhook registered for),\nand `requestKind: {group:\"apps\", version:\"v1beta1\", kind:\"Deployment\"}` (indicating the kind of the original API request).\n\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type for more details.",
-                        "properties": {
-                          "group": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          }
+                        "kind": {
+                          "type": "string"
                         },
-                        "required": [
-                          "group",
-                          "kind",
-                          "version"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "version": {
+                          "type": "string"
+                        }
                       },
-                      "requestResource": {
-                        "description": "RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).\nIf this is specified and differs from the value in \"resource\", an equivalent match and conversion was performed.\n\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `resource: {group:\"apps\", version:\"v1\", resource:\"deployments\"}` (matching the resource the webhook registered for),\nand `requestResource: {group:\"apps\", version:\"v1beta1\", resource:\"deployments\"}` (indicating the resource of the original API request).\n\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type.",
-                        "properties": {
-                          "group": {
-                            "type": "string"
-                          },
-                          "resource": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          }
+                      "required": [
+                        "group",
+                        "kind",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "name": {
+                      "description": "Name is the name of the object as presented in the request.  On a CREATE operation, the client may omit name and\nrely on the server to generate the name.  If that is the case, this field will contain an empty string.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace associated with the request (if any).",
+                      "type": "string"
+                    },
+                    "object": {
+                      "description": "Object is the object from the incoming request.",
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "oldObject": {
+                      "description": "OldObject is the existing object. Only populated for DELETE and UPDATE requests.",
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "operation": {
+                      "description": "Operation is the operation being performed. This may be different than the operation\nrequested. e.g. a patch can result in either a CREATE or UPDATE Operation.",
+                      "type": "string"
+                    },
+                    "options": {
+                      "description": "Options is the operation option structure of the operation being performed.\ne.g. `meta.k8s.io/v1.DeleteOptions` or `meta.k8s.io/v1.CreateOptions`. This may be\ndifferent than the options the caller provided. e.g. for a patch request the performed\nOperation might be a CREATE, in which case the Options will a\n`meta.k8s.io/v1.CreateOptions` even though the caller provided `meta.k8s.io/v1.PatchOptions`.",
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "requestKind": {
+                      "description": "RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale).\nIf this is specified and differs from the value in \"kind\", an equivalent match and conversion was performed.\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `kind: {group:\"apps\", version:\"v1\", kind:\"Deployment\"}` (matching the rule the webhook registered for),\nand `requestKind: {group:\"apps\", version:\"v1beta1\", kind:\"Deployment\"}` (indicating the kind of the original API request).\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type for more details.",
+                      "properties": {
+                        "group": {
+                          "type": "string"
                         },
-                        "required": [
-                          "group",
-                          "resource",
-                          "version"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "requestSubResource": {
-                        "description": "RequestSubResource is the name of the subresource of the original API request, if any (for example, \"status\" or \"scale\")\nIf this is specified and differs from the value in \"subResource\", an equivalent match and conversion was performed.\nSee documentation for the \"matchPolicy\" field in the webhook configuration type.",
-                        "type": "string"
-                      },
-                      "resource": {
-                        "description": "Resource is the fully-qualified resource being requested (for example, v1.pods)",
-                        "properties": {
-                          "group": {
-                            "type": "string"
-                          },
-                          "resource": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "string"
-                          }
+                        "kind": {
+                          "type": "string"
                         },
-                        "required": [
-                          "group",
-                          "resource",
-                          "version"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "version": {
+                          "type": "string"
+                        }
                       },
-                      "subResource": {
-                        "description": "SubResource is the subresource being requested, if any (for example, \"status\" or \"scale\")",
-                        "type": "string"
+                      "required": [
+                        "group",
+                        "kind",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestResource": {
+                      "description": "RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).\nIf this is specified and differs from the value in \"resource\", an equivalent match and conversion was performed.\n\nFor example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of\n`apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]` and `matchPolicy: Equivalent`,\nan API request to apps/v1beta1 deployments would be converted and sent to the webhook\nwith `resource: {group:\"apps\", version:\"v1\", resource:\"deployments\"}` (matching the resource the webhook registered for),\nand `requestResource: {group:\"apps\", version:\"v1beta1\", resource:\"deployments\"}` (indicating the resource of the original API request).\n\nSee documentation for the \"matchPolicy\" field in the webhook configuration type.",
+                      "properties": {
+                        "group": {
+                          "type": "string"
+                        },
+                        "resource": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
                       },
-                      "uid": {
-                        "description": "UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are\notherwise identical (parallel requests, requests when earlier requests did not modify etc)\nThe UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.\nIt is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.",
-                        "type": "string"
+                      "required": [
+                        "group",
+                        "resource",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "requestSubResource": {
+                      "description": "RequestSubResource is the name of the subresource of the original API request, if any (for example, \"status\" or \"scale\")\nIf this is specified and differs from the value in \"subResource\", an equivalent match and conversion was performed.\nSee documentation for the \"matchPolicy\" field in the webhook configuration type.",
+                      "type": "string"
+                    },
+                    "resource": {
+                      "description": "Resource is the fully-qualified resource being requested (for example, v1.pods)",
+                      "properties": {
+                        "group": {
+                          "type": "string"
+                        },
+                        "resource": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
                       },
-                      "userInfo": {
-                        "description": "UserInfo is information about the requesting user",
-                        "properties": {
-                          "extra": {
-                            "additionalProperties": {
-                              "description": "ExtraValue masks the value so protobuf can generate",
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            },
-                            "description": "Any additional information provided by the authenticator.",
-                            "type": "object"
-                          },
-                          "groups": {
-                            "description": "The names of groups this user is a part of.",
+                      "required": [
+                        "group",
+                        "resource",
+                        "version"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "subResource": {
+                      "description": "SubResource is the subresource being requested, if any (for example, \"status\" or \"scale\")",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are\notherwise identical (parallel requests, requests when earlier requests did not modify etc)\nThe UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.\nIt is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.",
+                      "type": "string"
+                    },
+                    "userInfo": {
+                      "description": "UserInfo is information about the requesting user",
+                      "properties": {
+                        "extra": {
+                          "additionalProperties": {
+                            "description": "ExtraValue masks the value so protobuf can generate",
                             "items": {
                               "type": "string"
                             },
                             "type": "array"
                           },
-                          "uid": {
-                            "description": "A unique value that identifies this user across time. If this user is\ndeleted and another user by the same name is added, they will have\ndifferent UIDs.",
-                            "type": "string"
-                          },
-                          "username": {
-                            "description": "The name that uniquely identifies this user among all active users.",
-                            "type": "string"
-                          }
+                          "description": "Any additional information provided by the authenticator.",
+                          "type": "object"
                         },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "operation",
-                      "resource",
-                      "uid",
-                      "userInfo"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "operation": {
-                    "description": "Operation is the type of resource operation being checked for admission control",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "userInfo": {
-                "description": "RequestInfo contains permission info carried in an admission request.",
-                "properties": {
-                  "clusterRoles": {
-                    "description": "ClusterRoles is a list of possible clusterRoles send the request.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "type": "array"
-                  },
-                  "roles": {
-                    "description": "Roles is a list of possible role send the request.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "nullable": true,
-                    "type": "array"
-                  },
-                  "userInfo": {
-                    "description": "UserInfo is the userInfo carried in the admission request.",
-                    "properties": {
-                      "extra": {
-                        "additionalProperties": {
-                          "description": "ExtraValue masks the value so protobuf can generate",
+                        "groups": {
+                          "description": "The names of groups this user is a part of.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
-                        "description": "Any additional information provided by the authenticator.",
-                        "type": "object"
+                        "uid": {
+                          "description": "A unique value that identifies this user across time. If this user is\ndeleted and another user by the same name is added, they will have\ndifferent UIDs.",
+                          "type": "string"
+                        },
+                        "username": {
+                          "description": "The name that uniquely identifies this user among all active users.",
+                          "type": "string"
+                        }
                       },
-                      "groups": {
-                        "description": "The names of groups this user is a part of.",
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "operation",
+                    "resource",
+                    "uid",
+                    "userInfo"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "operation": {
+                  "description": "Operation is the type of resource operation being checked for admission control",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "userInfo": {
+              "description": "RequestInfo contains permission info carried in an admission request.",
+              "properties": {
+                "clusterRoles": {
+                  "description": "ClusterRoles is a list of possible clusterRoles send the request.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "type": "array"
+                },
+                "roles": {
+                  "description": "Roles is a list of possible role send the request.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "type": "array"
+                },
+                "userInfo": {
+                  "description": "UserInfo is the userInfo carried in the admission request.",
+                  "properties": {
+                    "extra": {
+                      "additionalProperties": {
+                        "description": "ExtraValue masks the value so protobuf can generate",
                         "items": {
                           "type": "string"
                         },
                         "type": "array"
                       },
-                      "uid": {
-                        "description": "A unique value that identifies this user across time. If this user is\ndeleted and another user by the same name is added, they will have\ndifferent UIDs.",
+                      "description": "Any additional information provided by the authenticator.",
+                      "type": "object"
+                    },
+                    "groups": {
+                      "description": "The names of groups this user is a part of.",
+                      "items": {
                         "type": "string"
                       },
-                      "username": {
-                        "description": "The name that uniquely identifies this user among all active users.",
-                        "type": "string"
-                      }
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "uid": {
+                      "description": "A unique value that identifies this user across time. If this user is\ndeleted and another user by the same name is added, they will have\ndifferent UIDs.",
+                      "type": "string"
+                    },
+                    "username": {
+                      "description": "The name that uniquely identifies this user among all active users.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "deleteDownstream": {
+          "description": "DeleteDownstream represents whether the downstream needs to be deleted.\nDeprecated",
+          "type": "boolean"
+        },
+        "policy": {
+          "description": "Specifies the name of the policy.",
+          "type": "string"
+        },
+        "requestType": {
+          "description": "Type represents request type for background processing",
+          "enum": [
+            "mutate",
+            "generate"
+          ],
+          "type": "string"
+        },
+        "resource": {
+          "description": "ResourceSpec is the information to identify the trigger resource.",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion specifies resource apiVersion.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind specifies resource kind.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name specifies the resource name.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace specifies resource namespace.",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID specifies the resource uid.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "rule": {
+          "description": "Rule is the associate rule name of the current UR.",
+          "type": "string"
+        },
+        "ruleContext": {
+          "description": "RuleContext is the associate context to apply rules.\noptional",
+          "items": {
+            "properties": {
+              "deleteDownstream": {
+                "description": "DeleteDownstream represents whether the downstream needs to be deleted.",
+                "type": "boolean"
+              },
+              "rule": {
+                "description": "Rule is the associate rule name of the current UR.",
+                "type": "string"
+              },
+              "synchronize": {
+                "description": "Synchronize represents the sync behavior of the corresponding rule\nOptional. Defaults to \"false\" if not specified.",
+                "type": "boolean"
+              },
+              "trigger": {
+                "description": "ResourceSpec is the information to identify the trigger resource.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion specifies resource apiVersion.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind specifies resource kind.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name specifies the resource name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace specifies resource namespace.",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
                   }
                 },
                 "type": "object",
                 "additionalProperties": false
               }
             },
+            "required": [
+              "deleteDownstream",
+              "rule",
+              "trigger"
+            ],
             "type": "object",
             "additionalProperties": false
           },
-          "deleteDownstream": {
-            "description": "DeleteDownstream represents whether the downstream needs to be deleted.",
-            "type": "boolean"
-          },
-          "policy": {
-            "description": "Specifies the name of the policy.",
-            "type": "string"
-          },
-          "requestType": {
-            "description": "Type represents request type for background processing",
-            "enum": [
-              "mutate",
-              "generate"
-            ],
-            "type": "string"
-          },
-          "resource": {
-            "description": "ResourceSpec is the information to identify the trigger resource.",
+          "type": "array"
+        },
+        "synchronize": {
+          "description": "Synchronize represents the sync behavior of the corresponding rule\nOptional. Defaults to \"false\" if not specified.\nDeprecated, will be removed in 1.14.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "context",
+        "deleteDownstream",
+        "policy",
+        "resource",
+        "rule"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status contains statistics related to update request.",
+      "properties": {
+        "generatedResources": {
+          "description": "This will track the resources that are updated by the generate Policy.\nWill be used during clean up resources.",
+          "items": {
             "properties": {
               "apiVersion": {
                 "description": "APIVersion specifies resource apiVersion.",
@@ -306,77 +412,26 @@
             "type": "object",
             "additionalProperties": false
           },
-          "rule": {
-            "description": "Rule is the associate rule name of the current UR.",
-            "type": "string"
-          },
-          "synchronize": {
-            "description": "Synchronize represents the sync behavior of the corresponding rule\nOptional. Defaults to \"false\" if not specified.",
-            "type": "boolean"
-          }
+          "type": "array"
         },
-        "required": [
-          "context",
-          "deleteDownstream",
-          "policy",
-          "resource",
-          "rule"
-        ],
-        "type": "object",
-        "additionalProperties": false
+        "message": {
+          "description": "Specifies request status message.",
+          "type": "string"
+        },
+        "retryCount": {
+          "type": "integer"
+        },
+        "state": {
+          "description": "State represents state of the update request.",
+          "type": "string"
+        }
       },
-      "status": {
-        "description": "Status contains statistics related to update request.",
-        "properties": {
-          "generatedResources": {
-            "description": "This will track the resources that are updated by the generate Policy.\nWill be used during clean up resources.",
-            "items": {
-              "properties": {
-                "apiVersion": {
-                  "description": "APIVersion specifies resource apiVersion.",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Kind specifies resource kind.",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Name specifies the resource name.",
-                  "type": "string"
-                },
-                "namespace": {
-                  "description": "Namespace specifies resource namespace.",
-                  "type": "string"
-                },
-                "uid": {
-                  "description": "UID specifies the resource uid.",
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": "array"
-          },
-          "message": {
-            "description": "Specifies request status message.",
-            "type": "string"
-          },
-          "retryCount": {
-            "type": "integer"
-          },
-          "state": {
-            "description": "State represents state of the update request.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "state"
-        ],
-        "type": "object",
-        "additionalProperties": false
-      }
-    },
-    "type": "object"
-  }
-  
+      "required": [
+        "state"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Very similar to https://github.com/datreeio/CRDs-catalog/pull/338, updated the CRDs using
github.com/yannh/kubeconform/scripts/openapi2jsonschema.py against the templated CRDs from https://github.com/kyverno/kyverno/tree/main/charts/kyverno/charts/crds/templates

Thanks!