### PR TITLE
Update opentelemetry.io schemas to the latest chart 0.74.3

### DIFF
--- a/opentelemetry.io/instrumentation_v1alpha1.json
+++ b/opentelemetry.io/instrumentation_v1alpha1.json
@@ -30,6 +30,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -93,6 +94,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -139,6 +141,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -202,6 +205,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -237,6 +241,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -305,6 +312,15 @@
           "type": "object",
           "additionalProperties": false
         },
+        "defaults": {
+          "properties": {
+            "useLabelsForResourceAttributes": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "dotnet": {
           "properties": {
             "env": {
@@ -324,6 +340,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -387,6 +404,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -422,6 +440,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -504,6 +525,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -567,6 +589,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -621,6 +644,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -684,6 +708,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -719,6 +744,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -803,6 +831,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -866,6 +895,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -920,6 +950,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -1004,6 +1037,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1067,6 +1101,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1113,6 +1148,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1176,6 +1212,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1211,6 +1248,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -1295,6 +1335,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1358,6 +1399,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1393,6 +1435,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -1493,6 +1538,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1556,6 +1602,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -1591,6 +1638,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },

--- a/opentelemetry.io/opampbridge_v1alpha1.json
+++ b/opentelemetry.io/opampbridge_v1alpha1.json
@@ -33,7 +33,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -43,7 +44,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -58,7 +60,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -68,7 +71,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -87,7 +91,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "properties": {
@@ -107,7 +112,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -117,7 +123,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -132,7 +139,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -142,14 +150,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -185,7 +195,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -195,7 +206,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -237,7 +249,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -247,7 +260,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -264,7 +278,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -288,7 +303,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -308,7 +324,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -318,7 +335,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -360,7 +378,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -370,7 +389,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -387,7 +407,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -399,7 +420,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -427,7 +449,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -437,7 +460,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -479,7 +503,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -489,7 +514,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -506,7 +532,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -530,7 +557,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -550,7 +578,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -560,7 +589,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -602,7 +632,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -612,7 +643,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -629,7 +661,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -641,7 +674,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -686,6 +720,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -749,6 +784,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -781,6 +817,7 @@
               "configMapRef": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -797,6 +834,7 @@
               "secretRef": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -828,6 +866,15 @@
         "imagePullPolicy": {
           "type": "string"
         },
+        "ipFamilies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ipFamilyPolicy": {
+          "type": "string"
+        },
         "nodeSelector": {
           "additionalProperties": {
             "type": "string"
@@ -840,8 +887,59 @@
           },
           "type": "object"
         },
+        "podDnsConfig": {
+          "properties": {
+            "nameservers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "options": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "searches": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "podSecurityContext": {
           "properties": {
+            "appArmorProfile": {
+              "properties": {
+                "localhostProfile": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "fsGroup": {
               "format": "int64",
               "type": "integer"
@@ -898,7 +996,11 @@
                 "format": "int64",
                 "type": "integer"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "supplementalGroupsPolicy": {
+              "type": "string"
             },
             "sysctls": {
               "items": {
@@ -917,7 +1019,8 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "windowsOptions": {
               "properties": {
@@ -998,6 +1101,9 @@
                 "properties": {
                   "name": {
                     "type": "string"
+                  },
+                  "request": {
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -1051,19 +1157,36 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "appArmorProfile": {
+              "properties": {
+                "localhostProfile": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "capabilities": {
               "properties": {
                 "add": {
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "drop": {
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -1190,7 +1313,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -1200,7 +1324,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -1273,6 +1398,9 @@
               "readOnly": {
                 "type": "boolean"
               },
+              "recursiveReadOnly": {
+                "type": "string"
+              },
               "subPath": {
                 "type": "string"
               },
@@ -1327,12 +1455,14 @@
                     "type": "string"
                   },
                   "fsType": {
+                    "default": "ext4",
                     "type": "string"
                   },
                   "kind": {
                     "type": "string"
                   },
                   "readOnly": {
+                    "default": false,
                     "type": "boolean"
                   }
                 },
@@ -1368,7 +1498,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "path": {
                     "type": "string"
@@ -1382,6 +1513,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -1410,6 +1542,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -1454,9 +1587,11 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -1478,6 +1613,7 @@
                   "nodePublishSecretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -1568,7 +1704,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -1635,7 +1772,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "dataSource": {
                             "properties": {
@@ -1730,7 +1868,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1740,7 +1879,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1796,13 +1936,15 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "wwids": {
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -1828,6 +1970,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -1928,6 +2071,18 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string"
+                  },
+                  "reference": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "iscsi": {
                 "properties": {
                   "chapAuthDiscovery": {
@@ -1946,6 +2101,7 @@
                     "type": "string"
                   },
                   "iscsiInterface": {
+                    "default": "default",
                     "type": "string"
                   },
                   "lun": {
@@ -1956,7 +2112,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "readOnly": {
                     "type": "boolean"
@@ -1964,6 +2121,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2079,7 +2237,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -2089,7 +2248,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -2144,9 +2304,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -2220,7 +2382,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
@@ -2249,9 +2412,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -2285,7 +2450,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -2328,15 +2494,18 @@
                     "type": "string"
                   },
                   "keyring": {
+                    "default": "/etc/ceph/keyring",
                     "type": "string"
                   },
                   "monitors": {
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "pool": {
+                    "default": "rbd",
                     "type": "string"
                   },
                   "readOnly": {
@@ -2345,6 +2514,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2353,6 +2523,7 @@
                     "additionalProperties": false
                   },
                   "user": {
+                    "default": "admin",
                     "type": "string"
                   }
                 },
@@ -2366,6 +2537,7 @@
               "scaleIO": {
                 "properties": {
                   "fsType": {
+                    "default": "xfs",
                     "type": "string"
                   },
                   "gateway": {
@@ -2380,6 +2552,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2391,6 +2564,7 @@
                     "type": "boolean"
                   },
                   "storageMode": {
+                    "default": "ThinProvisioned",
                     "type": "string"
                   },
                   "storagePool": {
@@ -2438,7 +2612,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "optional": {
                     "type": "boolean"
@@ -2461,6 +2636,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },

--- a/opentelemetry.io/opentelemetrycollector_v1alpha1.json
+++ b/opentelemetry.io/opentelemetrycollector_v1alpha1.json
@@ -18,13 +18,15 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "command": {
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "env": {
                 "items": {
@@ -43,6 +45,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -106,6 +109,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -130,7 +134,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "envFrom": {
                 "items": {
@@ -138,6 +146,7 @@
                     "configMapRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -154,6 +163,7 @@
                     "secretRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -168,7 +178,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "image": {
                 "type": "string"
@@ -186,7 +197,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -214,7 +226,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -288,7 +301,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -316,7 +330,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -394,7 +409,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -411,6 +427,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -442,7 +459,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -561,7 +579,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -578,6 +597,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -609,7 +629,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -709,6 +730,9 @@
                       "properties": {
                         "name": {
                           "type": "string"
+                        },
+                        "request": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -765,19 +789,36 @@
                   "allowPrivilegeEscalation": {
                     "type": "boolean"
                   },
+                  "appArmorProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "capabilities": {
                     "properties": {
                       "add": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "drop": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -866,7 +907,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -883,6 +925,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -914,7 +957,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -1019,7 +1063,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "devicePath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "volumeMounts": {
                 "items": {
@@ -1036,6 +1084,9 @@
                     "readOnly": {
                       "type": "boolean"
                     },
+                    "recursiveReadOnly": {
+                      "type": "string"
+                    },
                     "subPath": {
                       "type": "string"
                     },
@@ -1050,7 +1101,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "mountPath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "workingDir": {
                 "type": "string"
@@ -1086,7 +1141,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1096,7 +1152,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -1111,7 +1168,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1121,7 +1179,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -1140,7 +1199,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "properties": {
@@ -1160,7 +1220,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1170,7 +1231,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -1185,7 +1247,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1195,14 +1258,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -1238,7 +1303,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1248,7 +1314,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1290,7 +1357,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1300,7 +1368,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1317,7 +1386,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -1341,7 +1411,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -1361,7 +1432,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1371,7 +1443,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1413,7 +1486,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1423,7 +1497,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1440,7 +1515,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -1452,7 +1528,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -1480,7 +1557,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1490,7 +1568,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1532,7 +1611,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1542,7 +1622,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1559,7 +1640,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -1583,7 +1665,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -1603,7 +1686,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1613,7 +1697,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1655,7 +1740,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1665,7 +1751,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1682,7 +1769,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -1694,7 +1782,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -1825,7 +1914,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1835,7 +1925,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2007,6 +2098,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -2070,6 +2162,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -2102,6 +2195,7 @@
               "configMapRef": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -2118,6 +2212,7 @@
               "secretRef": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -2216,13 +2311,15 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "command": {
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "env": {
                 "items": {
@@ -2241,6 +2338,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -2304,6 +2402,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -2328,7 +2427,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "envFrom": {
                 "items": {
@@ -2336,6 +2439,7 @@
                     "configMapRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -2352,6 +2456,7 @@
                     "secretRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -2366,7 +2471,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "image": {
                 "type": "string"
@@ -2384,7 +2490,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -2412,7 +2519,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -2486,7 +2594,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -2514,7 +2623,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -2592,7 +2702,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -2609,6 +2720,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2640,7 +2752,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -2759,7 +2872,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -2776,6 +2890,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2807,7 +2922,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -2907,6 +3023,9 @@
                       "properties": {
                         "name": {
                           "type": "string"
+                        },
+                        "request": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -2963,19 +3082,36 @@
                   "allowPrivilegeEscalation": {
                     "type": "boolean"
                   },
+                  "appArmorProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "capabilities": {
                     "properties": {
                       "add": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "drop": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -3064,7 +3200,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -3081,6 +3218,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -3112,7 +3250,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -3217,7 +3356,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "devicePath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "volumeMounts": {
                 "items": {
@@ -3234,6 +3377,9 @@
                     "readOnly": {
                       "type": "boolean"
                     },
+                    "recursiveReadOnly": {
+                      "type": "string"
+                    },
                     "subPath": {
                       "type": "string"
                     },
@@ -3248,7 +3394,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "mountPath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "workingDir": {
                 "type": "string"
@@ -3272,7 +3422,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3300,7 +3451,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -3374,7 +3526,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3402,7 +3555,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -3587,6 +3741,21 @@
         },
         "podSecurityContext": {
           "properties": {
+            "appArmorProfile": {
+              "properties": {
+                "localhostProfile": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "fsGroup": {
               "format": "int64",
               "type": "integer"
@@ -3643,7 +3812,11 @@
                 "format": "int64",
                 "type": "integer"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "supplementalGroupsPolicy": {
+              "type": "string"
             },
             "sysctls": {
               "items": {
@@ -3662,7 +3835,8 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "windowsOptions": {
               "properties": {
@@ -3746,6 +3920,9 @@
                 "properties": {
                   "name": {
                     "type": "string"
+                  },
+                  "request": {
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -3799,19 +3976,36 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "appArmorProfile": {
+              "properties": {
+                "localhostProfile": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "capabilities": {
               "properties": {
                 "add": {
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "drop": {
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -3922,7 +4116,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3932,7 +4127,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -3947,7 +4143,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3957,7 +4154,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -3976,7 +4174,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -3996,7 +4195,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4006,7 +4206,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -4021,7 +4222,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4031,14 +4233,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -4074,7 +4278,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4084,7 +4289,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4126,7 +4332,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4136,7 +4343,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4153,7 +4361,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -4177,7 +4386,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -4197,7 +4407,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4207,7 +4418,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4249,7 +4461,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4259,7 +4472,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4276,7 +4490,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -4288,7 +4503,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -4316,7 +4532,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4326,7 +4543,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4368,7 +4586,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4378,7 +4597,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4395,7 +4615,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -4419,7 +4640,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -4439,7 +4661,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4449,7 +4672,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4491,7 +4715,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4501,7 +4726,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4518,7 +4744,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -4530,7 +4757,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -4569,6 +4797,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -4632,6 +4861,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -4719,6 +4949,21 @@
             },
             "podSecurityContext": {
               "properties": {
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
                   "format": "int64",
                   "type": "integer"
@@ -4775,7 +5020,11 @@
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -4794,7 +5043,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
                   "properties": {
@@ -4855,6 +5105,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "request": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -4908,19 +5161,36 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "capabilities": {
                   "properties": {
                     "add": {
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "drop": {
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -5047,7 +5317,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -5057,7 +5328,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -5159,7 +5431,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -5169,7 +5442,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -5309,7 +5583,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "dataSource": {
                     "properties": {
@@ -5404,7 +5679,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -5414,7 +5690,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -5449,7 +5726,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "allocatedResourceStatuses": {
                     "additionalProperties": {
@@ -5519,7 +5797,11 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "currentVolumeAttributesClassName": {
                     "type": "string"
@@ -5567,6 +5849,9 @@
               },
               "readOnly": {
                 "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "type": "string"
               },
               "subPath": {
                 "type": "string"
@@ -5622,12 +5907,14 @@
                     "type": "string"
                   },
                   "fsType": {
+                    "default": "ext4",
                     "type": "string"
                   },
                   "kind": {
                     "type": "string"
                   },
                   "readOnly": {
+                    "default": false,
                     "type": "boolean"
                   }
                 },
@@ -5663,7 +5950,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "path": {
                     "type": "string"
@@ -5677,6 +5965,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -5705,6 +5994,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -5749,9 +6039,11 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -5773,6 +6065,7 @@
                   "nodePublishSecretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -5863,7 +6156,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -5930,7 +6224,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "dataSource": {
                             "properties": {
@@ -6025,7 +6320,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -6035,7 +6331,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -6091,13 +6388,15 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "wwids": {
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -6123,6 +6422,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6223,6 +6523,18 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string"
+                  },
+                  "reference": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "iscsi": {
                 "properties": {
                   "chapAuthDiscovery": {
@@ -6241,6 +6553,7 @@
                     "type": "string"
                   },
                   "iscsiInterface": {
+                    "default": "default",
                     "type": "string"
                   },
                   "lun": {
@@ -6251,7 +6564,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "readOnly": {
                     "type": "boolean"
@@ -6259,6 +6573,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6374,7 +6689,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -6384,7 +6700,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -6439,9 +6756,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -6515,7 +6834,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
@@ -6544,9 +6864,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -6580,7 +6902,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -6623,15 +6946,18 @@
                     "type": "string"
                   },
                   "keyring": {
+                    "default": "/etc/ceph/keyring",
                     "type": "string"
                   },
                   "monitors": {
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "pool": {
+                    "default": "rbd",
                     "type": "string"
                   },
                   "readOnly": {
@@ -6640,6 +6966,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6648,6 +6975,7 @@
                     "additionalProperties": false
                   },
                   "user": {
+                    "default": "admin",
                     "type": "string"
                   }
                 },
@@ -6661,6 +6989,7 @@
               "scaleIO": {
                 "properties": {
                   "fsType": {
+                    "default": "xfs",
                     "type": "string"
                   },
                   "gateway": {
@@ -6675,6 +7004,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6686,6 +7016,7 @@
                     "type": "boolean"
                   },
                   "storageMode": {
+                    "default": "ThinProvisioned",
                     "type": "string"
                   },
                   "storagePool": {
@@ -6733,7 +7064,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "optional": {
                     "type": "boolean"
@@ -6756,6 +7088,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6805,6 +7138,10 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
+      "required": [
+        "config",
+        "managementState"
+      ],
       "type": "object",
       "additionalProperties": false
     },

--- a/opentelemetry.io/opentelemetrycollector_v1beta1.json
+++ b/opentelemetry.io/opentelemetrycollector_v1beta1.json
@@ -18,13 +18,15 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "command": {
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "env": {
                 "items": {
@@ -43,6 +45,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -106,6 +109,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -130,7 +134,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "envFrom": {
                 "items": {
@@ -138,6 +146,7 @@
                     "configMapRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -154,6 +163,7 @@
                     "secretRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -168,7 +178,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "image": {
                 "type": "string"
@@ -186,7 +197,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -214,7 +226,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -288,7 +301,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -316,7 +330,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -394,7 +409,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -411,6 +427,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -442,7 +459,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -561,7 +579,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -578,6 +597,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -609,7 +629,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -709,6 +730,9 @@
                       "properties": {
                         "name": {
                           "type": "string"
+                        },
+                        "request": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -765,19 +789,36 @@
                   "allowPrivilegeEscalation": {
                     "type": "boolean"
                   },
+                  "appArmorProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "capabilities": {
                     "properties": {
                       "add": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "drop": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -866,7 +907,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -883,6 +925,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -914,7 +957,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -1019,7 +1063,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "devicePath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "volumeMounts": {
                 "items": {
@@ -1036,6 +1084,9 @@
                     "readOnly": {
                       "type": "boolean"
                     },
+                    "recursiveReadOnly": {
+                      "type": "string"
+                    },
                     "subPath": {
                       "type": "string"
                     },
@@ -1050,7 +1101,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "mountPath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "workingDir": {
                 "type": "string"
@@ -1086,7 +1141,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1096,7 +1152,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -1111,7 +1168,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1121,7 +1179,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -1140,7 +1199,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "properties": {
@@ -1160,7 +1220,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1170,7 +1231,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -1185,7 +1247,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1195,14 +1258,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -1238,7 +1303,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1248,7 +1314,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1290,7 +1357,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1300,7 +1368,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1317,7 +1386,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -1341,7 +1411,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -1361,7 +1432,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1371,7 +1443,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1413,7 +1486,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1423,7 +1497,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1440,7 +1515,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -1452,7 +1528,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -1480,7 +1557,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1490,7 +1568,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1532,7 +1611,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1542,7 +1622,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1559,7 +1640,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -1583,7 +1665,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -1603,7 +1686,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1613,7 +1697,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1655,7 +1740,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1665,7 +1751,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1682,7 +1769,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -1694,7 +1782,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -1825,7 +1914,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1835,7 +1925,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1985,7 +2076,6 @@
                     },
                     "required": [
                       "exporters",
-                      "processors",
                       "receivers"
                     ],
                     "type": "object",
@@ -2014,6 +2104,11 @@
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true,
           "additionalProperties": false
+        },
+        "configVersions": {
+          "default": 3,
+          "minimum": 1,
+          "type": "integer"
         },
         "configmaps": {
           "items": {
@@ -2125,6 +2220,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -2188,6 +2284,7 @@
                         "type": "string"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -2220,6 +2317,7 @@
               "configMapRef": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -2236,6 +2334,7 @@
               "secretRef": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -2334,13 +2433,15 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "command": {
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "env": {
                 "items": {
@@ -2359,6 +2460,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -2422,6 +2524,7 @@
                               "type": "string"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -2446,7 +2549,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "envFrom": {
                 "items": {
@@ -2454,6 +2561,7 @@
                     "configMapRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -2470,6 +2578,7 @@
                     "secretRef": {
                       "properties": {
                         "name": {
+                          "default": "",
                           "type": "string"
                         },
                         "optional": {
@@ -2484,7 +2593,8 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
               },
               "image": {
                 "type": "string"
@@ -2502,7 +2612,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -2530,7 +2641,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -2604,7 +2716,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -2632,7 +2745,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -2710,7 +2824,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -2727,6 +2842,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2758,7 +2874,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -2877,7 +2994,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -2894,6 +3012,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -2925,7 +3044,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -3025,6 +3145,9 @@
                       "properties": {
                         "name": {
                           "type": "string"
+                        },
+                        "request": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -3081,19 +3204,36 @@
                   "allowPrivilegeEscalation": {
                     "type": "boolean"
                   },
+                  "appArmorProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "capabilities": {
                     "properties": {
                       "add": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "drop": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -3182,7 +3322,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -3199,6 +3340,7 @@
                         "type": "integer"
                       },
                       "service": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -3230,7 +3372,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -3335,7 +3478,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "devicePath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "volumeMounts": {
                 "items": {
@@ -3352,6 +3499,9 @@
                     "readOnly": {
                       "type": "boolean"
                     },
+                    "recursiveReadOnly": {
+                      "type": "string"
+                    },
                     "subPath": {
                       "type": "string"
                     },
@@ -3366,7 +3516,11 @@
                   "type": "object",
                   "additionalProperties": false
                 },
-                "type": "array"
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "mountPath"
+                ],
+                "x-kubernetes-list-type": "map"
               },
               "workingDir": {
                 "type": "string"
@@ -3380,6 +3534,16 @@
           },
           "type": "array"
         },
+        "ipFamilies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ipFamilyPolicy": {
+          "default": "SingleStack",
+          "type": "string"
+        },
         "lifecycle": {
           "properties": {
             "postStart": {
@@ -3390,7 +3554,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3418,7 +3583,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -3492,7 +3658,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3520,7 +3687,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -3695,8 +3863,59 @@
           "type": "object",
           "additionalProperties": false
         },
+        "podDnsConfig": {
+          "properties": {
+            "nameservers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "options": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "searches": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "podSecurityContext": {
           "properties": {
+            "appArmorProfile": {
+              "properties": {
+                "localhostProfile": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "fsGroup": {
               "format": "int64",
               "type": "integer"
@@ -3753,7 +3972,11 @@
                 "format": "int64",
                 "type": "integer"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "supplementalGroupsPolicy": {
+              "type": "string"
             },
             "sysctls": {
               "items": {
@@ -3772,7 +3995,8 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "windowsOptions": {
               "properties": {
@@ -3845,6 +4069,36 @@
         "priorityClassName": {
           "type": "string"
         },
+        "readinessProbe": {
+          "properties": {
+            "failureThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "terminationGracePeriodSeconds": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "replicas": {
           "format": "int32",
           "type": "integer"
@@ -3855,6 +4109,9 @@
               "items": {
                 "properties": {
                   "name": {
+                    "type": "string"
+                  },
+                  "request": {
                     "type": "string"
                   }
                 },
@@ -3909,19 +4166,36 @@
             "allowPrivilegeEscalation": {
               "type": "boolean"
             },
+            "appArmorProfile": {
+              "properties": {
+                "localhostProfile": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "capabilities": {
               "properties": {
                 "add": {
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "drop": {
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -4032,7 +4306,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4042,7 +4317,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -4057,7 +4333,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4067,7 +4344,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -4086,7 +4364,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -4106,7 +4385,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4116,7 +4396,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -4131,7 +4412,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4141,14 +4423,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -4184,7 +4468,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4194,7 +4479,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4236,7 +4522,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4246,7 +4533,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4263,7 +4551,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -4287,7 +4576,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -4307,7 +4597,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4317,7 +4608,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4359,7 +4651,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4369,7 +4662,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4386,7 +4680,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -4398,7 +4693,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -4426,7 +4722,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4436,7 +4733,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4478,7 +4776,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4488,7 +4787,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4505,7 +4805,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -4529,7 +4830,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -4549,7 +4851,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4559,7 +4862,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4601,7 +4905,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -4611,7 +4916,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -4628,7 +4934,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -4640,7 +4947,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -4679,6 +4987,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -4742,6 +5051,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -4833,6 +5143,21 @@
             },
             "podSecurityContext": {
               "properties": {
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
                   "format": "int64",
                   "type": "integer"
@@ -4889,7 +5214,11 @@
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -4908,7 +5237,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
                   "properties": {
@@ -4952,7 +5282,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "required": [
@@ -4962,7 +5293,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "matchLabels": {
                       "additionalProperties": {
@@ -4995,7 +5327,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "required": [
@@ -5005,7 +5338,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "matchLabels": {
                       "additionalProperties": {
@@ -5032,6 +5366,9 @@
                   "items": {
                     "properties": {
                       "name": {
+                        "type": "string"
+                      },
+                      "request": {
                         "type": "string"
                       }
                     },
@@ -5086,19 +5423,36 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "capabilities": {
                   "properties": {
                     "add": {
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "drop": {
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -5225,7 +5579,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -5235,7 +5590,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -5337,7 +5693,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -5347,7 +5704,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -5450,7 +5808,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "dataSource": {
                     "properties": {
@@ -5545,7 +5904,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -5555,7 +5915,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -5590,7 +5951,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "allocatedResourceStatuses": {
                     "additionalProperties": {
@@ -5660,7 +6022,11 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "currentVolumeAttributesClassName": {
                     "type": "string"
@@ -5708,6 +6074,9 @@
               },
               "readOnly": {
                 "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "type": "string"
               },
               "subPath": {
                 "type": "string"
@@ -5763,12 +6132,14 @@
                     "type": "string"
                   },
                   "fsType": {
+                    "default": "ext4",
                     "type": "string"
                   },
                   "kind": {
                     "type": "string"
                   },
                   "readOnly": {
+                    "default": false,
                     "type": "boolean"
                   }
                 },
@@ -5804,7 +6175,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "path": {
                     "type": "string"
@@ -5818,6 +6190,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -5846,6 +6219,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -5890,9 +6264,11 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "name": {
+                    "default": "",
                     "type": "string"
                   },
                   "optional": {
@@ -5914,6 +6290,7 @@
                   "nodePublishSecretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6004,7 +6381,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -6071,7 +6449,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "dataSource": {
                             "properties": {
@@ -6166,7 +6545,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -6176,7 +6556,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -6232,13 +6613,15 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "wwids": {
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -6264,6 +6647,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6364,6 +6748,18 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "image": {
+                "properties": {
+                  "pullPolicy": {
+                    "type": "string"
+                  },
+                  "reference": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "iscsi": {
                 "properties": {
                   "chapAuthDiscovery": {
@@ -6382,6 +6778,7 @@
                     "type": "string"
                   },
                   "iscsiInterface": {
+                    "default": "default",
                     "type": "string"
                   },
                   "lun": {
@@ -6392,7 +6789,8 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "readOnly": {
                     "type": "boolean"
@@ -6400,6 +6798,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6515,7 +6914,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -6525,7 +6925,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -6580,9 +6981,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -6656,7 +7059,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
@@ -6685,9 +7089,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -6721,7 +7127,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -6764,15 +7171,18 @@
                     "type": "string"
                   },
                   "keyring": {
+                    "default": "/etc/ceph/keyring",
                     "type": "string"
                   },
                   "monitors": {
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "pool": {
+                    "default": "rbd",
                     "type": "string"
                   },
                   "readOnly": {
@@ -6781,6 +7191,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6789,6 +7200,7 @@
                     "additionalProperties": false
                   },
                   "user": {
+                    "default": "admin",
                     "type": "string"
                   }
                 },
@@ -6802,6 +7214,7 @@
               "scaleIO": {
                 "properties": {
                   "fsType": {
+                    "default": "xfs",
                     "type": "string"
                   },
                   "gateway": {
@@ -6816,6 +7229,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6827,6 +7241,7 @@
                     "type": "boolean"
                   },
                   "storageMode": {
+                    "default": "ThinProvisioned",
                     "type": "string"
                   },
                   "storagePool": {
@@ -6874,7 +7289,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "optional": {
                     "type": "boolean"
@@ -6897,6 +7313,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
@@ -6947,7 +7364,8 @@
         }
       },
       "required": [
-        "config"
+        "config",
+        "managementState"
       ],
       "type": "object",
       "additionalProperties": false


### PR DESCRIPTION
These CRDs were generated using 

```
dependencies:
  - name: opentelemetry-operator
    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
    version: 0.74.3
```

deployed on a local kubernetes environment (Docker desktop), exported with `crd-extractor.sh` and tested locally with an object kind: OpenTelemetryCollector v1beta1 and instrumentation. I did not validate the other version/object kind

opentelemetrycollector_v1beta1
```
#valid collector
kubeconform -summary  -schema-location ~/.datree/crdSchemas/opentelemetrycollector_v1beta1.json -strict  /tmp/eventhub/otel-eventhub/charts/open/templates/collector.yaml
Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Errors: 0, Skipped: 0

#removing a needed field
 kubeconform -summary  -schema-location ~/.datree/crdSchemas/opentelemetrycollector_v1beta1.json -strict  /tmp/eventhub/otel-eventhub/charts/open/templates/collector.yaml
/tmp/eventhub/otel-eventhub/charts/open/templates/collector.yaml - OpenTelemetryCollector test-collector is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec' does not validate with file:///~/.datree/crdSchemas/opentelemetrycollector_v1beta1.json#/properties/spec/required: missing properties: 'managementState'
Summary: 1 resource found in 1 file - Valid: 0, Invalid: 1, Errors: 0, Skipped: 0
```

/instrumentation_v1alpha1
```
# Valid object
 kubeconform -summary  -schema-location ~/.datree/crdSchemas/instrumentation_v1alpha1.json -strict  /Users/vag/workspace/tmp/kubeconform/instrumentation.yaml
Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Errors: 0, Skipped: 0

# Adding a wrong property
  kubeconform -summary  -schema-location ~/.datree/crdSchemas/instrumentation_v1alpha1.json -strict  /Users/vag/workspace/tmp/kubeconform/instrumentation.yaml
/Users/vag/workspace/tmp/kubeconform/instrumentation.yaml - Instrumentation go-instrumentation is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec' does not validate with file:///Users/vag/.datree/crdSchemas/instrumentation_v1alpha1.json#/properties/spec/additionalProperties: additionalProperties 'foo' not allowed
Summary: 1 resource found in 1 file - Valid: 0, Invalid: 1, Errors: 0, Skipped: 0
```