### PR TITLE
fix(utilities): Check if the bash version is 4+

### DIFF
--- a/Utilities/crd-extractor.sh
+++ b/Utilities/crd-extractor.sh
@@ -12,6 +12,12 @@ if ! command -v kubectl &> /dev/null; then
     printf "please visit https://kubernetes.io/docs/tasks/tools/#kubectl to install it"
     exit 1
 fi
+# Check if the major version is 4 or higher
+if [[ ! ${BASH_VERSION%%.*} -ge 4 ]]; then
+    printf "Bash version is lower than 4"
+    printf "please visit https://www.gnu.org/software/bash/ to install it"
+    exit 1
+fi
 
 # Check if the pyyaml module is installed
 if ! echo 'import yaml' | python3 &> /dev/null; then


### PR DESCRIPTION
I may have missed it earlier, but I was curious why my outputs didn’t display the nice grouping of CRDs. After some digging, I found [issue #147](https://github.com/datreeio/CRDs-catalog/issues/147#issuecomment-1502885415), which clarified that my Mac was running Bash version 3.x. Once I upgraded to Bash 4+ using Homebrew, everything worked as expected.

To help others avoid this issue, I added a check to ensure compatibility. If you’re facing a similar problem, upgrading Bash to version 4+ should resolve it!

` brew install bash`

And added this to my `~/.zshrc`
```
# BASH 4+
BASH=$1
if [ -z $BASH ]; then
    BASH=/opt/homebrew/bin/bash
fi
```