### PR TITLE
fix: update Teleport CRDs

### DIFF
--- a/resources.teleport.dev/teleportaccesslist_v1.json
+++ b/resources.teleport.dev/teleportaccesslist_v1.json
@@ -151,6 +151,10 @@
                 "description": "ineligible_status describes if this owner is eligible or not and if not, describes how they're lacking eligibility.",
                 "x-kubernetes-int-or-string": true
               },
+              "membership_kind": {
+                "description": "membership_kind describes the type of membership, either `MEMBERSHIP_KIND_USER` or `MEMBERSHIP_KIND_LIST`.",
+                "x-kubernetes-int-or-string": true
+              },
               "name": {
                 "description": "name is the username of the owner.",
                 "type": "string"
@@ -202,7 +206,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -237,7 +241,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportaccesslist_v1.json
+++ b/resources.teleport.dev/teleportaccesslist_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "SAMLConnector is the Schema for the samlconnectors API",
+  "description": "AccessList is the Schema for the accesslists API",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,136 +13,183 @@
       "type": "object"
     },
     "spec": {
-      "description": "SAMLConnector resource definition v2 from Teleport",
+      "description": "AccessList resource definition v1 from Teleport",
       "properties": {
-        "acs": {
-          "description": "AssertionConsumerService is a URL for assertion consumer service on the service provider (Teleport's side).",
-          "type": "string"
-        },
-        "allow_idp_initiated": {
-          "description": "AllowIDPInitiated is a flag that indicates if the connector can be used for IdP-initiated logins.",
-          "type": "boolean"
-        },
-        "assertion_key_pair": {
-          "description": "EncryptionKeyPair is a key pair used for decrypting SAML assertions.",
+        "audit": {
+          "description": "audit describes the frequency that this Access List must be audited.",
           "nullable": true,
           "properties": {
-            "cert": {
-              "description": "Cert is a PEM-encoded x509 certificate.",
+            "next_audit_date": {
+              "description": "next_audit_date is when the next audit date should be done by.",
+              "format": "date-time",
               "type": "string"
             },
-            "private_key": {
-              "description": "PrivateKey is a PEM encoded x509 private key.",
-              "type": "string"
+            "notifications": {
+              "description": "notifications is the configuration for notifying users.",
+              "nullable": true,
+              "properties": {
+                "start": {
+                  "description": "start specifies when to start notifying users that the next audit date is coming up.",
+                  "format": "duration",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "recurrence": {
+              "description": "recurrence is the recurrence definition",
+              "nullable": true,
+              "properties": {
+                "day_of_month": {
+                  "description": "day_of_month is the day of month that reviews will be scheduled on. Supported values are 0, 1, 15, and 31.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "frequency": {
+                  "description": "frequency is the frequency of reviews. This represents the period in months between two reviews. Supported values are 0, 1, 3, 6, and 12.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
         },
-        "attributes_to_roles": {
-          "description": "AttributesToRoles is a list of mappings of attribute statements to roles.",
-          "items": {
-            "properties": {
-              "name": {
-                "description": "Name is an attribute statement name.",
+        "description": {
+          "description": "description is an optional plaintext description of the Access List.",
+          "type": "string"
+        },
+        "grants": {
+          "description": "grants describes the access granted by membership to this Access List.",
+          "nullable": true,
+          "properties": {
+            "roles": {
+              "description": "roles are the roles that are granted to users who are members of the Access List.",
+              "items": {
                 "type": "string"
               },
-              "roles": {
-                "description": "Roles is a list of static teleport roles to map to.",
+              "nullable": true,
+              "type": "array"
+            },
+            "traits": {
+              "additionalProperties": {
                 "items": {
                   "type": "string"
                 },
-                "nullable": true,
                 "type": "array"
               },
-              "value": {
-                "description": "Value is an attribute statement value to match.",
+              "description": "traits are the traits that are granted to users who are members of the Access List.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "membership_requires": {
+          "description": "membership_requires describes the requirements for a user to be a member of the Access List. For a membership to an Access List to be effective, the user must meet the requirements of Membership_requires and must be in the members list.",
+          "nullable": true,
+          "properties": {
+            "roles": {
+              "description": "roles are the user roles that must be present for the user to obtain access.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "traits": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "traits are the traits that must be present for the user to obtain access.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "owner_grants": {
+          "description": "owner_grants describes the access granted by owners to this Access List.",
+          "nullable": true,
+          "properties": {
+            "roles": {
+              "description": "roles are the roles that are granted to users who are members of the Access List.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "traits": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "traits are the traits that are granted to users who are members of the Access List.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "owners": {
+          "description": "owners is a list of owners of the Access List.",
+          "items": {
+            "properties": {
+              "description": {
+                "description": "description is the plaintext description of the owner and why they are an owner.",
+                "type": "string"
+              },
+              "ineligible_status": {
+                "description": "ineligible_status describes if this owner is eligible or not and if not, describes how they're lacking eligibility.",
+                "x-kubernetes-int-or-string": true
+              },
+              "name": {
+                "description": "name is the username of the owner.",
                 "type": "string"
               }
             },
             "type": "object",
             "additionalProperties": false
           },
+          "nullable": true,
           "type": "array"
         },
-        "audience": {
-          "description": "Audience uniquely identifies our service provider.",
-          "type": "string"
-        },
-        "cert": {
-          "description": "Cert is the identity provider certificate PEM. IDP signs `<Response>` responses using this certificate.",
-          "type": "string"
-        },
-        "client_redirect_settings": {
-          "description": "ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.",
+        "ownership_requires": {
+          "description": "ownership_requires describes the requirements for a user to be an owner of the Access List. For ownership of an Access List to be effective, the user must meet the requirements of ownership_requires and must be in the owners list.",
           "nullable": true,
           "properties": {
-            "allowed_https_hostnames": {
-              "description": "a list of hostnames allowed for https client redirect URLs",
+            "roles": {
+              "description": "roles are the user roles that must be present for the user to obtain access.",
               "items": {
                 "type": "string"
               },
               "nullable": true,
               "type": "array"
             },
-            "insecure_allowed_cidr_ranges": {
-              "description": "a list of CIDRs allowed for HTTP or HTTPS client redirect URLs",
-              "items": {
-                "type": "string"
+            "traits": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
-              "nullable": true,
-              "type": "array"
+              "description": "traits are the traits that must be present for the user to obtain access.",
+              "type": "object"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
-        "display": {
-          "description": "Display controls how this connector is displayed.",
-          "type": "string"
-        },
-        "entity_descriptor": {
-          "description": "EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.",
-          "type": "string"
-        },
-        "entity_descriptor_url": {
-          "description": "EntityDescriptorURL is a URL that supplies a configuration XML.",
-          "type": "string"
-        },
-        "issuer": {
-          "description": "Issuer is the identity provider issuer.",
-          "type": "string"
-        },
-        "provider": {
-          "description": "Provider is the external identity provider.",
-          "type": "string"
-        },
-        "service_provider_issuer": {
-          "description": "ServiceProviderIssuer is the issuer of the service provider (Teleport).",
-          "type": "string"
-        },
-        "signing_key_pair": {
-          "description": "SigningKeyPair is an x509 key pair used to sign AuthnRequest.",
-          "nullable": true,
-          "properties": {
-            "cert": {
-              "description": "Cert is a PEM-encoded x509 certificate.",
-              "type": "string"
-            },
-            "private_key": {
-              "description": "PrivateKey is a PEM encoded x509 private key.",
-              "type": "string"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "single_logout_url": {
-          "description": "SingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out). If this is not provided, SLO is disabled.",
-          "type": "string"
-        },
-        "sso": {
-          "description": "SSO is the URL of the identity provider's SSO service.",
+        "title": {
+          "description": "title is a plaintext short description of the Access List.",
           "type": "string"
         }
       },

--- a/resources.teleport.dev/teleportgithubconnector_v3.json
+++ b/resources.teleport.dev/teleportgithubconnector_v3.json
@@ -99,7 +99,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -134,7 +134,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportloginrule_v1.json
+++ b/resources.teleport.dev/teleportloginrule_v1.json
@@ -40,30 +40,31 @@
       "additionalProperties": false
     },
     "status": {
+      "description": "Status defines the observed state of the Teleport resource",
       "properties": {
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
@@ -79,7 +80,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportloginrule_v1.json
+++ b/resources.teleport.dev/teleportloginrule_v1.json
@@ -45,7 +45,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -80,7 +80,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportoidcconnector_v3.json
+++ b/resources.teleport.dev/teleportoidcconnector_v3.json
@@ -106,6 +106,39 @@
           "format": "duration",
           "type": "string"
         },
+        "mfa": {
+          "description": "MFASettings contains settings to enable SSO MFA checks through this auth connector.",
+          "nullable": true,
+          "properties": {
+            "acr_values": {
+              "description": "AcrValues are Authentication Context Class Reference values. The meaning of the ACR value is context-specific and varies for identity providers. Some identity providers support MFA specific contexts, such Okta with its \"phr\" (phishing-resistant) ACR.",
+              "type": "string"
+            },
+            "client_id": {
+              "description": "ClientID is the OIDC OAuth app client ID.",
+              "type": "string"
+            },
+            "client_secret": {
+              "description": "ClientSecret is the OIDC OAuth app client secret.",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Enabled specified whether this OIDC connector supports MFA checks. Defaults to false.",
+              "type": "boolean"
+            },
+            "max_age": {
+              "description": "MaxAge is the amount of time in nanoseconds that an IdP session is valid for. Defaults to 0 to always force re-authentication for MFA checks. This should only be set to a non-zero value if the IdP is setup to perform MFA checks on top of active user sessions.",
+              "format": "duration",
+              "type": "string"
+            },
+            "prompt": {
+              "description": "Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "prompt": {
           "description": "Prompt is an optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.",
           "type": "string"
@@ -143,7 +176,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -178,7 +211,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportoidcconnector_v3.json
+++ b/resources.teleport.dev/teleportoidcconnector_v3.json
@@ -50,11 +50,35 @@
           "type": "array"
         },
         "client_id": {
-          "description": "ClientID is the id of the authentication client (Teleport Auth server).",
+          "description": "ClientID is the id of the authentication client (Teleport Auth Service).",
           "type": "string"
         },
+        "client_redirect_settings": {
+          "description": "ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.",
+          "nullable": true,
+          "properties": {
+            "allowed_https_hostnames": {
+              "description": "a list of hostnames allowed for https client redirect URLs",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "insecure_allowed_cidr_ranges": {
+              "description": "a list of CIDRs allowed for HTTP or HTTPS client redirect URLs",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "client_secret": {
-          "description": "ClientSecret is used to authenticate the client.",
+          "description": "ClientSecret is used to authenticate the client. This field supports secret lookup. See the operator documentation for more details.",
           "type": "string"
         },
         "display": {
@@ -114,31 +138,31 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "TeleportOIDCConnectorStatus defines the observed state of TeleportOIDCConnector",
+      "description": "Status defines the observed state of the Teleport resource",
       "properties": {
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
@@ -154,7 +178,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportoktaimportrule_v1.json
+++ b/resources.teleport.dev/teleportoktaimportrule_v1.json
@@ -93,30 +93,31 @@
       "additionalProperties": false
     },
     "status": {
+      "description": "Status defines the observed state of the Teleport resource",
       "properties": {
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
@@ -132,7 +133,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportoktaimportrule_v1.json
+++ b/resources.teleport.dev/teleportoktaimportrule_v1.json
@@ -98,7 +98,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -133,7 +133,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportopenssheiceserverv2_v1.json
+++ b/resources.teleport.dev/teleportopenssheiceserverv2_v1.json
@@ -161,7 +161,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -196,7 +196,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportopenssheiceserverv2_v1.json
+++ b/resources.teleport.dev/teleportopenssheiceserverv2_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "GithubConnector is the Schema for the githubconnectors API",
+  "description": "OpenSSHEICEServerV2 is the Schema for the openssheiceserversv2 API",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,81 +13,143 @@
       "type": "object"
     },
     "spec": {
-      "description": "GithubConnector resource definition v3 from Teleport",
+      "description": "OpenSSHEICEServer resource definition v2 from Teleport",
       "properties": {
-        "api_endpoint_url": {
-          "description": "APIEndpointURL is the URL of the API endpoint of the Github instance this connector is for.",
+        "addr": {
+          "description": "Addr is a host:port address where this server can be reached.",
           "type": "string"
         },
-        "client_id": {
-          "description": "ClientID is the Github OAuth app client ID.",
-          "type": "string"
-        },
-        "client_redirect_settings": {
-          "description": "ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.",
+        "cloud_metadata": {
+          "description": "CloudMetadata contains info about the cloud instance the server is running on, if any.",
           "nullable": true,
           "properties": {
-            "allowed_https_hostnames": {
-              "description": "a list of hostnames allowed for https client redirect URLs",
-              "items": {
-                "type": "string"
-              },
+            "aws": {
+              "description": "AWSInfo contains attributes to match to an EC2 instance.",
               "nullable": true,
-              "type": "array"
-            },
-            "insecure_allowed_cidr_ranges": {
-              "description": "a list of CIDRs allowed for HTTP or HTTPS client redirect URLs",
-              "items": {
-                "type": "string"
+              "properties": {
+                "account_id": {
+                  "description": "AccountID is an AWS account ID.",
+                  "type": "string"
+                },
+                "instance_id": {
+                  "description": "InstanceID is an EC2 instance ID.",
+                  "type": "string"
+                },
+                "integration": {
+                  "description": "Integration is the integration name that added this Node. When connecting to it, it will use this integration to issue AWS API calls in order to set up the connection. This includes sending an SSH Key and then opening a tunnel (EC2 Instance Connect Endpoint) so Teleport can connect to it.",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "Region is the AWS EC2 Instance Region.",
+                  "type": "string"
+                },
+                "subnet_id": {
+                  "description": "SubnetID is the Subnet ID in use by the instance.",
+                  "type": "string"
+                },
+                "vpc_id": {
+                  "description": "VPCID is the AWS VPC ID where the Instance is running.",
+                  "type": "string"
+                }
               },
-              "nullable": true,
-              "type": "array"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
         },
-        "client_secret": {
-          "description": "ClientSecret is the Github OAuth app client secret. This field supports secret lookup. See the operator documentation for more details.",
+        "hostname": {
+          "description": "Hostname is server hostname",
           "type": "string"
         },
-        "display": {
-          "description": "Display is the connector display name.",
+        "peer_addr": {
+          "description": "PeerAddr is the address a proxy server is reachable at by its peer proxies.",
           "type": "string"
         },
-        "endpoint_url": {
-          "description": "EndpointURL is the URL of the GitHub instance this connector is for.",
-          "type": "string"
-        },
-        "redirect_url": {
-          "description": "RedirectURL is the authorization callback URL.",
-          "type": "string"
-        },
-        "teams_to_roles": {
-          "description": "TeamsToRoles maps Github team memberships onto allowed roles.",
+        "proxy_ids": {
+          "description": "ProxyIDs is a list of proxy IDs this server is expected to be connected to.",
           "items": {
-            "properties": {
-              "organization": {
-                "description": "Organization is a Github organization a user belongs to.",
-                "type": "string"
-              },
-              "roles": {
-                "description": "Roles is a list of allowed logins for this org/team.",
-                "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "public_addrs": {
+          "description": "PublicAddrs is a list of public addresses where this server can be reached.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "rotation": {
+          "description": "Rotation specifies server rotation",
+          "properties": {
+            "current_id": {
+              "description": "CurrentID is the ID of the rotation operation to differentiate between rotation attempts.",
+              "type": "string"
+            },
+            "grace_period": {
+              "description": "GracePeriod is a period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.",
+              "format": "duration",
+              "type": "string"
+            },
+            "last_rotated": {
+              "description": "LastRotated specifies the last time of the completed rotation.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode sets manual or automatic rotation mode.",
+              "type": "string"
+            },
+            "phase": {
+              "description": "Phase is the current rotation phase.",
+              "type": "string"
+            },
+            "schedule": {
+              "description": "Schedule is a rotation schedule - used in automatic mode to switch between phases.",
+              "properties": {
+                "standby": {
+                  "description": "Standby specifies time to switch to the \"Standby\" phase.",
+                  "format": "date-time",
                   "type": "string"
                 },
-                "nullable": true,
-                "type": "array"
+                "update_clients": {
+                  "description": "UpdateClients specifies time to switch to the \"Update clients\" phase",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "update_servers": {
+                  "description": "UpdateServers specifies time to switch to the \"Update servers\" phase.",
+                  "format": "date-time",
+                  "type": "string"
+                }
               },
-              "team": {
-                "description": "Team is a team within the organization a user belongs to.",
-                "type": "string"
-              }
+              "type": "object",
+              "additionalProperties": false
             },
-            "type": "object",
-            "additionalProperties": false
+            "started": {
+              "description": "Started is set to the time when rotation has been started in case if the state of the rotation is \"in_progress\".",
+              "format": "date-time",
+              "type": "string"
+            },
+            "state": {
+              "description": "State could be one of \"init\" or \"in_progress\".",
+              "type": "string"
+            }
           },
-          "type": "array"
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_tunnel": {
+          "description": "UseTunnel indicates that connections to this server should occur over a reverse tunnel.",
+          "type": "boolean"
+        },
+        "version": {
+          "description": "TeleportVersion is the teleport version that the server is running on",
+          "type": "string"
         }
       },
       "type": "object",

--- a/resources.teleport.dev/teleportopensshserverv2_v1.json
+++ b/resources.teleport.dev/teleportopensshserverv2_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "GithubConnector is the Schema for the githubconnectors API",
+  "description": "OpenSSHServerV2 is the Schema for the opensshserversv2 API",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,81 +13,143 @@
       "type": "object"
     },
     "spec": {
-      "description": "GithubConnector resource definition v3 from Teleport",
+      "description": "OpenSSHServer resource definition v2 from Teleport",
       "properties": {
-        "api_endpoint_url": {
-          "description": "APIEndpointURL is the URL of the API endpoint of the Github instance this connector is for.",
+        "addr": {
+          "description": "Addr is a host:port address where this server can be reached.",
           "type": "string"
         },
-        "client_id": {
-          "description": "ClientID is the Github OAuth app client ID.",
-          "type": "string"
-        },
-        "client_redirect_settings": {
-          "description": "ClientRedirectSettings defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.",
+        "cloud_metadata": {
+          "description": "CloudMetadata contains info about the cloud instance the server is running on, if any.",
           "nullable": true,
           "properties": {
-            "allowed_https_hostnames": {
-              "description": "a list of hostnames allowed for https client redirect URLs",
-              "items": {
-                "type": "string"
-              },
+            "aws": {
+              "description": "AWSInfo contains attributes to match to an EC2 instance.",
               "nullable": true,
-              "type": "array"
-            },
-            "insecure_allowed_cidr_ranges": {
-              "description": "a list of CIDRs allowed for HTTP or HTTPS client redirect URLs",
-              "items": {
-                "type": "string"
+              "properties": {
+                "account_id": {
+                  "description": "AccountID is an AWS account ID.",
+                  "type": "string"
+                },
+                "instance_id": {
+                  "description": "InstanceID is an EC2 instance ID.",
+                  "type": "string"
+                },
+                "integration": {
+                  "description": "Integration is the integration name that added this Node. When connecting to it, it will use this integration to issue AWS API calls in order to set up the connection. This includes sending an SSH Key and then opening a tunnel (EC2 Instance Connect Endpoint) so Teleport can connect to it.",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "Region is the AWS EC2 Instance Region.",
+                  "type": "string"
+                },
+                "subnet_id": {
+                  "description": "SubnetID is the Subnet ID in use by the instance.",
+                  "type": "string"
+                },
+                "vpc_id": {
+                  "description": "VPCID is the AWS VPC ID where the Instance is running.",
+                  "type": "string"
+                }
               },
-              "nullable": true,
-              "type": "array"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
         },
-        "client_secret": {
-          "description": "ClientSecret is the Github OAuth app client secret. This field supports secret lookup. See the operator documentation for more details.",
+        "hostname": {
+          "description": "Hostname is server hostname",
           "type": "string"
         },
-        "display": {
-          "description": "Display is the connector display name.",
+        "peer_addr": {
+          "description": "PeerAddr is the address a proxy server is reachable at by its peer proxies.",
           "type": "string"
         },
-        "endpoint_url": {
-          "description": "EndpointURL is the URL of the GitHub instance this connector is for.",
-          "type": "string"
-        },
-        "redirect_url": {
-          "description": "RedirectURL is the authorization callback URL.",
-          "type": "string"
-        },
-        "teams_to_roles": {
-          "description": "TeamsToRoles maps Github team memberships onto allowed roles.",
+        "proxy_ids": {
+          "description": "ProxyIDs is a list of proxy IDs this server is expected to be connected to.",
           "items": {
-            "properties": {
-              "organization": {
-                "description": "Organization is a Github organization a user belongs to.",
-                "type": "string"
-              },
-              "roles": {
-                "description": "Roles is a list of allowed logins for this org/team.",
-                "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "public_addrs": {
+          "description": "PublicAddrs is a list of public addresses where this server can be reached.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "rotation": {
+          "description": "Rotation specifies server rotation",
+          "properties": {
+            "current_id": {
+              "description": "CurrentID is the ID of the rotation operation to differentiate between rotation attempts.",
+              "type": "string"
+            },
+            "grace_period": {
+              "description": "GracePeriod is a period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.",
+              "format": "duration",
+              "type": "string"
+            },
+            "last_rotated": {
+              "description": "LastRotated specifies the last time of the completed rotation.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode sets manual or automatic rotation mode.",
+              "type": "string"
+            },
+            "phase": {
+              "description": "Phase is the current rotation phase.",
+              "type": "string"
+            },
+            "schedule": {
+              "description": "Schedule is a rotation schedule - used in automatic mode to switch between phases.",
+              "properties": {
+                "standby": {
+                  "description": "Standby specifies time to switch to the \"Standby\" phase.",
+                  "format": "date-time",
                   "type": "string"
                 },
-                "nullable": true,
-                "type": "array"
+                "update_clients": {
+                  "description": "UpdateClients specifies time to switch to the \"Update clients\" phase",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "update_servers": {
+                  "description": "UpdateServers specifies time to switch to the \"Update servers\" phase.",
+                  "format": "date-time",
+                  "type": "string"
+                }
               },
-              "team": {
-                "description": "Team is a team within the organization a user belongs to.",
-                "type": "string"
-              }
+              "type": "object",
+              "additionalProperties": false
             },
-            "type": "object",
-            "additionalProperties": false
+            "started": {
+              "description": "Started is set to the time when rotation has been started in case if the state of the rotation is \"in_progress\".",
+              "format": "date-time",
+              "type": "string"
+            },
+            "state": {
+              "description": "State could be one of \"init\" or \"in_progress\".",
+              "type": "string"
+            }
           },
-          "type": "array"
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_tunnel": {
+          "description": "UseTunnel indicates that connections to this server should occur over a reverse tunnel.",
+          "type": "boolean"
+        },
+        "version": {
+          "description": "TeleportVersion is the teleport version that the server is running on",
+          "type": "string"
         }
       },
       "type": "object",

--- a/resources.teleport.dev/teleportopensshserverv2_v1.json
+++ b/resources.teleport.dev/teleportopensshserverv2_v1.json
@@ -161,7 +161,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -196,7 +196,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportprovisiontoken_v2.json
+++ b/resources.teleport.dev/teleportprovisiontoken_v2.json
@@ -466,7 +466,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -501,7 +501,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportprovisiontoken_v2.json
+++ b/resources.teleport.dev/teleportprovisiontoken_v2.json
@@ -36,7 +36,7 @@
                 "type": "array"
               },
               "aws_role": {
-                "description": "AWSRole is used for the EC2 join method and is the the ARN of the AWS role that the auth server will assume in order to call the ec2 API.",
+                "description": "AWSRole is used for the EC2 join method and is the ARN of the AWS role that the Auth Service will assume in order to call the ec2 API.",
                 "type": "string"
               }
             },
@@ -192,7 +192,11 @@
               "type": "array"
             },
             "enterprise_server_host": {
-              "description": "EnterpriseServerHost allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Server.",
+              "description": "EnterpriseServerHost allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Service.",
+              "type": "string"
+            },
+            "enterprise_slug": {
+              "description": "EnterpriseSlug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.",
               "type": "string"
             }
           },
@@ -207,8 +211,20 @@
               "description": "Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.",
               "items": {
                 "properties": {
+                  "ci_config_ref_uri": {
+                    "type": "string"
+                  },
+                  "ci_config_sha": {
+                    "type": "string"
+                  },
+                  "deployment_tier": {
+                    "type": "string"
+                  },
                   "environment": {
                     "type": "string"
+                  },
+                  "environment_protected": {
+                    "type": "boolean"
                   },
                   "namespace_path": {
                     "type": "string"
@@ -219,13 +235,28 @@
                   "project_path": {
                     "type": "string"
                   },
+                  "project_visibility": {
+                    "type": "string"
+                  },
                   "ref": {
                     "type": "string"
+                  },
+                  "ref_protected": {
+                    "type": "boolean"
                   },
                   "ref_type": {
                     "type": "string"
                   },
                   "sub": {
+                    "type": "string"
+                  },
+                  "user_email": {
+                    "type": "string"
+                  },
+                  "user_id": {
+                    "type": "string"
+                  },
+                  "user_login": {
                     "type": "string"
                   }
                 },
@@ -244,7 +275,7 @@
           "additionalProperties": false
         },
         "join_method": {
-          "description": "JoinMethod is the joining method required in order to use this token. Supported joining methods include \"token\", \"ec2\", and \"iam\".",
+          "description": "JoinMethod is the joining method required in order to use this token. Supported joining methods include: azure, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm",
           "type": "string"
         },
         "kubernetes": {
@@ -292,6 +323,41 @@
           "nullable": true,
           "type": "array"
         },
+        "spacelift": {
+          "description": "Spacelift allows the configuration of options specific to the \"spacelift\" join method.",
+          "nullable": true,
+          "properties": {
+            "allow": {
+              "description": "Allow is a list of Rules, nodes using this token must match one allow rule to use this token.",
+              "items": {
+                "properties": {
+                  "caller_id": {
+                    "type": "string"
+                  },
+                  "caller_type": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": "string"
+                  },
+                  "space_id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "hostname": {
+              "description": "Hostname is the hostname of the Spacelift tenant that tokens will originate from. E.g `example.app.spacelift.io`",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "suggested_agent_matcher_labels": {
           "additionalProperties": {
             "x-kubernetes-preserve-unknown-fields": true
@@ -305,37 +371,121 @@
           },
           "description": "SuggestedLabels is a set of labels that resources should set when using this token to enroll themselves in the cluster. Currently, only node-join scripts create a configuration according to the suggestion.",
           "type": "object"
+        },
+        "terraform_cloud": {
+          "description": "TerraformCloud allows the configuration of options specific to the \"terraform_cloud\" join method.",
+          "nullable": true,
+          "properties": {
+            "allow": {
+              "description": "Allow is a list of Rules, nodes using this token must match one allow rule to use this token.",
+              "items": {
+                "properties": {
+                  "organization_id": {
+                    "type": "string"
+                  },
+                  "organization_name": {
+                    "type": "string"
+                  },
+                  "project_id": {
+                    "type": "string"
+                  },
+                  "project_name": {
+                    "type": "string"
+                  },
+                  "run_phase": {
+                    "type": "string"
+                  },
+                  "workspace_id": {
+                    "type": "string"
+                  },
+                  "workspace_name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "audience": {
+              "description": "Audience is the JWT audience as configured in the TFC_WORKLOAD_IDENTITY_AUDIENCE(_$TAG) variable in Terraform Cloud. If unset, defaults to the Teleport cluster name. For example, if `TFC_WORKLOAD_IDENTITY_AUDIENCE_TELEPORT=foo` is set in Terraform Cloud, this value should be `foo`. If the variable is set to match the cluster name, it does not need to be set here.",
+              "type": "string"
+            },
+            "hostname": {
+              "description": "Hostname is the hostname of the Terraform Enterprise instance expected to issue JWTs allowed by this token. This may be unset for regular Terraform Cloud use, in which case it will be assumed to be `app.terraform.io`. Otherwise, it must both match the `iss` (issuer) field included in JWTs, and provide standard JWKS endpoints.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tpm": {
+          "description": "TPM allows the configuration of options specific to the \"tpm\" join method.",
+          "nullable": true,
+          "properties": {
+            "allow": {
+              "description": "Allow is a list of Rules, the presented delegated identity must match one allow rule to permit joining.",
+              "items": {
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "ek_certificate_serial": {
+                    "type": "string"
+                  },
+                  "ek_public_hash": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "ekcert_allowed_cas": {
+              "description": "EKCertAllowedCAs is a list of CA certificates that will be used to validate TPM EKCerts. When specified, joining TPMs must present an EKCert signed by one of the specified CAs. TPMs that do not present an EKCert will be not permitted to join. When unspecified, TPMs will be allowed to join with either an EKCert or an EKPubHash.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "type": "object",
       "additionalProperties": false
     },
     "status": {
-      "description": "TeleportProvisionTokenStatus defines the observed state of TeleportProvisionToken",
+      "description": "Status defines the observed state of the Teleport resource",
       "properties": {
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
@@ -351,7 +501,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportrole_v5.json
+++ b/resources.teleport.dev/teleportrole_v5.json
@@ -18,6 +18,22 @@
         "allow": {
           "description": "Allow is the set of conditions evaluated to grant access.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -261,7 +277,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -344,6 +360,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -606,6 +636,22 @@
         "deny": {
           "description": "Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -849,7 +895,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -932,6 +978,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -1393,7 +1453,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -1428,7 +1488,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportrole_v6.json
+++ b/resources.teleport.dev/teleportrole_v6.json
@@ -18,6 +18,22 @@
         "allow": {
           "description": "Allow is the set of conditions evaluated to grant access.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -261,7 +277,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -344,6 +360,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -606,6 +636,22 @@
         "deny": {
           "description": "Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -849,7 +895,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -932,6 +978,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -1393,7 +1453,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -1428,7 +1488,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportrole_v6.json
+++ b/resources.teleport.dev/teleportrole_v6.json
@@ -75,6 +75,31 @@
               "nullable": true,
               "type": "array"
             },
+            "db_permissions": {
+              "description": "DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.",
+              "items": {
+                "properties": {
+                  "match": {
+                    "additionalProperties": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "description": "Match is a list of object labels that must be matched for the permission to be granted.",
+                    "type": "object"
+                  },
+                  "permissions": {
+                    "description": "Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "db_roles": {
               "description": "DatabaseRoles is a list of databases roles for automatic user creation.",
               "items": {
@@ -246,6 +271,14 @@
                   "namespace": {
                     "description": "Namespace is the resource namespace. It supports wildcards.",
                     "type": "string"
+                  },
+                  "verbs": {
+                    "description": "Verbs are the allowed Kubernetes verbs for the following resource.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
                   }
                 },
                 "type": "object",
@@ -290,7 +323,7 @@
                     },
                     "type": "array"
                   },
-                  "description": "Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via {{external.trait_name}} style substitutions.",
+                  "description": "Annotations is a collection of annotations to be programmatically appended to pending Access Requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.",
                   "type": "object"
                 },
                 "claims_to_roles": {
@@ -514,6 +547,37 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "type": "array"
+            },
+            "spiffe": {
+              "description": "SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.",
+              "items": {
+                "properties": {
+                  "dns_sans": {
+                    "description": "DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "ip_sans": {
+                    "description": "IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "path": {
+                    "description": "Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\\/svc\\/foo\\/.*\\/bar$ would match /svc/foo/baz/bar",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
               "type": "array"
             },
             "windows_desktop_labels": {
@@ -599,6 +663,31 @@
               "nullable": true,
               "type": "array"
             },
+            "db_permissions": {
+              "description": "DatabasePermissions specifies a set of permissions that will be granted to the database user when using automatic database user provisioning.",
+              "items": {
+                "properties": {
+                  "match": {
+                    "additionalProperties": {
+                      "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "description": "Match is a list of object labels that must be matched for the permission to be granted.",
+                    "type": "object"
+                  },
+                  "permissions": {
+                    "description": "Permission is the list of string representations of the permission to be given, e.g. SELECT, INSERT, UPDATE, ...",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "db_roles": {
               "description": "DatabaseRoles is a list of databases roles for automatic user creation.",
               "items": {
@@ -770,6 +859,14 @@
                   "namespace": {
                     "description": "Namespace is the resource namespace. It supports wildcards.",
                     "type": "string"
+                  },
+                  "verbs": {
+                    "description": "Verbs are the allowed Kubernetes verbs for the following resource.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
                   }
                 },
                 "type": "object",
@@ -814,7 +911,7 @@
                     },
                     "type": "array"
                   },
-                  "description": "Annotations is a collection of annotations to be programmatically appended to pending access requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via {{external.trait_name}} style substitutions.",
+                  "description": "Annotations is a collection of annotations to be programmatically appended to pending Access Requests at the time of their creation. These annotations serve as a mechanism to propagate extra information to plugins.  Since these annotations support variable interpolation syntax, they also offer a mechanism for forwarding claims from an external identity provider, to a plugin via `{{external.trait_name}}` style substitutions.",
                   "type": "object"
                 },
                 "claims_to_roles": {
@@ -1040,6 +1137,37 @@
               },
               "type": "array"
             },
+            "spiffe": {
+              "description": "SPIFFE is used to allow or deny access to a role holder to generating a SPIFFE SVID.",
+              "items": {
+                "properties": {
+                  "dns_sans": {
+                    "description": "DNSSANs specifies matchers for the SPIFFE ID DNS SANs.  Each requested DNS SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: *.example.com would match foo.example.com",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "ip_sans": {
+                    "description": "IPSANs specifies matchers for the SPIFFE ID IP SANs.  Each requested IP SAN is compared against all matchers configured and if any match, the condition is considered to be met.  The matchers should be specified using CIDR notation, it supports IPv4 and IPv6.  Examples: - 10.0.0.0/24 would match 10.0.0.0 to 10.255.255.255 - 10.0.0.42/32 would match only 10.0.0.42",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "path": {
+                    "description": "Path specifies a matcher for the SPIFFE ID path. It should not include the trust domain and should start with a leading slash.  The matcher by default allows '*' to be used to indicate zero or more of any character. Prepend '^' and append '$' to instead switch to matching using the Go regex syntax.  Example: - /svc/foo/*/bar would match /svc/foo/baz/bar - ^\\/svc\\/foo\\/.*\\/bar$ would match /svc/foo/baz/bar",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
+              "type": "array"
+            },
             "windows_desktop_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -1071,7 +1199,7 @@
               "items": {
                 "properties": {
                   "mode": {
-                    "description": "Mode is the type of extension to be used -- currently critical-option is not supported",
+                    "description": "Mode is the type of extension to be used -- currently critical-option is not supported. 0 is \"extension\".",
                     "x-kubernetes-int-or-string": true
                   },
                   "name": {
@@ -1079,7 +1207,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "description": "Type represents the certificate type being extended, only ssh is supported at this time.",
+                    "description": "Type represents the certificate type being extended, only ssh is supported at this time. 0 is \"ssh\".",
                     "x-kubernetes-int-or-string": true
                   },
                   "value": {
@@ -1106,16 +1234,24 @@
               "description": "CreateDatabaseUser enabled automatic database user creation.",
               "type": "boolean"
             },
+            "create_db_user_mode": {
+              "description": "CreateDatabaseUserMode allows users to be automatically created on a database when not set to off. 0 is \"unspecified\", 1 is \"off\", 2 is \"keep\", 3 is \"best_effort_drop\".",
+              "x-kubernetes-int-or-string": true
+            },
             "create_desktop_user": {
               "description": "CreateDesktopUser allows users to be automatically created on a Windows desktop",
               "type": "boolean"
             },
             "create_host_user": {
-              "description": "CreateHostUser allows users to be automatically created on a host",
+              "description": "Deprecated: use CreateHostUserMode instead.",
               "type": "boolean"
             },
+            "create_host_user_default_shell": {
+              "description": "CreateHostUserDefaultShell is used to configure the default shell for newly provisioned host users.",
+              "type": "string"
+            },
             "create_host_user_mode": {
-              "description": "CreateHostUserMode allows users to be automatically created on a host when not set to off",
+              "description": "CreateHostUserMode allows users to be automatically created on a host when not set to off. 0 is \"unspecified\"; 1 is \"off\"; 2 is \"drop\" (removed for v15 and above), 3 is \"keep\"; 4 is \"insecure-drop\".",
               "x-kubernetes-int-or-string": true
             },
             "desktop_clipboard": {
@@ -1127,7 +1263,7 @@
               "type": "boolean"
             },
             "device_trust_mode": {
-              "description": "DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode. Reserved for future use, not yet used by Teleport.",
+              "description": "DeviceTrustMode is the device authorization mode used for the resources associated with the role. See DeviceTrust.Mode.",
               "type": "string"
             },
             "disconnect_expired_cert": {
@@ -1190,6 +1326,11 @@
               "format": "int64",
               "type": "integer"
             },
+            "mfa_verification_interval": {
+              "description": "MFAVerificationInterval optionally defines the maximum duration that can elapse between successive MFA verifications. This variable is used to ensure that users are periodically prompted to verify their identity, enhancing security by preventing prolonged sessions without re-authentication when using tsh proxy * derivatives. It's only effective if the session requires MFA. If not set, defaults to `max_session_ttl`.",
+              "format": "duration",
+              "type": "string"
+            },
             "permit_x11_forwarding": {
               "description": "PermitX11Forwarding authorizes use of X11 forwarding.",
               "type": "boolean"
@@ -1223,15 +1364,15 @@
               "additionalProperties": false
             },
             "request_access": {
-              "description": "RequestAccess defines the access request strategy (optional|note|always) where optional is the default.",
+              "description": "RequestAccess defines the request strategy (optional|note|always) where optional is the default.",
               "type": "string"
             },
             "request_prompt": {
-              "description": "RequestPrompt is an optional message which tells users what they aught to",
+              "description": "RequestPrompt is an optional message which tells users what they aught to request.",
               "type": "string"
             },
             "require_session_mfa": {
-              "description": "RequireMFAType is the type of MFA requirement enforced for this user.",
+              "description": "RequireMFAType is the type of MFA requirement enforced for this user. 0 is \"OFF\", 1 is \"SESSION\", 2 is \"SESSION_AND_HARDWARE_KEY\", 3 is \"HARDWARE_KEY_TOUCH\", 4 is \"HARDWARE_KEY_PIN\", 5 is \"HARDWARE_KEY_TOUCH_AND_PIN\".",
               "x-kubernetes-int-or-string": true
             },
             "ssh_file_copy": {
@@ -1247,31 +1388,31 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "TeleportRoleStatus defines the observed state of TeleportRole",
+      "description": "Status defines the observed state of the Teleport resource",
       "properties": {
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
@@ -1287,7 +1428,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportrolev6_v1.json
+++ b/resources.teleport.dev/teleportrolev6_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "Role is the Schema for the roles API",
+  "description": "RoleV6 is the Schema for the rolesv6 API",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,7 +13,7 @@
       "type": "object"
     },
     "spec": {
-      "description": "Role resource definition v5 from Teleport",
+      "description": "Role resource definition v6 from Teleport",
       "properties": {
         "allow": {
           "description": "Allow is the set of conditions evaluated to grant access.",

--- a/resources.teleport.dev/teleportrolev6_v1.json
+++ b/resources.teleport.dev/teleportrolev6_v1.json
@@ -18,6 +18,22 @@
         "allow": {
           "description": "Allow is the set of conditions evaluated to grant access.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -261,7 +277,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -344,6 +360,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -606,6 +636,22 @@
         "deny": {
           "description": "Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -849,7 +895,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -932,6 +978,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -1393,7 +1453,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -1428,7 +1488,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportrolev7_v1.json
+++ b/resources.teleport.dev/teleportrolev7_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "Role is the Schema for the roles API",
+  "description": "RoleV7 is the Schema for the rolesv7 API",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,7 +13,7 @@
       "type": "object"
     },
     "spec": {
-      "description": "Role resource definition v5 from Teleport",
+      "description": "Role resource definition v7 from Teleport",
       "properties": {
         "allow": {
           "description": "Allow is the set of conditions evaluated to grant access.",

--- a/resources.teleport.dev/teleportrolev7_v1.json
+++ b/resources.teleport.dev/teleportrolev7_v1.json
@@ -18,6 +18,22 @@
         "allow": {
           "description": "Allow is the set of conditions evaluated to grant access.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -261,7 +277,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -344,6 +360,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -606,6 +636,22 @@
         "deny": {
           "description": "Deny is the set of conditions evaluated to deny access. Deny takes priority over allow.",
           "properties": {
+            "account_assignments": {
+              "description": "AccountAssignments holds the list of account assignments affected by this condition.",
+              "items": {
+                "properties": {
+                  "account": {
+                    "type": "string"
+                  },
+                  "permission_set": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "app_labels": {
               "additionalProperties": {
                 "x-kubernetes-preserve-unknown-fields": true
@@ -849,7 +895,7 @@
               "items": {
                 "properties": {
                   "kind": {
-                    "description": "Kind specifies the Kubernetes Resource type. At the moment only \"pod\" is supported.",
+                    "description": "Kind specifies the Kubernetes Resource type.",
                     "type": "string"
                   },
                   "name": {
@@ -932,6 +978,20 @@
                       },
                       "value": {
                         "description": "Value is a claim value to match.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "kubernetes_resources": {
+                  "description": "kubernetes_resources can optionally enforce a requester to request only certain kinds of kube resources. Eg: Users can make request to either a resource kind \"kube_cluster\" or any of its subresources like \"namespaces\". This field can be defined such that it prevents a user from requesting \"kube_cluster\" and enforce requesting any of its subresources.",
+                  "items": {
+                    "properties": {
+                      "kind": {
+                        "description": "kind specifies the Kubernetes Resource type.",
                         "type": "string"
                       }
                     },
@@ -1393,7 +1453,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -1428,7 +1488,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportsamlconnector_v2.json
+++ b/resources.teleport.dev/teleportsamlconnector_v2.json
@@ -109,9 +109,49 @@
           "description": "EntityDescriptorURL is a URL that supplies a configuration XML.",
           "type": "string"
         },
+        "force_authn": {
+          "description": "ForceAuthn specified whether re-authentication should be forced on login. UNSPECIFIED is treated as NO.",
+          "x-kubernetes-int-or-string": true
+        },
         "issuer": {
           "description": "Issuer is the identity provider issuer.",
           "type": "string"
+        },
+        "mfa": {
+          "description": "MFASettings contains settings to enable SSO MFA checks through this auth connector.",
+          "nullable": true,
+          "properties": {
+            "cert": {
+              "description": "Cert is the identity provider certificate PEM. IDP signs `<Response>` responses using this certificate.",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Enabled specified whether this SAML connector supports MFA checks. Defaults to false.",
+              "type": "boolean"
+            },
+            "entity_descriptor": {
+              "description": "EntityDescriptor is XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements. Usually set from EntityDescriptorUrl.",
+              "type": "string"
+            },
+            "entity_descriptor_url": {
+              "description": "EntityDescriptorUrl is a URL that supplies a configuration XML.",
+              "type": "string"
+            },
+            "force_authn": {
+              "description": "ForceAuthn specified whether re-authentication should be forced for MFA checks. UNSPECIFIED is treated as YES to always re-authentication for MFA checks. This should only be set to NO if the IdP is setup to perform MFA checks on top of active user sessions.",
+              "x-kubernetes-int-or-string": true
+            },
+            "issuer": {
+              "description": "Issuer is the identity provider issuer. Usually set from EntityDescriptor.",
+              "type": "string"
+            },
+            "sso": {
+              "description": "SSO is the URL of the identity provider's SSO service. Usually set from EntityDescriptor.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "provider": {
           "description": "Provider is the external identity provider.",
@@ -155,7 +195,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -190,7 +230,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportuser_v2.json
+++ b/resources.teleport.dev/teleportuser_v2.json
@@ -23,6 +23,10 @@
                 "description": "ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'",
                 "type": "string"
               },
+              "samlSingleLogoutUrl": {
+                "description": "SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.",
+                "type": "string"
+              },
               "username": {
                 "description": "Username is username supplied by external identity provider",
                 "type": "string"
@@ -39,6 +43,10 @@
             "properties": {
               "connector_id": {
                 "description": "ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'",
+                "type": "string"
+              },
+              "samlSingleLogoutUrl": {
+                "description": "SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.",
                 "type": "string"
               },
               "username": {
@@ -67,6 +75,10 @@
                 "description": "ConnectorID is id of registered OIDC connector, e.g. 'google-example.com'",
                 "type": "string"
               },
+              "samlSingleLogoutUrl": {
+                "description": "SAMLSingleLogoutURL is the SAML Single log-out URL to initiate SAML SLO (single log-out), if applicable.",
+                "type": "string"
+              },
               "username": {
                 "description": "Username is username supplied by external identity provider",
                 "type": "string"
@@ -88,7 +100,7 @@
           "type": "object"
         },
         "trusted_device_ids": {
-          "description": "TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user. Managed by the Device Trust subsystem, avoid manual edits.",
+          "description": "TrustedDeviceIDs contains the IDs of trusted devices enrolled by the user.  Note that SSO users are transient and thus may contain an empty TrustedDeviceIDs field, even though the user->device association exists under the Device Trust subsystem. Do not rely on this field to determine device associations or ownership, it exists for legacy/informative purposes only.  Managed by the Device Trust subsystem, avoid manual edits.",
           "items": {
             "type": "string"
           },
@@ -100,31 +112,31 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "TeleportUserStatus defines the observed state of TeleportUser",
+      "description": "Status defines the observed state of the Teleport resource",
       "properties": {
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
@@ -140,7 +152,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"

--- a/resources.teleport.dev/teleportuser_v2.json
+++ b/resources.teleport.dev/teleportuser_v2.json
@@ -117,7 +117,7 @@
         "conditions": {
           "description": "Conditions represent the latest available observations of an object's state",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "properties": {
               "lastTransitionTime": {
                 "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
@@ -152,7 +152,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"


### PR DESCRIPTION
Generated from [v17.0.1](https://github.com/gravitational/teleport/tree/v17.0.1/integrations/operator/config/crd/bases):

```bash
cd resources.teleport.dev
TELEPORT_VERSION=17.0.1
OPENAPI2JSONSCHEMA=https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py
curl -s -L https://github.com/gravitational/teleport/archive/refs/tags/v$TELEPORT_VERSION.tar.gz | tar xvz
python3 <(curl "$OPENAPI2JSONSCHEMA") "teleport-$TELEPORT_VERSION"/integrations/operator/config/crd/bases/*.yaml
rm -rf "teleport-$TELEPORT_VERSION"
```