### PR TITLE
fix: remove opentelemetry managementState required field

### DIFF
--- a/opentelemetry.io/opentelemetrycollector_v1alpha1.json
+++ b/opentelemetry.io/opentelemetrycollector_v1alpha1.json
@@ -7139,8 +7139,7 @@
         }
       },
       "required": [
-        "config",
-        "managementState"
+        "config"
       ],
       "type": "object",
       "additionalProperties": false

--- a/opentelemetry.io/opentelemetrycollector_v1beta1.json
+++ b/opentelemetry.io/opentelemetrycollector_v1beta1.json
@@ -7364,8 +7364,7 @@
         }
       },
       "required": [
-        "config",
-        "managementState"
+        "config"
       ],
       "type": "object",
       "additionalProperties": false


### PR DESCRIPTION
Removes `managementState` as a required field in the OpentelemetryCollector CRDs since it has a default value in the CRD.

Fixes #430 